### PR TITLE
docs: rewrite README for the vocabulary notebook web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,136 @@
-# 日本語學習筆記 Japanese Learning Notes
+# 語彙帳 — Japanese Vocabulary Notebook
 
-A personal collection of Japanese vocabulary and phrases encountered in daily life and work — explained in Cantonese for easier understanding and retention.
+A personal web app for recording and reviewing Japanese vocabulary picked up in
+daily life and at work, with Cantonese translations and notes.
 
----
+This repository began as 67 hand-written Markdown notes. Once they were imported
+into Firestore the tracked Markdown was removed, so Firestore now holds the live
+data. [`migration/README.md`](migration/README.md) documents the committed import
+artefacts and how to replay them.
 
-## Purpose
+## Features
 
-- Record Japanese words, phrases, and expressions heard in daily life and at work
-- Explain them in Cantonese to make memorisation more natural and intuitive
-- Build up a long-term reference to steadily improve Japanese proficiency
+### Available
 
----
+- **Dashboard** — counts by week, month and year; a learning heatmap; JLPT and
+  part-of-speech breakdowns; a word of the day; and the most recently learned
+  entries.
+- **Browse** — substring search over headwords, readings, definitions, examples,
+  tags and notes, plus filters for JLPT level, part of speech, origin, style,
+  frequency, tags and learning date range. Filter state lives in the URL, so a
+  view can be bookmarked.
+- **Entry detail** — furigana split per kanji run where the reading can be
+  aligned, falling back to one annotation over the whole word where it cannot;
+  senses, example sentences, usage notes and context sections.
+- **Create / edit / delete** — a quick form and a detailed form, plus a JSON
+  import path for assistant-generated entries.
 
-## Note Structure
+### Planned
 
-Each note generally includes:
+Flashcards, dictation, word sets and practice history are placeholder routes.
 
-| Field      | Description                                                  |
-| ---------- | ------------------------------------------------------------ |
-| 日文       | Original Japanese (kanji / kana)                             |
-| 讀音       | Furigana / Romaji                                            |
-| 詞性       | Part of speech (noun, verb, adjective, etc.)                 |
-| 廣東話解釋 | Meaning and usage explained in Cantonese                     |
-| 例句       | Example sentence in Japanese with Cantonese translation      |
-| 出處       | Context where it was heard (work, conversation, media, etc.) |
+## Stack
 
----
+| Layer | Choice |
+| --- | --- |
+| Build | Vite 7 |
+| UI | React 19 + TypeScript (strict), React Router 7 |
+| Styling | Tailwind CSS 4 |
+| Data & auth | Firebase — Firestore + Google sign-in |
+| Hosting | Firebase Hosting |
 
-## Categories
+Pure client-side app: the Firestore web SDK talks to the database directly, and
+security rules — not a server — are what protect the data. The whole `entries`
+collection is loaded into memory once, and search, filtering and sorting all run
+over that array. There is no pagination; the design assumes a personal notebook,
+not a corpus.
 
-Notes are organised by topic:
+## Getting started
 
-- `work/` — Workplace vocabulary and business Japanese
-- `daily/` — Everyday conversational words
-- `keigo/` — Keigo (丁寧語、尊敬語、謙讓語)
-- `phrases/` — Common phrases and set expressions
-- `grammar/` — Grammar notes
-- `擬態語/` — Mimetic words (擬態語・擬音語)
+```bash
+yarn install
+cp .env.example .env.development   # fill in your Firebase web config
+yarn dev
+```
 
----
+Pointing this at a fresh Firebase project takes three more steps: register a web
+app and enable Google sign-in, replace the hard-coded owner email in
+`firestore.rules`, then `yarn rules:dev`. Skip the last two and sign-in will
+succeed while every read and write is denied.
 
-## Language Note
+`.env.development` and `.env.production` are gitignored. Their values ship inside
+the JS bundle and are not secrets — Firestore rules are what enforce access — but
+keeping them out of Git stops the two projects' configs from drifting into the
+source tree.
 
-> Notes are primarily written in **Cantonese (Traditional Chinese)**. Japanese terms and technical vocabulary are kept in their original form.
+### Scripts
 
----
+| Command | What it does |
+| --- | --- |
+| `yarn dev` | Vite dev server (`.env.development`) |
+| `yarn build` | Type-check, then build to `dist/` (`.env.production`) |
+| `yarn preview` | Serve the existing `dist/` build locally |
+| `yarn typecheck` | `tsc -b --noEmit` |
+| `yarn rules:dev` / `yarn rules:prod` | Deploy `firestore.rules` |
+| `yarn auth:login` / `yarn auth:revoke` | Repo-local Google ADC, used by the migration upload |
 
-_Maintained by [kowinauyeung](https://github.com/kowinauyeung) — updated continuously_
+`yarn auth:login` writes to `.gcloud/` via `CLOUDSDK_CONFIG`, deliberately apart
+from the machine-wide `~/.config/gcloud`. There is no long-lived service-account
+key in this project, and there should not be one.
+
+`migrate:parse` and `migrate:upload` are one-shot migration scripts — see
+[`migration/README.md`](migration/README.md) before running either.
+
+## Environments
+
+`.firebaserc` maps `default` and `dev` to `goitei-dev`, and `prod` to `goitei`,
+so a bare `firebase deploy` targets development. Branches follow the same split
+by convention — `develop` for dev, `main` for production — but nothing enforces
+it; there is no CI yet and every deploy so far has been manual.
+
+Which project a build talks to comes from the env file Vite picks, not from the
+`--project` flag, so the two must be set together:
+
+```bash
+# dev
+yarn vite build --mode development
+firebase deploy --only hosting,firestore:rules --project dev
+
+# production
+yarn build
+firebase deploy --only hosting,firestore:rules --project prod
+```
+
+`firestore.rules` allows read and write on `entries`, `entryProgress`,
+`practiceSessions` and `wordSets` for one hard-coded verified email; every other
+path is denied. For the first production import, follow the rules-first order in
+[`migration/README.md`](migration/README.md).
+
+## Data model
+
+Defined in [`src/types/entry.ts`](src/types/entry.ts). Points worth knowing:
+
+- A new entry requires `headword` and `definition`. `definition` is the only
+  required explanatory field and is not tied to a language; the migrated entries
+  keep their Cantonese gloss in `definitionSub`.
+- `pos` is an array — plenty of entries are compound (名詞／動詞).
+- Tags allow letters, digits and underscore only (`/^[\p{L}\p{N}_]{1,32}$/u`),
+  so kanji are fine but spaces and punctuation are not.
+- `learnedOn` is an editable `YYYY-MM-DD` date. It drives the week/month/year
+  counts, the heatmap and the recent list; the JLPT and part-of-speech
+  breakdowns read their own fields. `createdAt` is written once, `updatedAt` on
+  every save.
+
+[`src/lib/sanitize.ts`](src/lib/sanitize.ts) coerces pasted JSON and Firestore
+documents into a valid draft rather than casting them, with unusable values
+falling back to that field's default; URL parameters are parsed separately in
+`src/lib/filters.ts`. Writes are validated on their own — the form rejects a
+missing headword or definition, bad tags and an impossible `learnedOn` before
+anything reaches Firestore. Coercing on read is not a substitute for that, and
+rules enforce account access only, never document shape.
+
+## Language note
+
+> The app UI is in Japanese and repository documentation is in English. Entry
+> content is mostly Japanese, with Cantonese (Traditional Chinese) translations
+> and remarks in `definitionSub` and the translation fields.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,16 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
 4. Point the tooling at your project: change the `dev` alias in `.firebaserc`,
    or pass `--project <your-project-id>` instead of using the `rules:dev`
    script, which is wired to `goitei-dev`.
-5. `firebase login`, then deploy the rules.
+5. `yarn firebase login`, then deploy the rules with `yarn rules:dev` (once the
+   alias points at your project) or
+   `yarn firebase deploy --only firestore:rules --project <your-project-id>`.
 
-Steps 3 and 4 are what stop you deploying rules into someone else's project or
-running against defaults that do not name you as the owner. Once they are in
-place, sign-in succeeds and every read and write is scoped to your account.
+`firebase-tools` is a local devDependency, so the CLI is reached through
+`yarn firebase …` unless you have installed it globally.
+
+Steps 3 and 4 only change local configuration; nothing is enforced until step 5
+deploys the rules successfully. After that deploy, sign-in works and every read
+and write is scoped to your account.
 
 `.env.development` and `.env.production` are gitignored. Their values ship inside
 the JS bundle and are not secrets — Firestore rules are what enforce access — but
@@ -95,7 +100,7 @@ key in this project, and there should not be one.
 ## Environments
 
 `.firebaserc` maps `default` and `dev` to `goitei-dev`, and `prod` to `goitei`,
-so a bare `firebase deploy` targets development. Branches follow the same split
+so a deploy with no `--project` targets development. Branches follow the same split
 by convention — `develop` for dev, `main` for production — but nothing enforces
 it; there is no CI yet and every deploy so far has been manual.
 
@@ -105,11 +110,11 @@ Which project a build talks to comes from the env file Vite picks, not from the
 ```bash
 # dev
 yarn vite build --mode development
-firebase deploy --only hosting,firestore:rules --project dev
+yarn firebase deploy --only hosting,firestore:rules --project dev
 
 # production
 yarn build
-firebase deploy --only hosting,firestore:rules --project prod
+yarn firebase deploy --only hosting,firestore:rules --project prod
 ```
 
 `firestore.rules` allows read and write on `entries`, `entryProgress`,

--- a/README.md
+++ b/README.md
@@ -53,10 +53,21 @@ cp .env.example .env.development   # fill in your Firebase web config
 yarn dev
 ```
 
-Pointing this at a fresh Firebase project takes three more steps: register a web
-app and enable Google sign-in, replace the hard-coded owner email in
-`firestore.rules`, then `yarn rules:dev`. Skip the last two and sign-in will
-succeed while every read and write is denied.
+Pointing this at a fresh Firebase project takes a few more steps, in order:
+
+1. Register a web app and enable Google sign-in.
+2. [Create a Cloud Firestore database](https://firebase.google.com/docs/firestore/quickstart#create_a_cloud_firestore_database)
+   — a new project has none — choosing a location and **Production mode**. Test
+   mode leaves the data open to any client for its first 30 days.
+3. Replace the hard-coded owner email in `firestore.rules` with your own.
+4. Point the tooling at your project: change the `dev` alias in `.firebaserc`,
+   or pass `--project <your-project-id>` instead of using the `rules:dev`
+   script, which is wired to `goitei-dev`.
+5. `firebase login`, then deploy the rules.
+
+Steps 3 and 4 are what stop you deploying rules into someone else's project or
+running against defaults that do not name you as the owner. Once they are in
+place, sign-in succeeds and every read and write is scoped to your account.
 
 `.env.development` and `.env.production` are gitignored. Their values ship inside
 the JS bundle and are not secrets — Firestore rules are what enforce access — but
@@ -122,8 +133,11 @@ Defined in [`src/types/entry.ts`](src/types/entry.ts). Points worth knowing:
   every save.
 
 [`src/lib/sanitize.ts`](src/lib/sanitize.ts) coerces pasted JSON and Firestore
-documents into a valid draft rather than casting them, with unusable values
-falling back to that field's default; URL parameters are parsed separately in
+documents rather than casting them: it is best-effort over the fields it knows
+about, so enums, `freq` and `learnedOn` fall back to a default when the incoming
+value is unusable, while `pitchAccent` accepts any number, tags are split but not
+checked against `TAG_PATTERN`, and `wordSets` takes arbitrary strings. URL
+parameters are parsed separately in
 `src/lib/filters.ts`. Writes are validated on their own — the form rejects a
 missing headword or definition, bad tags and an impossible `learnedOn` before
 anything reaches Firestore. Coercing on read is not a substitute for that, and


### PR DESCRIPTION
## What

The README still described this repo as a folder of hand-written Markdown notes, listing category directories (`work/`, `daily/`, `keigo/`, …) that no longer exist. It now documents the actual app.

Rewritten to cover:

- **What it is** — a client-side Vite + React 19 + TypeScript app on Firestore, and where the original 67 Markdown notes went.
- **Features** — split into what works today and what is still a placeholder route (flashcards, dictation, word sets, history).
- **Getting started** — an ordered setup list for a fresh Firebase project: register a web app and enable Google sign-in, create a Cloud Firestore database (location + Production mode, since a new project has none), replace the hard-coded owner email in `firestore.rules`, repoint the `dev` alias in `.firebaserc` or pass an explicit `--project`, then log in and deploy the rules. Nothing is enforced until that last deploy succeeds.
- **Environments** — `.firebaserc` aliases, and the fact that the Vite build mode selects the Firebase project, so it must be set together with `--project`.
- **Data model** — required fields, tag rules, what `learnedOn` actually drives, and the coerce-on-read / validate-on-write split.

`firebase-tools` is a local devDependency, so every CLI example goes through `yarn firebase …`.

## Notable corrections

Claims in the first draft that turned out to be wrong when checked against the code:

- `yarn build` always loads `.env.production`, so deploying that bundle with `--project dev` would ship a prod-connected app to dev. The deploy snippet now pairs the build mode with the target.
- The dashboard's recent list sorts by `learnedOn`, not creation time.
- Search covers a specific set of text fields, not "every field" (`src/lib/filters.ts`).
- Both `headword` and `definition` are required on write, not `definition` alone.
- `createdAt` / `updatedAt` are cast rather than sanitised.
- Furigana falls back to a whole-word annotation when per-kanji alignment fails.

Review rounds corrected three more:

- A fresh Firebase project has no Firestore database at all, and Test mode would leave it open to any client for 30 days — so the earlier claim that reads and writes are denied without the rules deploy was wrong in both directions. That sentence is gone.
- `yarn rules:dev` is wired to `goitei-dev` through `.firebaserc`, so it was never the right command for someone else's project.
- `sanitizeDraft` is best-effort over known fields, not total: `pitchAccent` accepts any number, tags are split but never checked against `TAG_PATTERN`, and `wordSets` takes arbitrary strings. The README now says so, and hardening the sanitizer is tracked separately in #4.

Also documents that the entire `entries` collection is loaded into memory with no pagination — a deliberate assumption worth stating.

## Testing

Docs only; no code changed. Every factual claim was checked against the referenced source file, and `yarn firebase --version` was run to confirm the local CLI path works.