### PR TITLE
chore: tighten TypeScript and sort imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,9 +1,10 @@
 import js from '@eslint/js';
-import globals from 'globals';
+import prettier from 'eslint-config-prettier';
+import perfectionist from 'eslint-plugin-perfectionist';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
-import prettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   {
@@ -15,6 +16,27 @@ export default tseslint.config(
   {
     rules: {
       'no-irregular-whitespace': ['error', { skipRegExps: true }],
+    },
+  },
+
+  // Import order only. Perfectionist can also sort object keys, union members
+  // and JSX props, and none of those are wanted: the manifest rows, the schema
+  // in jsonImport.ts and the POS_MAP in normalize.mjs are all ordered on
+  // purpose, and alphabetising them would destroy information.
+  {
+    plugins: { perfectionist },
+    rules: {
+      'perfectionist/sort-imports': [
+        'error',
+        {
+          type: 'natural',
+          internalPattern: ['^@/'],
+          newlinesBetween: 'ignore',
+          // Bare selectors, so a `import type` stays beside the value import
+          // from the same module instead of being hoisted into a types block.
+          groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index'], 'unknown'],
+        },
+      ],
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@vitejs/plugin-react": "^5.0.0",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-perfectionist": "^5.10.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "firebase-admin": "^13.6.0",

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,10 +2,10 @@ import { useCallback, useRef, useState } from 'react';
 import { NavLink, Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/lib/auth';
 import { EntriesProvider } from '@/lib/entries';
-import { EntryFormModal } from './entry-form/EntryFormModal';
-import { LogoMark } from './Logo';
 import { useTheme } from '@/lib/theme';
 import { useClickOutside } from '@/lib/useClickOutside';
+import { EntryFormModal } from './entry-form/EntryFormModal';
+import { LogoMark } from './Logo';
 
 const NAV = [
   { to: '/', label: 'ダッシュボード', end: true },

--- a/src/components/browse/EntryCard.tsx
+++ b/src/components/browse/EntryCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import type { Entry } from '@/types/entry';
 import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/types/entry';
 
 export function EntryCard({ entry }: { entry: Entry }) {
   return (

--- a/src/components/dashboard/EntryRow.tsx
+++ b/src/components/dashboard/EntryRow.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
-import type { Entry } from '@/types/entry';
 import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/types/entry';
 
 export function EntryRow({ entry }: { entry: Entry }) {
   return (

--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -110,14 +110,21 @@ export function Heatmap({
     const start = addDays(from, -from.getDay());
 
     const result: { key: string; date: Date; count: number; future: boolean }[][] = [];
+    // `start` is a Sunday by construction, so the first iteration always opens
+    // a week before anything is pushed into one. Holding the current week in a
+    // variable says that to the compiler; indexing result.length - 1 did not.
+    let week: (typeof result)[number] = [];
     for (
       let cursor = start;
       cursor <= today || cursor.getDay() !== 0;
       cursor = addDays(cursor, 1)
     ) {
-      if (cursor.getDay() === 0) result.push([]);
+      if (cursor.getDay() === 0) {
+        week = [];
+        result.push(week);
+      }
       const key = dateKey(cursor);
-      result[result.length - 1].push({
+      week.push({
         key,
         date: new Date(cursor),
         count: countsByDay.get(key) ?? 0,
@@ -154,12 +161,12 @@ export function Heatmap({
           <div className="min-w-max">
             {/* Month label sits above the week that contains the 1st. */}
             <div className="mb-1 grid grid-flow-col gap-[2px]">
-              {weeks.map((week) => {
+              {weeks.map((week, index) => {
                 const first = week.find((day) => day.date.getDate() <= 7);
                 const isMonthStart = week.some((day) => day.date.getDate() === 1);
                 return (
                   <span
-                    key={week[0].key}
+                    key={week[0]?.key ?? index}
                     className="h-3 w-[11px] text-[10px] leading-3 whitespace-nowrap text-muted"
                   >
                     {isMonthStart && first ? MONTHS[first.date.getMonth()] : ''}

--- a/src/components/dashboard/TodayWord.tsx
+++ b/src/components/dashboard/TodayWord.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
-import type { Entry } from '@/types/entry';
-import { Ruby } from '@/components/Ruby';
 import { LogoMark } from '@/components/Logo';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/types/entry';
 
 /**
  * Same word all day, a different one tomorrow, with nothing persisted: the

--- a/src/components/dashboard/TodayWord.tsx
+++ b/src/components/dashboard/TodayWord.tsx
@@ -12,7 +12,7 @@ export function pickWordOfDay(entries: Entry[], todayKey: string): Entry | null 
   let hash = 0;
   for (const char of todayKey) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
   const ordered = [...entries].sort((a, b) => a.id.localeCompare(b.id));
-  return ordered[hash % ordered.length];
+  return ordered[hash % ordered.length] ?? null;
 }
 
 /**

--- a/src/components/entry-form/EntryForm.tsx
+++ b/src/components/entry-form/EntryForm.tsx
@@ -1,6 +1,6 @@
+import { parseTags } from '@/lib/draft';
 import type { EntryDraft, Pos } from '@/types/entry';
 import { JLPT_LEVELS, POLITENESS, POS, STYLES, WORD_ORIGINS } from '@/types/entry';
-import { parseTags } from '@/lib/draft';
 import { Area, Field, RepeatableList, Select, Text, inputClass } from './fields';
 
 export function EntryForm({

--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from 'react';
-import type { Entry, EntryDraft } from '@/types/entry';
-import { createEntry, updateEntry } from '@/lib/entryWrite';
-import { emptyDraft, invalidTags, parseTags, toDraft } from '@/lib/draft';
-import { isValidIsoDate } from '@/lib/sanitize';
-import { useEntries } from '@/lib/entries';
 import { Modal } from '@/components/Modal';
+import { emptyDraft, invalidTags, parseTags, toDraft } from '@/lib/draft';
+import { useEntries } from '@/lib/entries';
+import { createEntry, updateEntry } from '@/lib/entryWrite';
+import { isValidIsoDate } from '@/lib/sanitize';
+import type { Entry, EntryDraft } from '@/types/entry';
 import { EntryForm } from './EntryForm';
-import { JsonImport } from './JsonImport';
 import { Area, Field, Text } from './fields';
+import { JsonImport } from './JsonImport';
 
 type Tab = 'simple' | 'full' | 'json';
 

--- a/src/components/entry-form/JsonImport.tsx
+++ b/src/components/entry-form/JsonImport.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import type { EntryDraft } from '@/types/entry';
 import { buildPrompt, jsonToDraft, SCHEMA } from '@/lib/jsonImport';
+import type { EntryDraft } from '@/types/entry';
 import { Area, Field, inputClass } from './fields';
 
 export function JsonImport({ onLoad }: { onLoad: (draft: EntryDraft) => void }) {

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -1,7 +1,7 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
 import type { User } from 'firebase/auth';
 import { onAuthStateChanged, signInWithPopup, signOut } from 'firebase/auth';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import { auth, googleProvider } from './firebase';
 
 interface AuthValue {

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -6,7 +6,10 @@
  */
 
 export function parseLocalDate(key: string): Date {
-  const [y, m, d] = key.split('-').map(Number);
+  // A malformed key leaves components missing, which is why they default to
+  // NaN: `new Date(NaN, ...)` is the Invalid Date the callers already handled,
+  // and is exactly what `undefined` coerced to before.
+  const [y = NaN, m = NaN, d = NaN] = key.split('-').map(Number);
   return new Date(y, m - 1, d);
 }
 

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -1,6 +1,6 @@
+import { collection, getDocs } from 'firebase/firestore';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import { collection, getDocs } from 'firebase/firestore';
 import type { Entry } from '@/types/entry';
 import { db } from './firebase';
 import { sanitizeEntry } from './sanitize';

--- a/src/lib/furigana.ts
+++ b/src/lib/furigana.ts
@@ -44,6 +44,6 @@ export function segmentFurigana(headword: string, reading: string): FuriganaSegm
 
   let group = 1;
   return runs.map((run) =>
-    run.kanji ? { base: run.text, rt: match[group++] } : { base: run.text, rt: '' },
+    run.kanji ? { base: run.text, rt: match[group++] ?? '' } : { base: run.text, rt: '' },
   );
 }

--- a/src/routes/Browse.tsx
+++ b/src/routes/Browse.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { EntryCard } from '@/components/browse/EntryCard';
+import { FilterPanel } from '@/components/browse/FilterPanel';
 import { useEntries } from '@/lib/entries';
 import {
   EMPTY_FILTERS,
@@ -10,8 +12,6 @@ import {
   toSearchParams,
 } from '@/lib/filters';
 import type { Filters } from '@/lib/filters';
-import { EntryCard } from '@/components/browse/EntryCard';
-import { FilterPanel } from '@/components/browse/FilterPanel';
 
 export function Component() {
   const { entries, loading, error } = useEntries();

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from 'react';
-import { useEntries } from '@/lib/entries';
-import { JLPT_LEVELS } from '@/types/entry';
+import { Distribution } from '@/components/dashboard/Distribution';
+import { EntryRow } from '@/components/dashboard/EntryRow';
+import { Heatmap } from '@/components/dashboard/Heatmap';
+import { StatTiles } from '@/components/dashboard/StatTiles';
+import { TodayWord, pickWordOfDay } from '@/components/dashboard/TodayWord';
 import {
   dateKey,
   parseLocalDate,
@@ -9,11 +12,8 @@ import {
   startOfMonth,
   startOfYear,
 } from '@/lib/dates';
-import { StatTiles } from '@/components/dashboard/StatTiles';
-import { Distribution } from '@/components/dashboard/Distribution';
-import { Heatmap } from '@/components/dashboard/Heatmap';
-import { TodayWord, pickWordOfDay } from '@/components/dashboard/TodayWord';
-import { EntryRow } from '@/components/dashboard/EntryRow';
+import { useEntries } from '@/lib/entries';
+import { JLPT_LEVELS } from '@/types/entry';
 
 export function Component() {
   const { entries, loading, error } = useEntries();

--- a/src/routes/EntryDetail.tsx
+++ b/src/routes/EntryDetail.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { KeyValueTable, Section } from '@/components/detail/Section';
+import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
+import { Ruby } from '@/components/Ruby';
 import { useEntries } from '@/lib/entries';
 import { deleteEntry } from '@/lib/entryWrite';
-import { Ruby } from '@/components/Ruby';
-import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
-import { KeyValueTable, Section } from '@/components/detail/Section';
 
 /** ①②③… for sense and example numbering, matching the notes. */
 function circled(index: number): string {

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
+import { LogoMark } from '@/components/Logo';
 import { useAuth } from '@/lib/auth';
 import { projectId } from '@/lib/firebase';
-import { LogoMark } from '@/components/Logo';
 
 /**
  * Where to land after signing in. `state.from` is set by `AppLayout` when it

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,6 +15,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
 
     "allowImportingTsExtensions": true,

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,6 +14,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
 
     "erasableSyntaxOnly": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
-import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath, URL } from 'node:url';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,7 +1789,7 @@
     tinyglobby "^0.2.15"
     ts-api-utils "^2.5.0"
 
-"@typescript-eslint/utils@8.66.0":
+"@typescript-eslint/utils@8.66.0", "@typescript-eslint/utils@^8.65.0":
   version "8.66.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.66.0.tgz#e277d67427043cdca2580ee91aa62921e4689969"
   integrity sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==
@@ -2922,6 +2922,14 @@ eslint-config-prettier@^10.1.8:
   version "10.1.8"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz#15734ce4af8c2778cc32f0b01b37b0b5cd1ecb97"
   integrity sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==
+
+eslint-plugin-perfectionist@^5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-5.10.1.tgz#3fb3401fe97eae57aa1194a1fd824ff95becb497"
+  integrity sha512-Kprsp9Us0GqAesYaAIzUViw57xYp5WBqzXrcE0Mtww++E5fexWXYBipMuuD7yvyH4vvpBH0+oJ+OMAmZ0oYXkw==
+  dependencies:
+    "@typescript-eslint/utils" "^8.65.0"
+    natural-orderby "^5.0.0"
 
 eslint-plugin-react-hooks@^7.1.1:
   version "7.1.1"
@@ -4797,6 +4805,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+natural-orderby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/natural-orderby/-/natural-orderby-5.0.0.tgz#bb655f669ee9c84e82cdc6cddbba25eb263cd9f4"
+  integrity sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==
 
 nearley@^2.20.1:
   version "2.20.1"


### PR DESCRIPTION
## What

Two more TypeScript flags and an import-order rule. Two commits: read the first, skim the second.

Stacked on `chore/tooling-baseline` (#7) — GitHub will retarget this to `develop` once that merges.

### `exactOptionalPropertyTypes`

Already clean. Zero call sites needed touching, so this is a free tightening.

### `noUncheckedIndexedAccess`

Six call sites. **None of them was a live bug** — each is an invariant the compiler could not see, and the fixes say the invariant out loud rather than assert past it:

| Site | Invariant | Fix |
| --- | --- | --- |
| `lib/dates.ts` | `parseLocalDate` destructured three components out of a `split` with no defaults | Default to `NaN`. `new Date(NaN, …)` is the same Invalid Date `undefined` already coerced to, so a malformed key behaves exactly as before |
| `dashboard/Heatmap.tsx` ×2 | Weeks were built by indexing `result[result.length - 1]`; `start` is a Sunday by construction so a week is always open | Hold the current week in a variable. The month label falls back to the column index for its React key |
| `dashboard/TodayWord.tsx` | `pickWordOfDay` already returns `null` for an empty list | `?? null`, so the index expression agrees with the signature |
| `lib/furigana.ts` | One capture group per kanji run, read from a match that succeeded | An absent group falls back to no annotation |

No non-null assertions were used. Casting past the compiler is what this codebase already decided against at its input boundaries, and the same applies here.

### Import ordering

`eslint-plugin-perfectionist`, `sort-imports` only: node builtins → packages → `@/` → relative. Fully auto-fixable, so it costs nothing to keep and makes import diffs stable.

**Only that one rule.** Perfectionist will also sort object keys, union members and JSX props, and none of those are wanted here — the manifest rows, the schema string in `jsonImport.ts` and `POS_MAP` in `normalize.mjs` are all ordered deliberately, and alphabetising them would destroy information. `import type` stays beside the value import from the same module rather than being hoisted into a separate types block.

## Verified

`yarn typecheck`, `yarn lint`, `yarn format:check` and `yarn build` all pass. Lint is unchanged at 0 errors / 6 warnings.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ4pYbQ8bgT9XYhCAB8WdZ
