### PR TITLE
chore: add MIT licence, dependabot and verify every pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   # dozen. Major bumps stay separate: React, Firebase and Vite majors each
   # need reading release notes, which is not a review to rubber-stamp
   # alongside a patch bump.
+  # develop, not the repository default. The default branch is main, which is
+  # production; a dependency bump has no business landing there without going
+  # through dev first.
   - package-ecosystem: npm
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -24,6 +28,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: monthly
     commit-message:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  # Grouped so a week's updates arrive as two pull requests rather than a
+  # dozen. Major bumps stay separate: React, Firebase and Vite majors each
+  # need reading release notes, which is not a review to rubber-stamp
+  # alongside a patch bump.
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      production-minor-patch:
+        dependency-type: production
+        update-types: [minor, patch]
+      development-minor-patch:
+        dependency-type: development
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
+  # Every pull request, whatever it targets. Filtering on the base branch would
+  # leave a pull request stacked on another feature branch unverified until it
+  # was retargeted, which is exactly when it is easiest to merge something red.
   pull_request:
-    branches: [main, develop]
   push:
     branches: [main, develop]
 

--- a/LICENSE
+++ b/LICENSE
@@ -18,3 +18,18 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+SCOPE
+
+"The Software" above means the source code in this repository.
+
+It does not include the Japanese vocabulary entries. Those are personal study
+notes -- headwords, readings, definitions, example sentences, usage notes and
+Cantonese translations, written by hand over a year. They are committed as
+migration/output.json and migration/review.json so that the import into
+Firestore stays inspectable and replayable, not as a corpus offered for reuse.
+
+The vocabulary entries are Copyright (c) 2026 Kowin Au Yeung, all rights
+reserved. For any use of them, ask first.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2026 Kowin Au Yeung
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ key in this project, and there should not be one.
 ## Environments
 
 `.firebaserc` maps `default` and `dev` to `goitei-dev`, and `prod` to `goitei`,
-so a deploy with no `--project` targets development. Branches follow the same split
-by convention — `develop` for dev, `main` for production — but nothing enforces
-it; there is no CI yet and every deploy so far has been manual.
+so a deploy with no `--project` targets development. Branches follow the same
+split — `develop` for dev, `main` for production. Both are protected: changes
+land through a pull request with a green CI run, and neither accepts a force
+push. Deploys themselves are still run by hand.
 
 Which project a build talks to comes from the env file Vite picks, not from the
 `--project` flag, so the two must be set together:

--- a/README.md
+++ b/README.md
@@ -159,3 +159,8 @@ rules enforce account access only, never document shape.
 > The app UI is in Japanese and repository documentation is in English. Entry
 > content is mostly Japanese, with Cantonese (Traditional Chinese) translations
 > and remarks in `definitionSub` and the translation fields.
+
+## License
+
+[MIT](LICENSE). This covers the application code. Vocabulary entries are
+personal study notes.

--- a/README.md
+++ b/README.md
@@ -162,5 +162,10 @@ rules enforce account access only, never document shape.
 
 ## License
 
-[MIT](LICENSE). This covers the application code. Vocabulary entries are
-personal study notes.
+Source code: [MIT](LICENSE).
+
+The Japanese vocabulary entries are **not** covered by it. They are personal
+study notes, committed as `migration/output.json` and `migration/review.json`
+so the Firestore import stays inspectable — see
+[`migration/README.md`](migration/README.md) — and they are reserved. The scope
+note at the bottom of [`LICENSE`](LICENSE) is the authoritative wording.

--- a/migration/README.md
+++ b/migration/README.md
@@ -31,6 +31,11 @@ value in Firestore is surprising. They are not re-runnable without the notes.
 | `output.json`   | The 67 verified entries. **The artefact of record.**                                             |
 | `review.json`   | Parser warnings needing human judgement. `[]` = clean.                                           |
 
+The scripts are MIT like the rest of the source. The entries inside
+`output.json` and `review.json` are not: they are personal study notes,
+committed for provenance rather than reuse. See the scope note at the bottom of
+[`LICENSE`](../LICENSE).
+
 ## Running the upload
 
 Credentials resolve in this order, and the machine-wide ADC is never used

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "goitei",
   "private": true,
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "packageManager": "yarn@1.22.22",
   "engines": {


### PR DESCRIPTION
## What

Three pieces of repo hygiene that are unrelated to each other but all one-line-each to review.

Stacked on `chore/tooling-baseline` (#7) — GitHub will retarget this to `develop` once that merges.

### LICENSE

The repo is public and had no licence file, which means all rights reserved by default. MIT, covering the application code. The vocabulary entries are personal study notes, which the README now says.

Correct the copyright name if the legal spelling differs — it was taken from the GitHub profile.

### Dependabot

`.github/dependabot.yml` for npm and github-actions.

Minor and patch bumps are grouped into one production and one development pull request per week. Majors are deliberately left ungrouped: a React 19→20, Firebase 12→13 or Vite 7→8 bump needs release notes read, and burying that inside a group of patch bumps is how it gets rubber-stamped.

Dependabot **security alerts** and **automated security fixes** are also now enabled on the repository — they were off, which on a public repo is the part that actually matters.

### CI on every pull request

`on.pull_request` no longer filters by base branch.

The filter meant a pull request stacked on another feature branch got no CI at all until it was retargeted. That is precisely the moment when merging something red is easiest, so the filter was working against itself. `push` still only builds `main` and `develop`.

## Verified

`yarn format:check` passes. The rest is config; CI on this PR is the test of the trigger change, since the workflow file for a `pull_request` event is read from the PR head.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ4pYbQ8bgT9XYhCAB8WdZ
