### PR TITLE
ci: deploy develop to goitei-dev and preview every pull request

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -7,18 +7,17 @@ on:
 
 permissions:
   contents: read
-  # Workload Identity Federation mints a short-lived Google credential from
-  # this token. There is no service-account key in this project and this
-  # workflow is not a reason to create one.
-  id-token: write
-  pull-requests: write
 
 concurrency:
   group: deploy-dev-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  # Runs the pull request's own code, so it is treated as untrusted: no
+  # id-token permission, no Google credential, nothing a build could steal and
+  # escalate with. A dependency's postinstall script counts as the pull
+  # request's code too, which is why the split is by job and not by step.
+  build:
     # A fork's pull request must never reach these secrets. GitHub already
     # withholds them from fork runs, so the job would fail rather than leak,
     # but skipping outright keeps the pull request green instead of red for a
@@ -27,28 +26,63 @@ jobs:
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-
-    # Vite inlines VITE_-prefixed variables from the environment at build time,
-    # taking precedence over .env.production — which is gitignored, so the
-    # runner has none. Passing them here avoids writing secrets to disk.
-    #
-    # These six values ship inside the bundle and are public by design; rules,
-    # not secrecy, protect the data. They stay secrets anyway because the repo
-    # is public and a scraped key invites quota abuse.
-    env:
-      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
-      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
-      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
-      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
-      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
-      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # Vite inlines VITE_-prefixed variables from the environment at build
+      # time, taking precedence over .env.production — which is gitignored, so
+      # the runner has none. Scoped to this step rather than the job so that
+      # install-time scripts never see them.
+      #
+      # These six ship inside the bundle and can be read from the deployed site
+      # by anyone; rules, not secrecy, protect the data. They are secrets only
+      # because the repo is public and a scraped key invites quota abuse.
+      - name: Build
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+        run: yarn build
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
+
+  # Holds the credentials and runs no code from the pull request. It checks out
+  # the base branch, so firebase-tools comes from a lockfile that is already
+  # merged, and takes only dist/ from the build job.
+  #
+  # The consequence worth knowing: on a pull request, firebase.json and
+  # .firebaserc are the base branch's. A pull request that changes hosting
+  # config will not see that change in its own preview. Config belongs on the
+  # trusted path, so that is the intended behaviour rather than a gap.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
       # Until the federation provider exists there is nothing to deploy to, and
       # failing every pull request over a setup step nobody has done yet trains
-      # people to ignore a red check. Build and report, then stop.
+      # people to ignore a red check. Report and stop.
       #
       # The secrets context is not available to a job-level `if`, which is why
       # this is a step rather than a condition on the job.
@@ -64,15 +98,28 @@ jobs:
             echo '::notice::Deploy skipped: GCP_WORKLOAD_IDENTITY_PROVIDER is not set. See README → Deploy credentials.'
           fi
 
+      - uses: actions/checkout@v5
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+
       - uses: actions/setup-node@v6
+        if: steps.gate.outputs.configured == 'true'
         with:
           node-version-file: .nvmrc
           cache: yarn
 
-      - run: yarn install --frozen-lockfile
+      # Installed before authenticating, so even a trusted postinstall script
+      # runs with no credential in the environment.
+      - name: Install firebase-tools
+        if: steps.gate.outputs.configured == 'true'
+        run: yarn install --frozen-lockfile
 
-      - name: Build
-        run: yarn build
+      - uses: actions/download-artifact@v8
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          name: dist
+          path: dist
 
       - uses: google-github-actions/auth@v3
         if: steps.gate.outputs.configured == 'true'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,6 +46,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Until the federation provider exists there is nothing to deploy to, and
+      # failing every pull request over a setup step nobody has done yet trains
+      # people to ignore a red check. Build and report, then stop.
+      #
+      # The secrets context is not available to a job-level `if`, which is why
+      # this is a step rather than a condition on the job.
+      - name: Check for deploy credentials
+        id: gate
+        env:
+          PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        run: |
+          if [ -n "$PROVIDER" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::Deploy skipped: GCP_WORKLOAD_IDENTITY_PROVIDER is not set. See README → Deploy credentials.'
+          fi
+
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -57,6 +75,7 @@ jobs:
         run: yarn build
 
       - uses: google-github-actions/auth@v3
+        if: steps.gate.outputs.configured == 'true'
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
@@ -65,7 +84,7 @@ jobs:
       # the .firebaserc alias for goitei-dev; prod is not reachable from this
       # workflow at all.
       - name: Deploy to goitei-dev
-        if: github.event_name == 'push'
+        if: steps.gate.outputs.configured == 'true' && github.event_name == 'push'
         run: yarn firebase deploy --only hosting,firestore:rules --project dev --non-interactive
 
       # A preview channel is hosting-only on purpose. Rules are project-wide,
@@ -73,7 +92,7 @@ jobs:
       # other preview and the dev site itself are running under.
       - name: Deploy preview channel
         id: preview
-        if: github.event_name == 'pull_request'
+        if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
         env:
           PR: ${{ github.event.pull_request.number }}
         run: |
@@ -82,7 +101,7 @@ jobs:
           echo "url=$(jq -r '.result | to_entries[0].value.url' channel.json)" >> "$GITHUB_OUTPUT"
 
       - name: Comment the preview URL
-        if: github.event_name == 'pull_request'
+        if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,95 @@
+name: Deploy (dev)
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+
+permissions:
+  contents: read
+  # Workload Identity Federation mints a short-lived Google credential from
+  # this token. There is no service-account key in this project and this
+  # workflow is not a reason to create one.
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: deploy-dev-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # A fork's pull request must never reach these secrets. GitHub already
+    # withholds them from fork runs, so the job would fail rather than leak,
+    # but skipping outright keeps the pull request green instead of red for a
+    # reason the contributor cannot fix.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    # Vite inlines VITE_-prefixed variables from the environment at build time,
+    # taking precedence over .env.production — which is gitignored, so the
+    # runner has none. Passing them here avoids writing secrets to disk.
+    #
+    # These six values ship inside the bundle and are public by design; rules,
+    # not secrecy, protect the data. They stay secrets anyway because the repo
+    # is public and a scraped key invites quota abuse.
+    env:
+      VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+      VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+      VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+      VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+      VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+      VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+
+      # Hosting and rules together, and only from develop. `--project dev` is
+      # the .firebaserc alias for goitei-dev; prod is not reachable from this
+      # workflow at all.
+      - name: Deploy to goitei-dev
+        if: github.event_name == 'push'
+        run: yarn firebase deploy --only hosting,firestore:rules --project dev --non-interactive
+
+      # A preview channel is hosting-only on purpose. Rules are project-wide,
+      # so deploying them from a pull request would change the rules every
+      # other preview and the dev site itself are running under.
+      - name: Deploy preview channel
+        id: preview
+        if: github.event_name == 'pull_request'
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          ./node_modules/.bin/firebase hosting:channel:deploy "pr-$PR" \
+            --project dev --expires 7d --non-interactive --json > channel.json
+          echo "url=$(jq -r '.result | to_entries[0].value.url' channel.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment the preview URL
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          URL: ${{ steps.preview.outputs.url }}
+        run: |
+          printf '%s\n\n%s\n' \
+            "Preview: $URL" \
+            "Serves this branch against the **goitei-dev** Firestore — the same data as the dev site, not a copy. Expires in 7 days." \
+            > body.md
+          gh pr comment "$PR" --body-file body.md --edit-last --create-if-none

--- a/README.md
+++ b/README.md
@@ -109,7 +109,16 @@ key in this project, and there should not be one.
 so a deploy with no `--project` targets development. Branches follow the same
 split — `develop` for dev, `main` for production. Both are protected: changes
 land through a pull request with a green CI run, and neither accepts a force
-push. Deploys themselves are still run by hand.
+push.
+
+Pushing to `develop` deploys hosting and Firestore rules to `goitei-dev`, and
+every pull request gets its own Hosting preview channel that expires after seven
+days. Preview channels are hosting-only: rules are project-wide, so deploying
+them from a pull request would change the rules every other preview runs under.
+A preview reads the real `goitei-dev` data, not a copy.
+
+**Production is not automated.** Nothing in `.github/workflows/` can reach
+`goitei`; deploy it by hand with the commands below.
 
 Which project a build talks to comes from the env file Vite picks, not from the
 `--project` flag, so the two must be set together:
@@ -128,6 +137,23 @@ yarn firebase deploy --only hosting,firestore:rules --project prod
 `practiceSessions` and `wordSets` for one hard-coded verified email; every other
 path is denied. For the first production import, follow the rules-first order in
 [`migration/README.md`](migration/README.md).
+
+### Deploy credentials
+
+The dev workflow authenticates through Workload Identity Federation, so there is
+no long-lived service-account key anywhere in this project. It needs these
+repository secrets:
+
+| Secret                           | What it is                                                                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Full provider resource name, `projects/<number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>`                              |
+| `GCP_DEPLOY_SERVICE_ACCOUNT`     | Email of the service account the workflow impersonates                                                                                           |
+| `VITE_FIREBASE_*` (six)          | Same values as `.env.example`. Vite inlines them at build time; they are public by design, but the repo is public too, so they are not committed |
+
+The service account needs **Firebase Hosting Admin**, **Cloud Datastore Index
+Admin** and **Firebase Rules Admin** on `goitei-dev`, and the pool's provider
+must be restricted to this repository — an unrestricted provider lets any GitHub
+repository mint credentials for it.
 
 ## Data model
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,32 @@ Admin** and **Firebase Rules Admin** on `goitei-dev`, and the pool's provider
 must be restricted to this repository — an unrestricted provider lets any GitHub
 repository mint credentials for it.
 
+#### Trust boundary
+
+The deploy workflow is split into two jobs, and the split is the security
+boundary rather than a build-time optimisation:
+
+- **`build`** runs the pull request's own code. It has `contents: read` and
+  nothing else — no `id-token` permission, so `ACTIONS_ID_TOKEN_REQUEST_TOKEN`
+  is not in its environment and nothing it runs can mint a Google credential.
+  It uploads `dist/` and stops.
+- **`deploy`** holds the credentials and runs no code from the pull request. It
+  checks out the base branch, installs `firebase-tools` from a lockfile that is
+  already merged, and takes only `dist/` from the build job.
+
+A pull request is otherwise a code-execution primitive: `yarn install` runs
+whatever `postinstall` the branch's lockfile asks for, before any file in the
+diff has been read by a human. Keeping that away from the credential is what
+the two jobs buy.
+
+The six `VITE_FIREBASE_*` values are the exception, and are scoped to the build
+step. They can already be read out of the deployed bundle by anyone, so a build
+that leaks them gives away nothing that visiting the dev site would not.
+
+Tighten the provider further if you can: an attribute condition of
+`assertion.repository == '<owner>/<repo>' && assertion.ref == 'refs/heads/develop'`
+means a token minted in a pull request context cannot be exchanged at all.
+
 ## Data model
 
 Defined in [`src/types/entry.ts`](src/types/entry.ts). Points worth knowing:


### PR DESCRIPTION
## What

`develop` deploys to `goitei-dev`, and every pull request gets its own Hosting preview channel.

Stacked on `chore/tooling-baseline` (#7) — GitHub will retarget this to `develop` once that merges.

> [!IMPORTANT]
> **This cannot run until the setup below is done.** It needs a Workload Identity Federation provider and eight repository secrets that do not exist yet. Merging it before then means a red workflow on every push to `develop`.

### No service-account key

Authentication is through Workload Identity Federation (`google-github-actions/auth`), which mints a short-lived credential from the job's OIDC token.

This is not the default advice — the usual Firebase deploy action wants a service-account JSON key in a secret. This project removed its keys and revoked them after the first data upload, and needing a deploy workflow is not a reason to bring one back. `firebase-tools` picks up the federated credential through `GOOGLE_APPLICATION_CREDENTIALS`, so the CLI needs no special handling.

### Build config

Vite inlines `VITE_`-prefixed variables from the process environment at build time, and they take precedence over `.env.production` — verified locally by building with a sentinel value set and finding it in the emitted bundle. So the six values are passed as job `env` and never written to disk on the runner.

They ship inside the bundle regardless and Firestore rules, not secrecy, protect the data. They are still secrets because the repo is public and a scraped key invites quota abuse against a project whose key nobody rotates.

### Preview channels are hosting-only

`develop` deploys `hosting,firestore:rules`. A pull request deploys **hosting only**.

Rules are project-wide. Deploying them from a pull request would change the rules that every other preview channel — and the dev site itself — are running under, which is the opposite of what a preview is for.

The preview also reads the **real `goitei-dev` Firestore**, not a copy. The bot comment says so on every PR, because a preview URL looks disposable and the data behind it is not.

### Forks

The job is skipped for a pull request from a fork. GitHub already withholds secrets from fork runs so nothing could leak, but skipping keeps the check green rather than failing for a reason a contributor cannot fix.

### Production

Not wired up. `--project dev` is the `.firebaserc` alias, and no path in this workflow reaches `goitei`. The README now says production is deployed by hand.

## Setup required before merging

**1. Workload Identity Federation**, in the `goitei-dev` project:

```bash
gcloud iam workload-identity-pools create github --location=global
gcloud iam workload-identity-pools providers create-oidc github \
  --location=global --workload-identity-pool=github \
  --issuer-uri=https://token.actions.githubusercontent.com \
  --attribute-mapping=google.subject=assertion.sub,attribute.repository=assertion.repository \
  --attribute-condition="assertion.repository == 'kowinauyeung/japanese-learning-notes'"
```

The `--attribute-condition` is not optional. Without it any GitHub repository anywhere can mint credentials for the service account.

Then create a service account, grant it **Firebase Hosting Admin**, **Cloud Datastore Index Admin** and **Firebase Rules Admin**, and let the pool impersonate it via `roles/iam.workloadIdentityUser`.

**2. Repository secrets** — eight:

| Secret | Value |
| --- | --- |
| `GCP_WORKLOAD_IDENTITY_PROVIDER` | `projects/<number>/locations/global/workloadIdentityPools/github/providers/github` |
| `GCP_DEPLOY_SERVICE_ACCOUNT` | the service account email |
| `VITE_FIREBASE_API_KEY` and the other five | the values already in your local `.env.development` |

## Verified

The workflow parses, and `yarn format:check` passes. **The deploy itself is unverified** — it cannot run without the federation setup above, so treat the first push to `develop` after merging as the real test.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ4pYbQ8bgT9XYhCAB8WdZ
