### PR TITLE
feat: rebrand to 語彙庭 and restyle the app from the logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 語彙帳 — Japanese Vocabulary Notebook
+# 語彙庭 Goitei — Japanese Vocabulary Notebook
 
 A personal web app for recording and reviewing Japanese vocabulary picked up in
 daily life and at work, with Cantonese translations and notes.

--- a/index.html
+++ b/index.html
@@ -5,8 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>語彙庭</title>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
-    <meta name="theme-color" content="#f7fbf9" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#0d1a16" media="(prefers-color-scheme: dark)" />
+    <!--
+      One tag rather than a prefers-color-scheme pair: a saved theme overrides
+      the OS preference, so the media query would leave the browser chrome on
+      the opposite colour from the page. Both values live here so the script
+      below and useTheme read one source instead of duplicating the hexes.
+    -->
+    <meta name="theme-color" content="#f7fbf9" data-light="#f7fbf9" data-dark="#0d1a16" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -18,7 +23,10 @@
       (() => {
         const saved = localStorage.getItem('theme');
         const dark = saved ? saved === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.dataset.theme = dark ? 'dark' : 'light';
+        const theme = dark ? 'dark' : 'light';
+        document.documentElement.dataset.theme = theme;
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.content = meta.dataset[theme];
       })();
     </script>
   </head>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>単語帳</title>
+    <title>語彙庭</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>語彙庭</title>
+    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <meta name="theme-color" content="#f7fbf9" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0d1a16" media="(prefers-color-scheme: dark)" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "japanese-vocabulary-notebook",
+  "name": "goitei",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <!--
+    Standalone copy of the LogoMark in src/components/Logo.tsx. A favicon renders
+    outside the page, so it cannot read the theme custom properties and carries
+    literal colours instead. The book green is lifted from the brand #014D3A so
+    the mark still separates from a dark browser tab strip.
+  -->
+  <defs>
+    <linearGradient id="leaf" x1="24" y1="22" x2="24" y2="5" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2E8F63" />
+      <stop offset="1" stop-color="#85D136" />
+    </linearGradient>
+  </defs>
+  <g fill="#0B6B4E">
+    <path d="M23 40.5C18.5 35.2 12.5 33.2 7 33.2Q5.5 33.2 5.5 31.7L5.5 16.3Q5.5 14.8 7 14.8C13 15 19 17.4 23 21.8Z" />
+    <path d="M25 40.5C29.5 35.2 35.5 33.2 41 33.2Q42.5 33.2 42.5 31.7L42.5 16.3Q42.5 14.8 41 14.8C35 15 29 17.4 25 21.8Z" />
+  </g>
+  <path d="M24 31.5C24 25 24 19 24 13.5" fill="none" stroke="#4BB239" stroke-width="1.5" stroke-linecap="round" />
+  <g fill="url(#leaf)">
+    <path d="M24 20.5C15.5 19.5 10.5 14 11.5 5.5C20 7 24 12.5 24 20.5Z" />
+    <path d="M24 21C29.5 20 33.8 16 34 8.8C28.5 10.2 24.8 14.5 24 21Z" />
+  </g>
+</svg>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -42,7 +42,7 @@ export function AppLayout() {
       <header className="border-line bg-card/85 sticky top-0 z-30 border-b backdrop-blur">
         <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
           <NavLink to="/" className="font-display mr-1 text-lg font-bold text-accent">
-            単語帳
+            語彙庭
           </NavLink>
 
           {/* Desktop: the full pill row. */}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -3,6 +3,7 @@ import { NavLink, Navigate, Outlet, useLocation, useNavigate } from 'react-route
 import { useAuth } from '../lib/auth';
 import { EntriesProvider } from '../lib/entries';
 import { EntryFormModal } from './entry-form/EntryFormModal';
+import { LogoMark } from './Logo';
 import { useTheme } from '../lib/theme';
 import { useClickOutside } from '../lib/useClickOutside';
 
@@ -41,7 +42,11 @@ export function AppLayout() {
     <div className="min-h-dvh bg-bg text-ink">
       <header className="border-line bg-card/85 sticky top-0 z-30 border-b backdrop-blur">
         <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
-          <NavLink to="/" className="font-display mr-1 text-lg font-bold text-accent">
+          <NavLink
+            to="/"
+            className="font-display mr-1 flex items-center gap-1.5 text-lg font-bold text-accent"
+          >
+            <LogoMark className="h-7 w-7" />
             語彙庭
           </NavLink>
 

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,44 @@
+import { useId } from 'react';
+
+/**
+ * The 語彙庭 mark: an open book with a sprout rising from the spine.
+ *
+ * The two page halves are separate shapes with a real gap between them rather
+ * than a drawn crease, so the mark sits on any surface — header, card, dark
+ * theme — without needing to know the colour behind it. Leaves run the same
+ * deep-to-bright gradient as the source logo, built from the two theme tokens
+ * so the mark follows light and dark on its own.
+ */
+export function LogoMark({ className = 'h-7 w-7' }: { className?: string }) {
+  // Two marks render at once on some routes, and duplicate gradient ids would
+  // make the second one reference the first one's definition.
+  const gradientId = useId();
+
+  return (
+    <svg viewBox="0 0 48 48" className={className} role="presentation" focusable="false">
+      <defs>
+        <linearGradient id={gradientId} x1="24" y1="22" x2="24" y2="5" gradientUnits="userSpaceOnUse">
+          <stop offset="0" stopColor="var(--c-accent)" />
+          <stop offset="1" stopColor="var(--c-sprout)" />
+        </linearGradient>
+      </defs>
+
+      <g fill="var(--c-accent)">
+        <path d="M23 40.5C18.5 35.2 12.5 33.2 7 33.2Q5.5 33.2 5.5 31.7L5.5 16.3Q5.5 14.8 7 14.8C13 15 19 17.4 23 21.8Z" />
+        <path d="M25 40.5C29.5 35.2 35.5 33.2 41 33.2Q42.5 33.2 42.5 31.7L42.5 16.3Q42.5 14.8 41 14.8C35 15 29 17.4 25 21.8Z" />
+      </g>
+
+      <path
+        d="M24 31.5C24 25 24 19 24 13.5"
+        fill="none"
+        stroke="var(--c-sprout)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <g fill={`url(#${gradientId})`}>
+        <path d="M24 20.5C15.5 19.5 10.5 14 11.5 5.5C20 7 24 12.5 24 20.5Z" />
+        <path d="M24 21C29.5 20 33.8 16 34 8.8C28.5 10.2 24.8 14.5 24 21Z" />
+      </g>
+    </svg>
+  );
+}

--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -129,7 +129,11 @@ export function Heatmap({
           </div>
         </div>
 
-        <div className="overflow-x-auto pb-1">
+        {/* grow so the grid keeps filling the card — a flex item is content-width
+            by default, which would pack the year against the left edge on a wide
+            viewport. min-w-0 lets it shrink below content width and scroll on a
+            narrow one, which min-width:auto would otherwise prevent. */}
+        <div className="min-w-0 flex-1 overflow-x-auto pb-1">
           <div className="min-w-max">
             {/* Month label sits above the week that contains the 1st. */}
             <div className="mb-1 grid grid-flow-col gap-[2px]">

--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from 'react';
-import { addDays, dateKey, shortDate } from '../../lib/dates';
+import { useMemo, useState } from 'react';
+import { addDays, dateKey, fullDate } from '../../lib/dates';
 
 const MONTHS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
 
@@ -18,6 +18,23 @@ export function Heatmap({
   selected: string | null;
   onSelect: (key: string | null) => void;
 }) {
+  const [tip, setTip] = useState<{ label: string; x: number; y: number } | null>(null);
+
+  /**
+   * Positioned `fixed` from the cell's viewport rect rather than absolutely
+   * inside the grid: the grid scrolls horizontally, and a container with
+   * `overflow-x: auto` clips on the vertical axis too, which would cut the
+   * tooltip off above the top row.
+   */
+  const showTip = (cell: HTMLElement, day: { key: string; count: number }) => {
+    const rect = cell.getBoundingClientRect();
+    setTip({
+      label: `${fullDate(day.key)} ・ ${day.count}語`,
+      x: rect.left + rect.width / 2,
+      y: rect.top,
+    });
+  };
+
   const weeks = useMemo(() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
@@ -71,12 +88,17 @@ export function Heatmap({
                   <button
                     key={day.key}
                     type="button"
-                    title={`${shortDate(day.key)} — ${day.count}語`}
-                    aria-label={`${shortDate(day.key)} ${day.count}語`}
+                    aria-label={`${fullDate(day.key)} ${day.count}語`}
                     onClick={() => onSelect(selected === day.key ? null : day.key)}
+                    onMouseEnter={(event) => showTip(event.currentTarget, day)}
+                    onFocus={(event) => showTip(event.currentTarget, day)}
+                    onMouseLeave={() => setTip(null)}
+                    onBlur={() => setTip(null)}
                     style={{ background: `var(--heat-${level(day.count)})` }}
                     className={`h-[11px] w-[11px] rounded-[2px] transition ${
-                      selected === day.key ? 'ring-ink ring-2' : ''
+                      selected === day.key
+                        ? 'ring-ink ring-2'
+                        : 'hover:ring-ink/40 focus-visible:ring-ink/40 hover:ring-1 focus-visible:ring-1'
                     }`}
                   />
                 ),
@@ -97,6 +119,16 @@ export function Heatmap({
         ))}
         <span>多い</span>
       </div>
+
+      {tip && (
+        <div
+          role="tooltip"
+          style={{ left: tip.x, top: tip.y - 8 }}
+          className="rounded-pill bg-ink text-bg shadow-panel pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full px-2.5 py-1 text-xs font-medium whitespace-nowrap"
+        >
+          {tip.label}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -3,6 +3,12 @@ import { addDays, dateKey, fullDate } from '../../lib/dates';
 
 const MONTHS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
 
+/**
+ * Row labels, Sunday-first to match the grid. Every other day is left blank:
+ * a row is 11px tall, so seven stacked labels would run into each other.
+ */
+const WEEKDAYS = ['', '月', '', '水', '', '金', ''];
+
 /** Gap between a cell and its tooltip, and the tooltip's minimum inset from the viewport edge. */
 const TIP_MARGIN = 8;
 
@@ -108,49 +114,65 @@ export function Heatmap({
     <section className="rounded-card bg-card shadow-panel p-5">
       <h2 className="text-muted text-xs font-semibold tracking-wide">直近1年間の追加状況</h2>
 
-      <div className="mt-4 overflow-x-auto pb-1">
-        <div className="min-w-max">
-          {/* Month label sits above the week that contains the 1st. */}
-          <div className="mb-1 grid grid-flow-col gap-[2px]">
-            {weeks.map((week) => {
-              const first = week.find((day) => day.date.getDate() <= 7);
-              const isMonthStart = week.some((day) => day.date.getDate() === 1);
-              return (
-                <span
-                  key={week[0].key}
-                  className="text-muted h-3 w-[11px] text-[10px] leading-3 whitespace-nowrap"
-                >
-                  {isMonthStart && first ? MONTHS[first.date.getMonth()] : ''}
-                </span>
-              );
-            })}
+      <div className="mt-4 flex gap-1">
+        {/* Outside the scroller, so the labels stay put while the year scrolls
+            past. The empty box matches the month row's height to keep the two
+            columns aligned. Decorative — each cell already names its own date. */}
+        <div className="text-muted shrink-0 text-[10px]" aria-hidden="true">
+          <div className="mb-1 h-3" />
+          <div className="grid grid-rows-7 gap-[2px]">
+            {WEEKDAYS.map((label, index) => (
+              <span key={index} className="h-[11px] leading-[11px]">
+                {label}
+              </span>
+            ))}
           </div>
+        </div>
 
-          <div className="grid grid-flow-col grid-rows-7 gap-[2px]">
-            {weeks.flatMap((week) =>
-              week.map((day) =>
-                day.future ? (
-                  <span key={day.key} className="h-[11px] w-[11px]" />
-                ) : (
-                  <button
-                    key={day.key}
-                    type="button"
-                    aria-label={`${fullDate(day.key)} ${day.count}語`}
-                    onClick={() => onSelect(selected === day.key ? null : day.key)}
-                    onMouseEnter={(event) => showTip(event.currentTarget, day)}
-                    onFocus={(event) => showTip(event.currentTarget, day)}
-                    onMouseLeave={() => setTip(null)}
-                    onBlur={() => setTip(null)}
-                    style={{ background: `var(--heat-${level(day.count)})` }}
-                    className={`h-[11px] w-[11px] rounded-[2px] transition ${
-                      selected === day.key
-                        ? 'ring-ink ring-2'
-                        : 'hover:ring-ink/40 focus-visible:ring-ink/40 hover:ring-1 focus-visible:ring-1'
-                    }`}
-                  />
+        <div className="overflow-x-auto pb-1">
+          <div className="min-w-max">
+            {/* Month label sits above the week that contains the 1st. */}
+            <div className="mb-1 grid grid-flow-col gap-[2px]">
+              {weeks.map((week) => {
+                const first = week.find((day) => day.date.getDate() <= 7);
+                const isMonthStart = week.some((day) => day.date.getDate() === 1);
+                return (
+                  <span
+                    key={week[0].key}
+                    className="text-muted h-3 w-[11px] text-[10px] leading-3 whitespace-nowrap"
+                  >
+                    {isMonthStart && first ? MONTHS[first.date.getMonth()] : ''}
+                  </span>
+                );
+              })}
+            </div>
+
+            <div className="grid grid-flow-col grid-rows-7 gap-[2px]">
+              {weeks.flatMap((week) =>
+                week.map((day) =>
+                  day.future ? (
+                    <span key={day.key} className="h-[11px] w-[11px]" />
+                  ) : (
+                    <button
+                      key={day.key}
+                      type="button"
+                      aria-label={`${fullDate(day.key)} ${day.count}語`}
+                      onClick={() => onSelect(selected === day.key ? null : day.key)}
+                      onMouseEnter={(event) => showTip(event.currentTarget, day)}
+                      onFocus={(event) => showTip(event.currentTarget, day)}
+                      onMouseLeave={() => setTip(null)}
+                      onBlur={() => setTip(null)}
+                      style={{ background: `var(--heat-${level(day.count)})` }}
+                      className={`h-[11px] w-[11px] rounded-[2px] transition ${
+                        selected === day.key
+                          ? 'ring-ink ring-2'
+                          : 'hover:ring-ink/40 focus-visible:ring-ink/40 hover:ring-1 focus-visible:ring-1'
+                      }`}
+                    />
+                  ),
                 ),
-              ),
-            )}
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -1,7 +1,10 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { addDays, dateKey, fullDate } from '../../lib/dates';
 
 const MONTHS = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+
+/** Gap between a cell and its tooltip, and the tooltip's minimum inset from the viewport edge. */
+const TIP_MARGIN = 8;
 
 /** 0 entries, then 1 / 2 / 3 / 4+ — four filled buckets as the handoff asks. */
 function level(count: number) {
@@ -18,21 +21,65 @@ export function Heatmap({
   selected: string | null;
   onSelect: (key: string | null) => void;
 }) {
-  const [tip, setTip] = useState<{ label: string; x: number; y: number } | null>(null);
+  /**
+   * The tooltip is `fixed` rather than absolute inside the grid: the grid
+   * scrolls horizontally, and a container with `overflow-x: auto` clips on the
+   * vertical axis too, which would cut the tooltip off above the top row.
+   *
+   * Holding the anchor element rather than a captured rect is what lets the
+   * position be recalculated later — the rect goes stale as soon as anything
+   * scrolls.
+   */
+  const [tip, setTip] = useState<{ label: string; anchor: HTMLElement } | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const tipRef = useRef<HTMLDivElement>(null);
+
+  /** Centre on the cell, clamp to the viewport, and flip below when the space above is short. */
+  const place = useCallback(() => {
+    const node = tipRef.current;
+    if (!tip || !node) return;
+    const anchor = tip.anchor.getBoundingClientRect();
+    const { width, height } = node.getBoundingClientRect();
+
+    const centred = anchor.left + anchor.width / 2 - width / 2;
+    // The upper bound wins when the tooltip is wider than the viewport, which
+    // would otherwise push it off the left edge instead of the right.
+    const left = Math.min(
+      Math.max(centred, TIP_MARGIN),
+      Math.max(TIP_MARGIN, window.innerWidth - width - TIP_MARGIN),
+    );
+    const above = anchor.top - height - TIP_MARGIN;
+
+    setPos({ left, top: above >= TIP_MARGIN ? above : anchor.bottom + TIP_MARGIN });
+  }, [tip]);
+
+  // Measured before paint, so the frame where `pos` is still null is never shown.
+  useLayoutEffect(() => {
+    if (!tip) {
+      setPos(null);
+      return;
+    }
+    place();
+  }, [tip, place]);
 
   /**
-   * Positioned `fixed` from the cell's viewport rect rather than absolutely
-   * inside the grid: the grid scrolls horizontally, and a container with
-   * `overflow-x: auto` clips on the vertical axis too, which would cut the
-   * tooltip off above the top row.
+   * Reposition rather than dismiss: tabbing to a cell scrolls it into view, and
+   * dismissing on scroll would close the tooltip that focus had just opened.
+   * Capture phase so the heatmap's own horizontal scroller counts too — scroll
+   * events from an element do not bubble to window.
    */
+  useEffect(() => {
+    if (!tip) return;
+    window.addEventListener('scroll', place, true);
+    window.addEventListener('resize', place);
+    return () => {
+      window.removeEventListener('scroll', place, true);
+      window.removeEventListener('resize', place);
+    };
+  }, [tip, place]);
+
   const showTip = (cell: HTMLElement, day: { key: string; count: number }) => {
-    const rect = cell.getBoundingClientRect();
-    setTip({
-      label: `${fullDate(day.key)} ・ ${day.count}語`,
-      x: rect.left + rect.width / 2,
-      y: rect.top,
-    });
+    setTip({ label: `${fullDate(day.key)} ・ ${day.count}語`, anchor: cell });
   };
 
   const weeks = useMemo(() => {
@@ -122,9 +169,14 @@ export function Heatmap({
 
       {tip && (
         <div
+          ref={tipRef}
           role="tooltip"
-          style={{ left: tip.x, top: tip.y - 8 }}
-          className="rounded-pill bg-ink text-bg shadow-panel pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full px-2.5 py-1 text-xs font-medium whitespace-nowrap"
+          style={{
+            left: pos?.left ?? 0,
+            top: pos?.top ?? 0,
+            visibility: pos ? 'visible' : 'hidden',
+          }}
+          className="rounded-pill bg-ink text-bg shadow-panel pointer-events-none fixed z-50 px-2.5 py-1 text-xs font-medium whitespace-nowrap"
         >
           {tip.label}
         </div>

--- a/src/components/dashboard/StatTiles.tsx
+++ b/src/components/dashboard/StatTiles.tsx
@@ -1,4 +1,10 @@
-/** Three headline numbers — no plot, so no tooltip layer and no legend. */
+/**
+ * Three headline numbers — no plot, so no tooltip layer and no legend.
+ *
+ * Stacked rather than side by side: the column sits beside the word of the day
+ * at half width, which is too narrow for three centred tiles. `flex-1` splits
+ * whatever height the neighbouring card sets, so the two stay level.
+ */
 export function StatTiles({ week, month, year }: { week: number; month: number; year: number }) {
   const tiles = [
     { label: '今週学んだ語', value: week },
@@ -7,13 +13,14 @@ export function StatTiles({ week, month, year }: { week: number; month: number; 
   ];
 
   return (
-    <div className="grid grid-cols-3 gap-3">
+    <div className="flex h-full flex-col gap-3">
       {tiles.map((tile) => (
-        <div key={tile.label} className="rounded-card bg-accent-soft p-4 text-center sm:p-5">
-          <p className="font-display text-3xl font-bold text-accent tabular-nums sm:text-4xl">
-            {tile.value}
-          </p>
-          <p className="text-muted mt-1 text-xs">{tile.label}</p>
+        <div
+          key={tile.label}
+          className="rounded-card bg-accent-soft flex flex-1 items-center justify-between gap-3 px-5 py-4"
+        >
+          <p className="text-muted text-sm">{tile.label}</p>
+          <p className="font-display text-accent text-3xl font-bold tabular-nums">{tile.value}</p>
         </div>
       ))}
     </div>

--- a/src/components/dashboard/TodayWord.tsx
+++ b/src/components/dashboard/TodayWord.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import type { Entry } from '../../types/entry';
 import { Ruby } from '../Ruby';
+import { LogoMark } from '../Logo';
 
 /**
  * Same word all day, a different one tomorrow, with nothing persisted: the
@@ -14,21 +15,55 @@ export function pickWordOfDay(entries: Entry[], todayKey: string): Entry | null 
   return ordered[hash % ordered.length];
 }
 
+/**
+ * The one card on the dashboard meant to be looked at rather than scanned, so
+ * it gets treatment the sibling panels do not: a tinted gradient, an oversized
+ * headword, and the logomark bled off the corner as a watermark.
+ */
 export function TodayWord({ entry }: { entry: Entry }) {
+  const summary = entry.senses[0]?.description || entry.definition;
+
   return (
     <Link
       to={`/vocabulary/${entry.id}`}
-      className="rounded-card bg-accent-soft block p-5 transition hover:brightness-[0.98]"
+      className="rounded-card border-line from-accent-soft to-card shadow-panel relative block overflow-hidden border bg-linear-to-br p-5 transition hover:-translate-y-0.5"
     >
-      <p className="text-accent text-xs font-semibold">📅 今日の単語</p>
-      <Ruby
-        headword={entry.headword}
-        reading={entry.reading}
-        className="font-display has-ruby mt-2 block text-3xl font-bold"
-      />
-      <p className="prose-cjk mt-2 text-sm">
-        {entry.senses[0]?.description || entry.definition}
-      </p>
+      {/* Decorative, and already announced by the heading below. */}
+      <LogoMark className="pointer-events-none absolute -right-6 -bottom-8 h-40 w-40 opacity-[0.06]" />
+
+      <div className="relative">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-accent text-xs font-semibold tracking-wide">📅 今日の単語</p>
+          <span className="rounded-pill bg-card/70 text-accent shrink-0 px-2 py-0.5 text-[11px] font-semibold">
+            {entry.jlpt}
+          </span>
+        </div>
+
+        <Ruby
+          headword={entry.headword}
+          reading={entry.reading}
+          className="font-display has-ruby mt-3 block text-4xl font-bold"
+        />
+
+        {summary && <p className="prose-cjk mt-2 line-clamp-2 text-sm">{summary}</p>}
+
+        <div className="mt-4 flex flex-wrap items-center gap-1.5">
+          {entry.pos.slice(0, 2).map((part) => (
+            <span
+              key={part}
+              className="bg-card/70 text-muted rounded-pill px-2 py-0.5 text-[11px]"
+            >
+              {part}
+            </span>
+          ))}
+          {entry.tags.slice(0, 2).map((tag) => (
+            <span key={tag} className="text-accent rounded-pill px-1 text-[11px]">
+              #{tag}
+            </span>
+          ))}
+          <span className="text-accent ml-auto text-xs font-semibold">詳しく見る →</span>
+        </div>
+      </div>
     </Link>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,55 +1,71 @@
 @import 'tailwindcss';
 
 /*
- * Palette from the design handoff. Both themes are declared as plain custom
- * properties and referenced from @theme, so every Tailwind colour utility
- * follows the active theme without needing a `dark:` variant on each element.
+ * Palette derived from the 語彙庭 logo, which carries two distinct greens:
+ * the book and wordmark sit at hue ~169 (#014D3A, a blue-leaning forest green)
+ * and the sprout runs hue 133-141 (#4BB239 -> #85D136, a yellow-leaning leaf
+ * green). Forest green is the brand/accent; leaf green is reserved for growth
+ * and progress, which keeps the two from competing.
+ *
+ * Both themes are declared as plain custom properties and referenced from
+ * @theme, so every Tailwind colour utility follows the active theme without
+ * needing a `dark:` variant on each element.
  */
 :root,
 :root[data-theme='light'] {
-  --c-bg: oklch(99% 0.002 25);
-  --c-bg-alt: oklch(96.5% 0.012 25);
+  --c-bg: oklch(99% 0.003 169);
+  --c-bg-alt: oklch(96.5% 0.012 169);
   --c-card: oklch(100% 0 0);
-  --c-border: oklch(92% 0.01 25);
-  --c-text: oklch(18% 0.01 25);
-  --c-text-muted: oklch(50% 0.015 25);
-  --c-accent: oklch(50% 0.2 25);
-  --c-accent-soft: oklch(94% 0.045 25);
-  --c-on-accent: oklch(99% 0.005 25);
-  --c-danger: oklch(50% 0.16 45);
-  --c-danger-soft: oklch(94% 0.05 45);
-  --shadow-card: 0 1px 2px rgb(50 10 10 / 0.04), 0 8px 24px rgb(50 10 10 / 0.07);
+  --c-border: oklch(92% 0.012 169);
+  --c-text: oklch(18% 0.012 169);
+  --c-text-muted: oklch(50% 0.015 169);
+  --c-accent: oklch(38% 0.08 169);
+  --c-accent-soft: oklch(95% 0.03 169);
+  --c-on-accent: oklch(99% 0.005 169);
+  --c-sprout: oklch(60% 0.17 138);
+  /* Danger keeps its red hue, now far enough from the brand that a destructive
+     button can never be mistaken for a primary one. */
+  --c-danger: oklch(50% 0.16 25);
+  --c-danger-soft: oklch(94% 0.05 25);
+  --shadow-card: 0 1px 2px rgb(4 40 28 / 0.05), 0 8px 24px rgb(4 40 28 / 0.08);
 
-  /* Heatmap: sequential magnitude, so one hue stepped light -> dark. Level 0 is
-     near-neutral and levels jump ~0.07 in chroma at the first step, so "nothing
-     added" reads as clearly different from "one word added". */
-  --heat-0: oklch(94% 0.004 25);
-  --heat-1: oklch(84% 0.075 25);
-  --heat-2: oklch(72% 0.13 25);
-  --heat-3: oklch(61% 0.17 25);
-  --heat-4: oklch(50% 0.2 25);
+  /* Heatmap: sequential magnitude stepped light -> dark, sweeping hue from leaf
+     green to forest green so the ramp retraces the logo's own gradient — a
+     quiet day reads as a seedling, a busy one as established planting. Level 0
+     is near-neutral and level 1 jumps ~0.1 in chroma, so "nothing added" stays
+     clearly distinct from "one word added". */
+  --heat-0: oklch(94% 0.005 169);
+  --heat-1: oklch(85% 0.1 138);
+  --heat-2: oklch(72% 0.16 143);
+  --heat-3: oklch(56% 0.13 155);
+  --heat-4: oklch(40% 0.09 169);
 }
 
 :root[data-theme='dark'] {
-  --c-bg: oklch(15% 0.01 25);
-  --c-bg-alt: oklch(20% 0.02 25);
-  --c-card: oklch(22% 0.016 25);
-  --c-border: oklch(32% 0.02 25);
-  --c-text: oklch(94% 0.006 25);
-  --c-text-muted: oklch(68% 0.012 25);
-  --c-accent: oklch(66% 0.19 25);
-  --c-accent-soft: oklch(28% 0.08 25);
-  --c-on-accent: oklch(15% 0.01 25);
-  --c-danger: oklch(62% 0.15 45);
-  --c-danger-soft: oklch(28% 0.06 45);
+  --c-bg: oklch(15% 0.012 169);
+  --c-bg-alt: oklch(20% 0.02 169);
+  --c-card: oklch(22% 0.018 169);
+  --c-border: oklch(32% 0.022 169);
+  --c-text: oklch(94% 0.008 169);
+  --c-text-muted: oklch(68% 0.014 169);
+  /* The forest green is too dark to carry an accent against a dark surface, so
+     the accent moves along the logo's gradient toward the leaf, staying a step
+     below --c-sprout to keep the two readable side by side in the logomark. */
+  --c-accent: oklch(66% 0.155 152);
+  --c-accent-soft: oklch(28% 0.07 158);
+  --c-on-accent: oklch(16% 0.02 169);
+  --c-sprout: oklch(80% 0.19 133);
+  --c-danger: oklch(65% 0.16 25);
+  --c-danger-soft: oklch(28% 0.06 25);
   --shadow-card: 0 1px 2px rgb(0 0 0 / 0.3), 0 8px 24px rgb(0 0 0 / 0.35);
 
-  /* Stepped independently against the dark surface rather than inverted. */
-  --heat-0: oklch(27% 0.008 25);
-  --heat-1: oklch(38% 0.07 25);
-  --heat-2: oklch(48% 0.12 25);
-  --heat-3: oklch(57% 0.16 25);
-  --heat-4: oklch(66% 0.19 25);
+  /* Stepped independently against the dark surface rather than inverted, so the
+     ramp climbs toward the bright leaf instead of sinking into the background. */
+  --heat-0: oklch(27% 0.01 169);
+  --heat-1: oklch(36% 0.06 165);
+  --heat-2: oklch(48% 0.11 155);
+  --heat-3: oklch(60% 0.15 145);
+  --heat-4: oklch(73% 0.19 136);
 }
 
 @theme inline {
@@ -62,6 +78,7 @@
   --color-accent: var(--c-accent);
   --color-accent-soft: var(--c-accent-soft);
   --color-on-accent: var(--c-on-accent);
+  --color-sprout: var(--c-sprout);
   --color-danger: var(--c-danger);
   --color-danger-soft: var(--c-danger-soft);
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -43,3 +43,12 @@ export function shortDate(key: string): string {
   const date = parseLocalDate(key);
   return `${date.getMonth() + 1}/${date.getDate()}`;
 }
+
+/**
+ * 「2025年6月24日」 — for the heatmap, which spans a full year and wraps past
+ * the same month twice, so a bare 6/24 would not say which one.
+ */
+export function fullDate(key: string): string {
+  const date = parseLocalDate(key);
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -11,11 +11,23 @@ function currentTheme(): Theme {
   return document.documentElement.dataset.theme === 'dark' ? 'dark' : 'light';
 }
 
+/**
+ * Browser chrome has to follow the theme the page actually renders, which stops
+ * matching the OS preference the moment someone picks one by hand. The two
+ * colours are carried on the meta tag in index.html so the pre-paint script
+ * there and this function share a single source.
+ */
+function applyTheme(next: Theme) {
+  document.documentElement.dataset.theme = next;
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (meta) meta.content = meta.dataset[next] ?? meta.content;
+}
+
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(currentTheme);
 
   const setTheme = useCallback((next: Theme) => {
-    document.documentElement.dataset.theme = next;
+    applyTheme(next);
     localStorage.setItem('theme', next);
     setThemeState(next);
   }, []);
@@ -29,7 +41,7 @@ export function useTheme() {
     const media = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = (event: MediaQueryListEvent) => {
       if (localStorage.getItem('theme')) return;
-      document.documentElement.dataset.theme = event.matches ? 'dark' : 'light';
+      applyTheme(event.matches ? 'dark' : 'light');
       setThemeState(currentTheme());
     };
     media.addEventListener('change', onChange);

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -69,7 +69,12 @@ export function Component() {
 
   return (
     <div className="space-y-4">
-      <StatTiles week={stats.inWeek} month={stats.inMonth} year={stats.inYear} />
+      {/* Hero row. Without a word of the day the notebook is empty, so the
+          counts drop to a single full-width column rather than leaving a gap. */}
+      <div className={`grid gap-4 ${wordOfDay ? 'sm:grid-cols-2' : ''}`}>
+        {wordOfDay && <TodayWord entry={wordOfDay} />}
+        <StatTiles week={stats.inWeek} month={stats.inMonth} year={stats.inYear} />
+      </div>
 
       <section className="rounded-card bg-card shadow-panel p-5">
         <h2 className="text-muted text-xs font-semibold tracking-wide">最新の練習</h2>
@@ -87,8 +92,6 @@ export function Component() {
         <Distribution title={`JLPTレベル（全 ${entries.length} 語）`} rows={stats.jlptRows} />
         <Distribution title="品詞" rows={stats.posRows} />
       </div>
-
-      {wordOfDay && <TodayWord entry={wordOfDay} />}
 
       <Heatmap
         countsByDay={stats.countsByDay}

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -50,7 +50,7 @@ export function Component() {
   return (
     <main className="grid min-h-dvh place-items-center bg-bg px-4">
       <div className="rounded-card bg-card shadow-panel w-full max-w-[360px] p-8">
-        <h1 className="font-display text-center text-3xl font-bold text-accent">単語帳</h1>
+        <h1 className="font-display text-center text-3xl font-bold text-accent">語彙庭</h1>
         <p className="text-muted mt-1 text-center text-sm">ログインして続ける</p>
 
         <button

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../lib/auth';
 import { projectId } from '../lib/firebase';
+import { LogoMark } from '../components/Logo';
 
 /**
  * Where to land after signing in. `state.from` is set by `AppLayout` when it
@@ -50,8 +51,11 @@ export function Component() {
   return (
     <main className="grid min-h-dvh place-items-center bg-bg px-4">
       <div className="rounded-card bg-card shadow-panel w-full max-w-[360px] p-8">
-        <h1 className="font-display text-center text-3xl font-bold text-accent">語彙庭</h1>
-        <p className="text-muted mt-1 text-center text-sm">ログインして続ける</p>
+        <h1 className="flex flex-col items-center gap-3">
+          <LogoMark className="h-16 w-16" />
+          <span className="font-display text-3xl font-bold text-accent">語彙庭</span>
+        </h1>
+        <p className="text-muted mt-2 text-center text-sm">ログインして続ける</p>
 
         <button
           type="button"


### PR DESCRIPTION
## What

The product's official name is now **語彙庭** (ごいてい / goitei), and the app is restyled around the logo that came with it.

### Branding

Renames the product across the UI, `index.html`, `package.json` and the README. The package name becomes `goitei`, matching the Firebase project ids in `.firebaserc`, which already used `goitei` / `goitei-dev`.

The README on `develop` called it 語彙帳 (帳, ledger). The name is 語彙庭 (庭, garden), which is what the logo shows, so the title now reads `語彙庭 Goitei — Japanese Vocabulary Notebook`. Nothing else in the README needed changing.

### Palette

The logo carries two distinct greens, sampled by decoding its pixels rather than estimating by eye:

| Role | Hex | oklch |
| --- | --- | --- |
| Book and wordmark | `#014D3A` | `oklch(37.4% 0.074 169)` |
| Sprout, mid | `#4BB239` | `oklch(67.8% 0.185 141)` |
| Sprout, bright | `#85D136` | `oklch(78.2% 0.197 133)` |

Hue ~169 forest green becomes the accent and faintly tints every neutral. The leaf greens get their own `--c-sprout` token, reserved for growth and progress so the two never compete.

Every component already routed colour through the semantic tokens in `src/index.css`, so no component needed touching — grepping for hardcoded hex, `rgb()` and Tailwind palette classes across `src/` returned nothing.

The heatmap ramp now sweeps hue from leaf to forest as counts climb, retracing the logo's own gradient: a quiet day reads as a seedling, a busy one as established planting. Danger keeps its red hue, which — now that the accent is green — can no longer be confused with a primary action.

### Logomark

`LogoMark` is inline SVG, used in the header and on the login screen. The two page halves are separate shapes with a real gap between them rather than a drawn crease, so the mark sits on any surface without knowing the colour behind it, and the leaves run a gradient built from the two theme tokens so it follows light and dark on its own.

`public/favicon.svg` is a standalone copy carrying literal colours, since a favicon renders outside the page and cannot read the theme custom properties. Its book green is lifted from `#014D3A` so the mark still separates from a dark browser tab strip.

### Theme colour

`theme-color` is a single meta tag carrying both values as data attributes, set from the resolved theme by the pre-paint script and by `applyTheme()` in `src/lib/theme.ts`.

It deliberately does **not** use a `prefers-color-scheme` media query pair: a saved theme overrides the OS preference, so the media query would leave the browser chrome on the opposite colour from the page whenever someone picked a theme by hand.

### Dashboard

- The word of the day was a flat panel sitting below the distributions. It now leads the page at half width, with a tinted gradient, a larger headword, JLPT and part-of-speech pills, an explicit affordance to open the entry, and the logomark bled off the corner as a watermark.
- The three counts move beside it, stacked, splitting the card's height via `flex-1`. With no word of the day the notebook is empty, so they drop to one full-width column instead of leaving a gap.
- Heatmap rows are labelled with weekdays. Only alternate days are shown, since a row is 11px tall and seven stacked labels would collide, and the column sits outside the horizontal scroller so it stays put while the year scrolls. It is `aria-hidden`: every cell already names its own date.
- Heatmap cells get a real tooltip in place of the native `title`, which waits about a second and cannot be styled. Shown on focus as well as hover, and dates use a new `fullDate` helper — the heatmap spans a year and passes through the same month twice, so a bare `6/24` would not say which one.

#### Tooltip positioning

`fixed` rather than absolute inside the grid: the grid sits in an `overflow-x-auto` container, and CSS forces the other axis from `visible` to `auto` whenever one axis is not `visible`, so an absolutely positioned tooltip would be clipped above the top row.

It holds the anchor element rather than a captured rect and measures itself before paint, clamping horizontally to the viewport and flipping below the cell when the space above is short. Scroll and resize recalculate rather than dismiss — tabbing to a cell scrolls it into view, and dismissing on scroll would close the tooltip that focus had just opened. The scroll listener uses the capture phase, since scroll events from the heatmap's own scroller do not bubble to `window`.

## Testing

No automated tests; this repo has none yet by choice.

- `yarn typecheck` and `yarn build` pass.
- Contrast checked numerically against WCAG AA across both themes for text, muted text, accent, danger and the on-accent pairing. One real failure surfaced: dark `--c-danger` at L62% gave 4.40:1 on card surfaces, so it moved to L65% (4.94:1). The heatmap ramp was confirmed monotonic in lightness in both themes.
- Generated CSS was grepped to confirm each new utility actually emits — in particular `bg-linear-to-br`, since Tailwind v4 renamed `bg-gradient-to-*` and the old name would fail silently.
- Tooltip placement was exercised against the edge cases at a 390px viewport with a 132×24 tooltip: leftmost, rightmost, centre, top row and top-left corner all land fully on screen, the top ones flip below, and a tooltip wider than the viewport pins to the left edge rather than overflowing it.
- Heatmap widths were measured in a real browser at 390px and 1200px. At 1200px the grid fills the card (939px of 939px available); at 390px the scroller scrolls internally (687px of 415px) while the page itself does not overflow. Both `flex-1` and `min-w-0` are needed for that — a flex item is content-width by default, and its `min-width: auto` would otherwise push the overflow onto the page.
- The logomark and the dashboard were rendered from the real built stylesheet and screenshotted in both themes to check layout and legibility at header, login and favicon sizes.
