### PR TITLE
feat(practice): add practice setup, flashcards and dictation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ artefacts and how to replay them.
   senses, example sentences, usage notes and context sections.
 - **Create / edit / delete** — a quick form and a detailed form, plus a JSON
   import path for assistant-generated entries.
-
-- **Practice** — a setup screen (tag and JLPT chips, a 苦手な語のみ toggle, a live
-  match count) that starts either a **flashcard** run or a **dictation** run. Flashcards
-  flip to the meaning before offering もう一度 / わかった; dictation speaks the word
-  through the Web Speech API and marks what you type. A finished session is recorded
-  once, and a word answered wrong turns up under 苦手な語のみ next time.
+- **Practice** — a setup screen (単語集, tag and JLPT chips, 品詞 and 語種, a learning-date
+  range with 直近1週間 / 1ヶ月 / 1年 shortcuts, a 苦手な語のみ toggle and a live match
+  count) that starts either a **flashcard** run or a **dictation** run. Flashcards flip
+  to the meaning before offering もう一度 / わかった, and can be driven entirely from
+  the keyboard — <kbd>Space</kbd> turns the card, <kbd>←</kbd> / <kbd>→</kbd> answer it,
+  <kbd>Esc</kbd> asks to leave. Dictation speaks the word through the Web Speech API and
+  marks what you type. A finished session is recorded once, and a word answered wrong
+  turns up under 苦手な語のみ next time.
 
 ### Planned
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,15 @@ artefacts and how to replay them.
 - **Create / edit / delete** — a quick form and a detailed form, plus a JSON
   import path for assistant-generated entries.
 
+- **Practice** — a setup screen (tag and JLPT chips, a 苦手な語のみ toggle, a live
+  match count) that starts either a **flashcard** run or a **dictation** run. Flashcards
+  flip to the meaning before offering もう一度 / わかった; dictation speaks the word
+  through the Web Speech API and marks what you type. A finished session is recorded
+  once, and a word answered wrong turns up under 苦手な語のみ next time.
+
 ### Planned
 
-Flashcards, dictation, word sets and practice history are placeholder routes.
+Word sets and practice history are placeholder routes.
 
 ## Stack
 

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import { NavLink, Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/lib/auth';
 import { EntriesProvider } from '@/lib/entries';
+import { ProgressProvider } from '@/lib/progress';
 import { useTheme } from '@/lib/theme';
 import { useClickOutside } from '@/lib/useClickOutside';
 import { EntryFormModal } from './entry-form/EntryFormModal';
@@ -39,69 +40,71 @@ export function AppLayout() {
 
   return (
     <EntriesProvider uid={user.uid}>
-      <div className="min-h-dvh bg-bg text-ink">
-        <header className="sticky top-0 z-30 border-b border-line bg-card/85 backdrop-blur">
-          <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
-            <NavLink
-              to="/"
-              className="mr-1 flex items-center gap-1.5 font-display text-lg font-bold text-accent"
-            >
-              <LogoMark className="h-7 w-7" />
-              語彙庭
-            </NavLink>
-
-            {/* Desktop: the full pill row. */}
-            <nav className="hidden flex-1 items-center gap-1 nav:flex">
-              {NAV.map((item) => (
-                <NavLink key={item.to} to={item.to} end={item.end} className={pillClass}>
-                  {item.label}
-                </NavLink>
-              ))}
-            </nav>
-
-            <div className="flex flex-1 items-center justify-end gap-2 nav:flex-none">
-              <button
-                type="button"
-                onClick={() => setMenuOpen((open) => !open)}
-                aria-label="メニュー"
-                aria-expanded={menuOpen}
-                className="grid h-11 w-11 place-items-center rounded-pill text-xl hover:bg-bg-alt nav:hidden"
+      <ProgressProvider uid={user.uid}>
+        <div className="min-h-dvh bg-bg text-ink">
+          <header className="sticky top-0 z-30 border-b border-line bg-card/85 backdrop-blur">
+            <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
+              <NavLink
+                to="/"
+                className="mr-1 flex items-center gap-1.5 font-display text-lg font-bold text-accent"
               >
-                {menuOpen ? '✕' : '☰'}
-              </button>
-              <button
-                type="button"
-                onClick={() => setAdding(true)}
-                className="hidden rounded-pill bg-accent px-4 py-2 text-sm font-semibold text-on-accent nav:block"
-              >
-                ＋追加
-              </button>
-              <AvatarMenu />
+                <LogoMark className="h-7 w-7" />
+                語彙庭
+              </NavLink>
+
+              {/* Desktop: the full pill row. */}
+              <nav className="hidden flex-1 items-center gap-1 nav:flex">
+                {NAV.map((item) => (
+                  <NavLink key={item.to} to={item.to} end={item.end} className={pillClass}>
+                    {item.label}
+                  </NavLink>
+                ))}
+              </nav>
+
+              <div className="flex flex-1 items-center justify-end gap-2 nav:flex-none">
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen((open) => !open)}
+                  aria-label="メニュー"
+                  aria-expanded={menuOpen}
+                  className="grid h-11 w-11 place-items-center rounded-pill text-xl hover:bg-bg-alt nav:hidden"
+                >
+                  {menuOpen ? '✕' : '☰'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAdding(true)}
+                  className="hidden rounded-pill bg-accent px-4 py-2 text-sm font-semibold text-on-accent nav:block"
+                >
+                  ＋追加
+                </button>
+                <AvatarMenu />
+              </div>
             </div>
-          </div>
 
-          {menuOpen && <MobileNav onNavigate={() => setMenuOpen(false)} />}
-        </header>
+            {menuOpen && <MobileNav onNavigate={() => setMenuOpen(false)} />}
+          </header>
 
-        <main className="mx-auto max-w-5xl px-4 py-6 pb-28 nav:pb-10">
-          <Outlet />
-        </main>
+          <main className="mx-auto max-w-5xl px-4 py-6 pb-28 nav:pb-10">
+            <Outlet />
+          </main>
 
-        <button
-          type="button"
-          onClick={() => setAdding(true)}
-          aria-label="単語を追加"
-          className="fixed right-5 bottom-5 z-20 grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
-        >
-          ＋
-        </button>
+          <button
+            type="button"
+            onClick={() => setAdding(true)}
+            aria-label="単語を追加"
+            className="fixed right-5 bottom-5 z-20 grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
+          >
+            ＋
+          </button>
 
-        <EntryFormModal
-          open={adding}
-          onClose={() => setAdding(false)}
-          onSaved={(id) => void navigate(`/vocabulary/${id}`)}
-        />
-      </div>
+          <EntryFormModal
+            open={adding}
+            onClose={() => setAdding(false)}
+            onSaved={(id) => void navigate(`/vocabulary/${id}`)}
+          />
+        </div>
+      </ProgressProvider>
     </EntriesProvider>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import { EntriesProvider } from '@/lib/entries';
 import { ProgressProvider } from '@/lib/progress';
 import { useTheme } from '@/lib/theme';
 import { useClickOutside } from '@/lib/useClickOutside';
+import { WordSetsProvider } from '@/lib/wordSets';
 import { EntryFormModal } from './entry-form/EntryFormModal';
 import { LogoMark } from './Logo';
 
@@ -41,69 +42,71 @@ export function AppLayout() {
   return (
     <EntriesProvider uid={user.uid}>
       <ProgressProvider uid={user.uid}>
-        <div className="min-h-dvh bg-bg text-ink">
-          <header className="sticky top-0 z-30 border-b border-line bg-card/85 backdrop-blur">
-            <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
-              <NavLink
-                to="/"
-                className="mr-1 flex items-center gap-1.5 font-display text-lg font-bold text-accent"
-              >
-                <LogoMark className="h-7 w-7" />
-                語彙庭
-              </NavLink>
-
-              {/* Desktop: the full pill row. */}
-              <nav className="hidden flex-1 items-center gap-1 nav:flex">
-                {NAV.map((item) => (
-                  <NavLink key={item.to} to={item.to} end={item.end} className={pillClass}>
-                    {item.label}
-                  </NavLink>
-                ))}
-              </nav>
-
-              <div className="flex flex-1 items-center justify-end gap-2 nav:flex-none">
-                <button
-                  type="button"
-                  onClick={() => setMenuOpen((open) => !open)}
-                  aria-label="メニュー"
-                  aria-expanded={menuOpen}
-                  className="grid h-11 w-11 place-items-center rounded-pill text-xl hover:bg-bg-alt nav:hidden"
+        <WordSetsProvider uid={user.uid}>
+          <div className="min-h-dvh bg-bg text-ink">
+            <header className="sticky top-0 z-30 border-b border-line bg-card/85 backdrop-blur">
+              <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
+                <NavLink
+                  to="/"
+                  className="mr-1 flex items-center gap-1.5 font-display text-lg font-bold text-accent"
                 >
-                  {menuOpen ? '✕' : '☰'}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setAdding(true)}
-                  className="hidden rounded-pill bg-accent px-4 py-2 text-sm font-semibold text-on-accent nav:block"
-                >
-                  ＋追加
-                </button>
-                <AvatarMenu />
+                  <LogoMark className="h-7 w-7" />
+                  語彙庭
+                </NavLink>
+
+                {/* Desktop: the full pill row. */}
+                <nav className="hidden flex-1 items-center gap-1 nav:flex">
+                  {NAV.map((item) => (
+                    <NavLink key={item.to} to={item.to} end={item.end} className={pillClass}>
+                      {item.label}
+                    </NavLink>
+                  ))}
+                </nav>
+
+                <div className="flex flex-1 items-center justify-end gap-2 nav:flex-none">
+                  <button
+                    type="button"
+                    onClick={() => setMenuOpen((open) => !open)}
+                    aria-label="メニュー"
+                    aria-expanded={menuOpen}
+                    className="grid h-11 w-11 place-items-center rounded-pill text-xl hover:bg-bg-alt nav:hidden"
+                  >
+                    {menuOpen ? '✕' : '☰'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setAdding(true)}
+                    className="hidden rounded-pill bg-accent px-4 py-2 text-sm font-semibold text-on-accent nav:block"
+                  >
+                    ＋追加
+                  </button>
+                  <AvatarMenu />
+                </div>
               </div>
-            </div>
 
-            {menuOpen && <MobileNav onNavigate={() => setMenuOpen(false)} />}
-          </header>
+              {menuOpen && <MobileNav onNavigate={() => setMenuOpen(false)} />}
+            </header>
 
-          <main className="mx-auto max-w-5xl px-4 py-6 pb-28 nav:pb-10">
-            <Outlet />
-          </main>
+            <main className="mx-auto max-w-5xl px-4 py-6 pb-28 nav:pb-10">
+              <Outlet />
+            </main>
 
-          <button
-            type="button"
-            onClick={() => setAdding(true)}
-            aria-label="単語を追加"
-            className="fixed right-5 bottom-5 z-20 grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
-          >
-            ＋
-          </button>
+            <button
+              type="button"
+              onClick={() => setAdding(true)}
+              aria-label="単語を追加"
+              className="fixed right-5 bottom-5 z-20 grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
+            >
+              ＋
+            </button>
 
-          <EntryFormModal
-            open={adding}
-            onClose={() => setAdding(false)}
-            onSaved={(id) => void navigate(`/vocabulary/${id}`)}
-          />
-        </div>
+            <EntryFormModal
+              open={adding}
+              onClose={() => setAdding(false)}
+              onSaved={(id) => void navigate(`/vocabulary/${id}`)}
+            />
+          </div>
+        </WordSetsProvider>
       </ProgressProvider>
     </EntriesProvider>
   );

--- a/src/components/practice/DictationSession.tsx
+++ b/src/components/practice/DictationSession.tsx
@@ -41,26 +41,30 @@ export function DictationSession({
   const { status, speak } = useJapaneseSpeech();
 
   /**
-   * The card does **not** speak on arrival, and that is not an omission.
+   * Speak on arrival, so the drill starts by playing rather than by asking to.
    *
-   * It used to. Chrome has refused `speechSynthesis.speak()` outside a user
-   * gesture since M71, and an effect is one render removed from the click that
-   * caused it — so that call was always refused. Worse than refused: it left
-   * the engine reporting `speaking: true` with nothing playing, permanently,
-   * and `cancel()` could not clear it. Every later press of 単語を聞く then
-   * went into a queue that was already wedged, which is why the button was
-   * silent on a machine where `say -v Kyoko` worked perfectly.
+   * This was removed once, on the theory that Chrome's user-activation rule
+   * made it unworkable, and putting it back is deliberate: Safari on the same
+   * machine autoplays it correctly, so the feature is sound and Chrome is the
+   * thing to work around — not the reason to drop it. The workaround lives in
+   * `lib/speech.ts`, which clears the queue Chrome inherits from the previous
+   * page before this one speaks.
    *
-   * Measured, not deduced: on the affected page `speechSynthesis.speaking` read
-   * `true` before any test ran; on another site in the same browser it read
-   * `false` and spoke.
-   *
-   * Autoplay is not worth a wedged engine. The button is one press and it
-   * always works, because it is a gesture.
+   * If it is refused anyway the utterance reports `not-allowed`, the hook shows
+   * a message, and 単語を聞く still works because a click is a gesture.
    */
+  const autoSpokenFor = useRef<string | null>(null);
   useEffect(() => {
+    // Keyed on the card, not on the effect running. `status` is part of the
+    // dependencies because arrival can precede the voice list, and it also
+    // flips back to `ready` whenever the learner presses the button — without
+    // this guard that press would be answered by two overlapping utterances.
+    if (status === 'ready' && autoSpokenFor.current !== entry.id) {
+      autoSpokenFor.current = entry.id;
+      speak(spokenForm(entry));
+    }
     inputRef.current?.focus();
-  }, [entry]);
+  }, [entry, speak, status]);
 
   const check = () => {
     if (result !== null) return;
@@ -75,19 +79,27 @@ export function DictationSession({
   };
 
   /**
-   * Enter means 答え合わせ, except while the IME owns it.
+   * Enter means 答え合わせ, except while the IME owns it, and except on an
+   * empty field.
    *
    * Pressing Enter to accept a conversion candidate is the single most common
    * keystroke in typing Japanese. Treating it as a submission marks the answer
    * against whatever was on screen mid-conversion — usually the kana — and the
    * learner never gets to type the word they were converting.
+   *
+   * On an empty field it replays the word instead. Enter there can only mean
+   * "I did not catch that" — marking a blank answer wrong is a guaranteed
+   * failure the learner never chose, and replaying is what they were reaching
+   * for the mouse to do. It also keeps the whole drill on the keyboard, and the
+   * keypress is a gesture, so this path can speak even where autoplay cannot.
    */
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Enter') return;
     if (composing.current || event.nativeEvent.isComposing) return;
     event.preventDefault();
-    if (result === null) check();
-    else next();
+    if (result !== null) next();
+    else if (typed.trim() === '') speak(spokenForm(entry));
+    else check();
   };
 
   const speakable = status === 'ready' || status === 'loading' || status === 'failed';

--- a/src/components/practice/DictationSession.tsx
+++ b/src/components/practice/DictationSession.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Ruby } from '@/components/Ruby';
 import type { Entry } from '@/domain/entry';
 import { isCorrectAnswer, spokenForm } from '@/lib/dictation';
-import { canSpeak, speak } from '@/lib/speech';
+import { useJapaneseSpeech } from '@/lib/speech';
 import { SessionHeader } from './SessionHeader';
 
 /**
@@ -38,14 +38,21 @@ export function DictationSession({
    */
   const composing = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { status, speak } = useJapaneseSpeech();
 
-  // Speak on arrival, so the drill starts by playing rather than by asking to
-  // play. The first utterance follows the 開始する click in the same document,
-  // which is the gesture autoplay policies want.
+  /**
+   * Speak on arrival, so the drill starts by playing rather than by asking to.
+   *
+   * **Failure 4: no user activation.** Chrome has refused `speak()` outside a
+   * gesture since M71, and this call is one render removed from the click that
+   * caused it. When it is refused the utterance reports `not-allowed`, which
+   * the hook turns into a visible message — the button below is the path that
+   * always works, and silence is no longer the only symptom.
+   */
   useEffect(() => {
-    speak(spokenForm(entry));
+    if (status === 'ready') speak(spokenForm(entry));
     inputRef.current?.focus();
-  }, [entry]);
+  }, [entry, speak, status]);
 
   const check = () => {
     if (result !== null) return;
@@ -75,7 +82,7 @@ export function DictationSession({
     else next();
   };
 
-  const speakable = canSpeak();
+  const speakable = status === 'ready' || status === 'loading' || status === 'failed';
 
   return (
     <section className="mx-auto max-w-2xl space-y-4">
@@ -91,8 +98,19 @@ export function DictationSession({
           >
             🔊 単語を聞く
           </button>
-          {!speakable && (
+          {status === 'unsupported' && (
             <p className="mt-2 text-xs text-danger">このブラウザは音声読み上げに対応していません</p>
+          )}
+          {status === 'no-japanese-voice' && (
+            <p className="mt-2 text-xs text-danger">
+              日本語の音声が見つかりません。システム設定 → アクセシビリティ → 読み上げコンテンツ →
+              システムの声 から日本語の声を追加してください。
+            </p>
+          )}
+          {status === 'failed' && (
+            <p className="mt-2 text-xs text-danger">
+              音声を再生できませんでした。もう一度お試しください。
+            </p>
           )}
         </div>
 

--- a/src/components/practice/DictationSession.tsx
+++ b/src/components/practice/DictationSession.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useRef, useState } from 'react';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/domain/entry';
+import { isCorrectAnswer, spokenForm } from '@/lib/dictation';
+import { canSpeak, speak } from '@/lib/speech';
+import { SessionHeader } from './SessionHeader';
+
+/**
+ * Hear the word, type it, then see whether it matched.
+ *
+ * Two things here are about the IME rather than about dictation, and both are
+ * invisible until a Japanese keyboard is in front of it. See `handleKeyDown`
+ * for the Enter key, and `lib/dictation.ts` for what counts as a match.
+ */
+export function DictationSession({
+  entry,
+  index,
+  total,
+  onAnswer,
+  onQuit,
+}: {
+  entry: Entry;
+  index: number;
+  total: number;
+  onAnswer: (correct: boolean) => void;
+  onQuit: () => void;
+}) {
+  const [typed, setTyped] = useState('');
+  /** Null until 答え合わせ; the answer afterwards. */
+  const [result, setResult] = useState<boolean | null>(null);
+
+  /**
+   * True while the IME is mid-conversion.
+   *
+   * `KeyboardEvent.isComposing` alone is not enough: it has been unreliable in
+   * WebKit, and this is the one flag standing between "confirmed the candidate"
+   * and "submitted 「かんじ」 as the answer to 漢字".
+   */
+  const composing = useRef(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Speak on arrival, so the drill starts by playing rather than by asking to
+  // play. The first utterance follows the 開始する click in the same document,
+  // which is the gesture autoplay policies want.
+  useEffect(() => {
+    speak(spokenForm(entry));
+    inputRef.current?.focus();
+  }, [entry]);
+
+  const check = () => {
+    if (result !== null) return;
+    setResult(isCorrectAnswer(typed, entry));
+  };
+
+  const next = () => {
+    if (result === null) return;
+    setTyped('');
+    setResult(null);
+    onAnswer(result);
+  };
+
+  /**
+   * Enter means 答え合わせ, except while the IME owns it.
+   *
+   * Pressing Enter to accept a conversion candidate is the single most common
+   * keystroke in typing Japanese. Treating it as a submission marks the answer
+   * against whatever was on screen mid-conversion — usually the kana — and the
+   * learner never gets to type the word they were converting.
+   */
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Enter') return;
+    if (composing.current || event.nativeEvent.isComposing) return;
+    event.preventDefault();
+    if (result === null) check();
+    else next();
+  };
+
+  const speakable = canSpeak();
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-4">
+      <SessionHeader title="書き取り練習" index={index} total={total} onQuit={onQuit} />
+
+      <div className="space-y-5 rounded-card bg-card p-6 shadow-panel">
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={() => speak(spokenForm(entry))}
+            disabled={!speakable}
+            className="min-h-12 rounded-pill bg-accent px-6 text-sm font-semibold text-on-accent disabled:opacity-60"
+          >
+            🔊 単語を聞く
+          </button>
+          {!speakable && (
+            <p className="mt-2 text-xs text-danger">このブラウザは音声読み上げに対応していません</p>
+          )}
+        </div>
+
+        <label className="block space-y-1">
+          <span className="text-[11px] text-muted">聞こえた語</span>
+          <input
+            ref={inputRef}
+            value={typed}
+            readOnly={result !== null}
+            onChange={(event) => setTyped(event.target.value)}
+            onCompositionStart={() => (composing.current = true)}
+            onCompositionEnd={() => (composing.current = false)}
+            onKeyDown={handleKeyDown}
+            // The IME needs to be on for this field; `lang` is the only hint a
+            // browser takes for that.
+            lang="ja"
+            autoComplete="off"
+            className="min-h-12 w-full rounded-panel border border-line bg-bg px-3 text-lg text-ink"
+          />
+        </label>
+
+        {result !== null && (
+          <div
+            className={`space-y-2 rounded-panel p-4 ${result ? 'bg-accent-soft' : 'bg-danger-soft'}`}
+          >
+            <p className={`text-sm font-semibold ${result ? 'text-accent' : 'text-danger'}`}>
+              {result ? '✅ 正解' : '❌ 不正解'}
+            </p>
+            <Ruby
+              headword={entry.headword}
+              reading={entry.reading}
+              className="has-ruby block font-display text-2xl font-bold"
+            />
+            <p className="prose-cjk text-sm">{entry.senses[0]?.description || entry.definition}</p>
+          </div>
+        )}
+      </div>
+
+      {result === null ? (
+        <button
+          type="button"
+          onClick={check}
+          className="min-h-12 w-full rounded-pill bg-accent text-sm font-semibold text-on-accent"
+        >
+          答え合わせ
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={next}
+          className="min-h-12 w-full rounded-pill bg-accent text-sm font-semibold text-on-accent"
+        >
+          次へ
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/components/practice/DictationSession.tsx
+++ b/src/components/practice/DictationSession.tsx
@@ -41,18 +41,26 @@ export function DictationSession({
   const { status, speak } = useJapaneseSpeech();
 
   /**
-   * Speak on arrival, so the drill starts by playing rather than by asking to.
+   * The card does **not** speak on arrival, and that is not an omission.
    *
-   * **Failure 4: no user activation.** Chrome has refused `speak()` outside a
-   * gesture since M71, and this call is one render removed from the click that
-   * caused it. When it is refused the utterance reports `not-allowed`, which
-   * the hook turns into a visible message — the button below is the path that
-   * always works, and silence is no longer the only symptom.
+   * It used to. Chrome has refused `speechSynthesis.speak()` outside a user
+   * gesture since M71, and an effect is one render removed from the click that
+   * caused it — so that call was always refused. Worse than refused: it left
+   * the engine reporting `speaking: true` with nothing playing, permanently,
+   * and `cancel()` could not clear it. Every later press of 単語を聞く then
+   * went into a queue that was already wedged, which is why the button was
+   * silent on a machine where `say -v Kyoko` worked perfectly.
+   *
+   * Measured, not deduced: on the affected page `speechSynthesis.speaking` read
+   * `true` before any test ran; on another site in the same browser it read
+   * `false` and spoke.
+   *
+   * Autoplay is not worth a wedged engine. The button is one press and it
+   * always works, because it is a gesture.
    */
   useEffect(() => {
-    if (status === 'ready') speak(spokenForm(entry));
     inputRef.current?.focus();
-  }, [entry, speak, status]);
+  }, [entry]);
 
   const check = () => {
     if (result !== null) return;

--- a/src/components/practice/FlashcardSession.tsx
+++ b/src/components/practice/FlashcardSession.tsx
@@ -3,6 +3,38 @@ import { Ruby } from '@/components/Ruby';
 import type { Entry } from '@/domain/entry';
 import { SessionHeader } from './SessionHeader';
 
+const isEditable = (node: unknown): boolean => {
+  if (!(node instanceof HTMLElement)) return false;
+  return (
+    node.isContentEditable ||
+    node instanceof HTMLInputElement ||
+    node instanceof HTMLTextAreaElement ||
+    node instanceof HTMLSelectElement
+  );
+};
+
+/**
+ * Whether the session still owns the keyboard.
+ *
+ * It does not while anything is layered over it, and the session cannot be
+ * told about all of them: `AppLayout` renders ＋追加 and the mobile ＋ button
+ * on **every** route, `/practice/:mode` included, so the add-word sheet can be
+ * open over a running card without this component ever hearing about it. A
+ * document-level listener then sees every keystroke typed into that form —
+ * `→` scores a card the learner never saw, `Space` is swallowed by
+ * `preventDefault` so it cannot be typed, and `Escape` closes the sheet *and*
+ * asks to quit the drill. The first of those writes wrong data into 苦手な語.
+ *
+ * Two questions rather than a register of overlays, because a register is what
+ * lets the next overlay forget: is focus somewhere text goes, and is a modal
+ * dialog on screen. `Modal` marks itself `role="dialog"`, which is a semantic
+ * contract rather than an implementation detail.
+ */
+const ownsKeyboard = (target: unknown): boolean =>
+  !isEditable(target) &&
+  !isEditable(document.activeElement) &&
+  document.querySelector('[role="dialog"]') === null;
+
 /** The hint printed on a button. Not shown for 中断, which has no shortcut. */
 function Key({ children }: { children: string }) {
   return (
@@ -55,12 +87,19 @@ export function FlashcardSession({
    * The arrows are ignored before the flip, exactly as the buttons are absent
    * before it. A shortcut that could answer a card whose meaning is still
    * hidden would quietly reintroduce the thing the flip gate exists to stop.
+   *
+   * Space, by contrast, turns the card *both* ways — the hint sits on 裏を見る
+   * because that is the press that matters, but pressing it again hides the
+   * meaning rather than doing nothing. That asymmetry with the arrows is
+   * deliberate: re-hiding is harmless and occasionally wanted, whereas
+   * answering early is not recoverable.
    */
   useEffect(() => {
     if (!keyboard) return;
     const onKeyDown = (event: KeyboardEvent) => {
       // A held key repeats, and a repeated answer would tear through the queue.
       if (event.repeat || event.ctrlKey || event.metaKey || event.altKey) return;
+      if (!ownsKeyboard(event.target)) return;
 
       if (event.key === 'Escape') {
         onQuit();

--- a/src/components/practice/FlashcardSession.tsx
+++ b/src/components/practice/FlashcardSession.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/domain/entry';
+import { SessionHeader } from './SessionHeader';
+
+/**
+ * One card at a time: the word, then its meaning, then a self-assessment.
+ *
+ * The two answer buttons only appear after the flip, and that is the whole
+ * mechanic — 「わかった」 recorded before the meaning is visible measures
+ * confidence rather than recall, and 苦手な語 is built out of these answers.
+ */
+export function FlashcardSession({
+  entry,
+  index,
+  total,
+  onAnswer,
+  onQuit,
+}: {
+  entry: Entry;
+  index: number;
+  total: number;
+  onAnswer: (correct: boolean) => void;
+  onQuit: () => void;
+}) {
+  const [flipped, setFlipped] = useState(false);
+
+  const answer = (correct: boolean) => {
+    setFlipped(false);
+    onAnswer(correct);
+  };
+
+  const meanings = entry.senses.map((sense) => sense.description).filter(Boolean);
+  const example = entry.senses.find((sense) => sense.example)?.example ?? entry.examples[0]?.ja;
+  const exampleTranslation =
+    entry.senses.find((sense) => sense.example)?.translation ?? entry.examples[0]?.translation;
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-4">
+      <SessionHeader title="フラッシュカード" index={index} total={total} onQuit={onQuit} />
+
+      <div className="min-h-64 space-y-5 rounded-card bg-card p-6 text-center shadow-panel">
+        <Ruby
+          headword={entry.headword}
+          reading={flipped ? entry.reading : ''}
+          className="has-ruby block font-display text-4xl font-bold"
+        />
+
+        {flipped ? (
+          <div className="space-y-4 text-left">
+            <ul className="prose-cjk space-y-1 text-sm">
+              {(meanings.length ? meanings : [entry.definition]).map((meaning, position) => (
+                <li key={position} className="flex gap-2">
+                  <span className="text-muted">・</span>
+                  <span>{meaning}</span>
+                </li>
+              ))}
+            </ul>
+            {entry.definitionSub && <p className="text-sm text-muted">{entry.definitionSub}</p>}
+            {example && (
+              <div className="rounded-panel bg-bg-alt p-3">
+                <p className="prose-cjk text-sm">{example}</p>
+                {exampleTranslation && (
+                  <p className="mt-1 text-xs text-muted">{exampleTranslation}</p>
+                )}
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-sm text-muted">意味を思い出してから裏を見てください</p>
+        )}
+      </div>
+
+      {flipped ? (
+        <div className="grid grid-cols-2 gap-3">
+          <button
+            type="button"
+            onClick={() => answer(false)}
+            className="min-h-12 rounded-pill bg-danger-soft text-sm font-semibold text-danger"
+          >
+            もう一度
+          </button>
+          <button
+            type="button"
+            onClick={() => answer(true)}
+            className="min-h-12 rounded-pill bg-accent text-sm font-semibold text-on-accent"
+          >
+            わかった
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setFlipped(true)}
+          className="min-h-12 w-full rounded-pill bg-accent text-sm font-semibold text-on-accent"
+        >
+          裏を見る
+        </button>
+      )}
+    </section>
+  );
+}

--- a/src/components/practice/FlashcardSession.tsx
+++ b/src/components/practice/FlashcardSession.tsx
@@ -1,7 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Ruby } from '@/components/Ruby';
 import type { Entry } from '@/domain/entry';
 import { SessionHeader } from './SessionHeader';
+
+/** The hint printed on a button. Not shown for 中断, which has no shortcut. */
+function Key({ children }: { children: string }) {
+  return (
+    <kbd className="ml-2 rounded border border-current/25 px-1.5 py-0.5 text-[10px] font-normal opacity-70">
+      {children}
+    </kbd>
+  );
+}
 
 /**
  * One card at a time: the word, then its meaning, then a self-assessment.
@@ -14,12 +23,18 @@ export function FlashcardSession({
   entry,
   index,
   total,
+  keyboard = true,
   onAnswer,
   onQuit,
 }: {
   entry: Entry;
   index: number;
   total: number;
+  /**
+   * False while a dialog is over the card. Without it, the Escape that closes
+   * the quit confirmation is also the Escape that reopens it.
+   */
+  keyboard?: boolean;
   onAnswer: (correct: boolean) => void;
   onQuit: () => void;
 }) {
@@ -29,6 +44,45 @@ export function FlashcardSession({
     setFlipped(false);
     onAnswer(correct);
   };
+
+  /**
+   * Space turns the card, ← and → answer it, Escape leaves.
+   *
+   * Bound on the document rather than a focused element: there is nothing here
+   * worth making the learner tab to first, and a drill answered from the
+   * keyboard is the whole point of a flashcard.
+   *
+   * The arrows are ignored before the flip, exactly as the buttons are absent
+   * before it. A shortcut that could answer a card whose meaning is still
+   * hidden would quietly reintroduce the thing the flip gate exists to stop.
+   */
+  useEffect(() => {
+    if (!keyboard) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      // A held key repeats, and a repeated answer would tear through the queue.
+      if (event.repeat || event.ctrlKey || event.metaKey || event.altKey) return;
+
+      if (event.key === 'Escape') {
+        onQuit();
+        return;
+      }
+      if (event.key === ' ') {
+        // Space scrolls the page by default, which moves the card being read.
+        event.preventDefault();
+        setFlipped((current) => !current);
+        return;
+      }
+      if (!flipped) return;
+      if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+        setFlipped(false);
+        onAnswer(event.key === 'ArrowRight');
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [keyboard, flipped, onAnswer, onQuit]);
 
   const meanings = entry.senses.map((sense) => sense.description).filter(Boolean);
   const example = entry.senses.find((sense) => sense.example)?.example ?? entry.examples[0]?.ja;
@@ -79,6 +133,7 @@ export function FlashcardSession({
             className="min-h-12 rounded-pill bg-danger-soft text-sm font-semibold text-danger"
           >
             もう一度
+            <Key>←</Key>
           </button>
           <button
             type="button"
@@ -86,6 +141,7 @@ export function FlashcardSession({
             className="min-h-12 rounded-pill bg-accent text-sm font-semibold text-on-accent"
           >
             わかった
+            <Key>→</Key>
           </button>
         </div>
       ) : (
@@ -95,6 +151,7 @@ export function FlashcardSession({
           className="min-h-12 w-full rounded-pill bg-accent text-sm font-semibold text-on-accent"
         >
           裏を見る
+          <Key>Space</Key>
         </button>
       )}
     </section>

--- a/src/components/practice/PracticeSetup.tsx
+++ b/src/components/practice/PracticeSetup.tsx
@@ -1,0 +1,149 @@
+import { JLPT_LEVELS } from '@/domain/entry';
+import type { PracticeMode } from '@/domain/practice';
+import type { PracticeFilters } from '@/lib/practice';
+
+const MODE_TITLE: Record<PracticeMode, string> = {
+  flashcard: 'フラッシュカード',
+  dictation: '書き取り練習',
+};
+
+const MODE_NOTE: Record<PracticeMode, string> = {
+  flashcard: '見出し語を見て意味を思い出す練習です。',
+  dictation: '読み上げられた語を聞いて入力する練習です。',
+};
+
+function toggle(list: string[], value: string): string[] {
+  return list.includes(value) ? list.filter((item) => item !== value) : [...list, value];
+}
+
+function chipClass(active: boolean) {
+  return `rounded-pill px-3 py-1 text-xs font-medium transition ${
+    active ? 'bg-accent text-on-accent' : 'bg-bg-alt text-muted hover:text-ink'
+  }`;
+}
+
+/**
+ * The screen both practice modes open on.
+ *
+ * 単語集 chips are in the design and are absent here: `WordSetRepository` has
+ * no adapter yet, so there are no sets to show and the design says to hide the
+ * row when there are none. They belong with `/wordsets`, not ahead of it.
+ *
+ * `matchCount` is computed by the caller rather than here, because the same
+ * filtered list is what 開始する turns into the queue — recomputing it in two
+ * places is how a screen ends up promising a count it does not deliver.
+ */
+export function PracticeSetup({
+  mode,
+  filters,
+  allTags,
+  matchCount,
+  weakCount,
+  weakState,
+  onChange,
+  onStart,
+  onCancel,
+}: {
+  mode: PracticeMode;
+  filters: PracticeFilters;
+  allTags: string[];
+  matchCount: number;
+  weakCount: number;
+  /** 苦手のみ can only be honoured once the progress map has arrived. */
+  weakState: 'ready' | 'loading' | 'error';
+  onChange: (next: PracticeFilters) => void;
+  onStart: () => void;
+  onCancel: () => void;
+}) {
+  const set = <K extends keyof PracticeFilters>(key: K, value: PracticeFilters[K]) =>
+    onChange({ ...filters, [key]: value });
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-5 rounded-card bg-card p-6 shadow-panel">
+      <header>
+        <h1 className="font-display text-2xl font-bold">{MODE_TITLE[mode]}</h1>
+        <p className="mt-1 text-sm text-muted">{MODE_NOTE[mode]}</p>
+      </header>
+
+      {allTags.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted">タグ</p>
+          <div className="flex flex-wrap gap-1.5">
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                aria-pressed={filters.tags.includes(tag)}
+                onClick={() => set('tags', toggle(filters.tags, tag))}
+                className={chipClass(filters.tags.includes(tag))}
+              >
+                #{tag}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-1.5">
+        <p className="text-[11px] text-muted">JLPTレベル</p>
+        <div className="flex flex-wrap gap-1.5">
+          {JLPT_LEVELS.map((level) => (
+            <button
+              key={level}
+              type="button"
+              aria-pressed={filters.jlpt.includes(level)}
+              onClick={() => set('jlpt', toggle(filters.jlpt, level))}
+              className={chipClass(filters.jlpt.includes(level))}
+            >
+              {level}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <label className="flex min-h-11 items-center justify-between gap-3 rounded-panel bg-bg-alt px-4">
+        <span className="text-sm font-medium">
+          苦手な語のみ
+          <span className="ml-2 text-xs text-muted">
+            {weakState === 'ready'
+              ? `${weakCount} 語`
+              : weakState === 'loading'
+                ? '読み込み中…'
+                : '記録を読み込めませんでした'}
+          </span>
+        </span>
+        <input
+          type="checkbox"
+          checked={filters.weakOnly}
+          disabled={weakState !== 'ready'}
+          onChange={(event) => set('weakOnly', event.target.checked)}
+          className="h-5 w-5 accent-[var(--c-accent)]"
+        />
+      </label>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-line pt-4">
+        <p className="text-sm" role="status">
+          <strong className="tabular-nums">{matchCount}</strong> 件が対象
+          {matchCount === 0 && <span className="ml-2 text-danger">条件に合う語がありません</span>}
+        </p>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="min-h-10 rounded-pill px-4 text-sm text-muted hover:bg-bg-alt"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onStart}
+            disabled={matchCount === 0}
+            className="min-h-10 rounded-pill bg-accent px-5 text-sm font-semibold text-on-accent disabled:opacity-60"
+          >
+            開始する
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/practice/PracticeSetup.tsx
+++ b/src/components/practice/PracticeSetup.tsx
@@ -1,5 +1,7 @@
-import { JLPT_LEVELS } from '@/domain/entry';
+import { JLPT_LEVELS, POS, WORD_ORIGINS } from '@/domain/entry';
 import type { PracticeMode } from '@/domain/practice';
+import type { WordSet } from '@/domain/wordSet';
+import { activeQuickRange, QUICK_RANGES, quickRangeStart } from '@/lib/practice';
 import type { PracticeFilters } from '@/lib/practice';
 
 const MODE_TITLE: Record<PracticeMode, string> = {
@@ -22,12 +24,14 @@ function chipClass(active: boolean) {
   }`;
 }
 
+const selectClass = 'rounded-panel border-line bg-bg text-ink min-h-9 border px-2 text-xs w-full';
+
 /**
  * The screen both practice modes open on.
  *
- * 単語集 chips are in the design and are absent here: `WordSetRepository` has
- * no adapter yet, so there are no sets to show and the design says to hide the
- * row when there are none. They belong with `/wordsets`, not ahead of it.
+ * The 単語集 row hides itself when there are none, which is the design's rule
+ * and, until `/wordsets` exists, its permanent state in the running app: the
+ * read path is real but nothing writes a set yet.
  *
  * `matchCount` is computed by the caller rather than here, because the same
  * filtered list is what 開始する turns into the queue — recomputing it in two
@@ -37,6 +41,8 @@ export function PracticeSetup({
   mode,
   filters,
   allTags,
+  allSets,
+  now,
   matchCount,
   weakCount,
   weakState,
@@ -47,6 +53,10 @@ export function PracticeSetup({
   mode: PracticeMode;
   filters: PracticeFilters;
   allTags: string[];
+  /** Hidden entirely when empty, per the design — see the note above. */
+  allSets: WordSet[];
+  /** What 「直近1ヶ月」 is measured from. An argument so it can be frozen. */
+  now: Date;
   matchCount: number;
   weakCount: number;
   /** 苦手のみ can only be honoured once the progress map has arrived. */
@@ -55,8 +65,20 @@ export function PracticeSetup({
   onStart: () => void;
   onCancel: () => void;
 }) {
-  const set = <K extends keyof PracticeFilters>(key: K, value: PracticeFilters[K]) =>
+  const update = <K extends keyof PracticeFilters>(key: K, value: PracticeFilters[K]) =>
     onChange({ ...filters, [key]: value });
+
+  const active = activeQuickRange(filters, now);
+
+  // A quick range clears any end the learner had set: 「直近1ヶ月」 means
+  // "since that day", and leaving an old end in place would silently produce a
+  // window that is neither what was asked for nor visible as a mistake.
+  const applyQuickRange = (key: (typeof QUICK_RANGES)[number]['key']) =>
+    onChange(
+      active === key
+        ? { ...filters, from: '', to: '' }
+        : { ...filters, from: quickRangeStart(key, now), to: '' },
+    );
 
   return (
     <section className="mx-auto max-w-2xl space-y-5 rounded-card bg-card p-6 shadow-panel">
@@ -64,6 +86,26 @@ export function PracticeSetup({
         <h1 className="font-display text-2xl font-bold">{MODE_TITLE[mode]}</h1>
         <p className="mt-1 text-sm text-muted">{MODE_NOTE[mode]}</p>
       </header>
+
+      {allSets.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted">単語集</p>
+          <div className="flex flex-wrap gap-1.5">
+            {allSets.map((set) => (
+              <button
+                key={set.id}
+                type="button"
+                aria-pressed={filters.sets.includes(set.id)}
+                onClick={() => update('sets', toggle(filters.sets, set.id))}
+                className={chipClass(filters.sets.includes(set.id))}
+              >
+                {set.name}
+                <span className="ml-1.5 opacity-70">{set.entryIds.length}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {allTags.length > 0 && (
         <div className="space-y-1.5">
@@ -74,7 +116,7 @@ export function PracticeSetup({
                 key={tag}
                 type="button"
                 aria-pressed={filters.tags.includes(tag)}
-                onClick={() => set('tags', toggle(filters.tags, tag))}
+                onClick={() => update('tags', toggle(filters.tags, tag))}
                 className={chipClass(filters.tags.includes(tag))}
               >
                 #{tag}
@@ -92,12 +134,83 @@ export function PracticeSetup({
               key={level}
               type="button"
               aria-pressed={filters.jlpt.includes(level)}
-              onClick={() => set('jlpt', toggle(filters.jlpt, level))}
+              onClick={() => update('jlpt', toggle(filters.jlpt, level))}
               className={chipClass(filters.jlpt.includes(level))}
             >
               {level}
             </button>
           ))}
+        </div>
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="space-y-1">
+          <span className="text-[11px] text-muted">品詞</span>
+          <select
+            value={filters.pos}
+            onChange={(event) => update('pos', event.target.value)}
+            className={selectClass}
+          >
+            <option value="">すべて</option>
+            {POS.map((part) => (
+              <option key={part} value={part}>
+                {part}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="space-y-1">
+          <span className="text-[11px] text-muted">語種</span>
+          <select
+            value={filters.origin}
+            onChange={(event) => update('origin', event.target.value)}
+            className={selectClass}
+          >
+            <option value="">すべて</option>
+            {WORD_ORIGINS.map((origin) => (
+              <option key={origin} value={origin}>
+                {origin}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="space-y-1.5">
+        <p className="text-[11px] text-muted">学習日</p>
+        <div className="flex flex-wrap gap-1.5">
+          {QUICK_RANGES.map((range) => (
+            <button
+              key={range.key}
+              type="button"
+              aria-pressed={active === range.key}
+              onClick={() => applyQuickRange(range.key)}
+              className={chipClass(active === range.key)}
+            >
+              直近{range.label}
+            </button>
+          ))}
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2">
+          <label className="space-y-1">
+            <span className="text-[11px] text-muted">開始日</span>
+            <input
+              type="date"
+              value={filters.from}
+              onChange={(event) => update('from', event.target.value)}
+              className={selectClass}
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-[11px] text-muted">終了日</span>
+            <input
+              type="date"
+              value={filters.to}
+              onChange={(event) => update('to', event.target.value)}
+              className={selectClass}
+            />
+          </label>
         </div>
       </div>
 
@@ -116,7 +229,7 @@ export function PracticeSetup({
           type="checkbox"
           checked={filters.weakOnly}
           disabled={weakState !== 'ready'}
-          onChange={(event) => set('weakOnly', event.target.checked)}
+          onChange={(event) => update('weakOnly', event.target.checked)}
           className="h-5 w-5 accent-[var(--c-accent)]"
         />
       </label>

--- a/src/components/practice/SessionHeader.tsx
+++ b/src/components/practice/SessionHeader.tsx
@@ -1,0 +1,35 @@
+/** 「3 / 12」 plus the bar, shared by both modes so they stay in step visually. */
+export function SessionHeader({
+  title,
+  index,
+  total,
+  onQuit,
+}: {
+  title: string;
+  /** Zero-based position of the card on screen. */
+  index: number;
+  total: number;
+  onQuit: () => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-xs font-semibold tracking-wide text-muted">{title}</h1>
+        <div className="flex items-center gap-3">
+          <p className="text-xs text-muted tabular-nums" aria-label="進捗">
+            {index + 1} / {total}
+          </p>
+          <button type="button" onClick={onQuit} className="text-xs text-muted hover:text-ink">
+            中断
+          </button>
+        </div>
+      </div>
+      <div className="h-1 overflow-hidden rounded-full bg-bg-alt">
+        <span
+          className="block h-full rounded-full bg-accent transition-[width]"
+          style={{ width: `${((index + 1) / total) * 100}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/practice/SessionSummary.tsx
+++ b/src/components/practice/SessionSummary.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/domain/entry';
+
+/**
+ * End of a session: the score, what was missed, and the two ways back in.
+ *
+ * The missed list links each word to its detail page — the point of failing a
+ * card is to go and read the note, and making the learner search for it again
+ * is where a drill stops being a study tool.
+ */
+export function SessionSummary({
+  total,
+  correct,
+  missed,
+  saving,
+  saveError,
+  onRestart,
+  onRetryMissed,
+}: {
+  total: number;
+  correct: number;
+  missed: Entry[];
+  saving: boolean;
+  saveError: string | null;
+  onRestart: () => void;
+  onRetryMissed: () => void;
+}) {
+  return (
+    <section className="mx-auto max-w-2xl space-y-5 rounded-card bg-card p-6 shadow-panel">
+      <header className="text-center">
+        <h1 className="text-xs font-semibold tracking-wide text-muted">結果</h1>
+        <p className="mt-2 font-display text-4xl font-bold tabular-nums">
+          {correct} <span className="text-muted">/ {total}</span>
+        </p>
+        {saving && <p className="mt-1 text-xs text-muted">記録中…</p>}
+        {saveError && <p className="mt-1 text-xs text-danger">{saveError}</p>}
+      </header>
+
+      {missed.length > 0 && (
+        <div className="space-y-1.5">
+          <p className="text-[11px] text-muted">間違えた語</p>
+          <ul className="divide-y divide-line">
+            {missed.map((entry) => (
+              <li key={entry.id}>
+                <Link
+                  to={`/vocabulary/${entry.id}`}
+                  className="flex items-baseline justify-between gap-3 py-2.5"
+                >
+                  <Ruby
+                    headword={entry.headword}
+                    reading={entry.reading}
+                    className="has-ruby font-display font-bold"
+                  />
+                  <span className="line-clamp-1 text-xs text-muted">
+                    {entry.senses[0]?.description || entry.definition}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-2 border-t border-line pt-4">
+        <button
+          type="button"
+          onClick={onRestart}
+          className="min-h-11 flex-1 rounded-pill bg-accent px-4 text-sm font-semibold text-on-accent"
+        >
+          もう一度
+        </button>
+        {missed.length > 0 && (
+          <button
+            type="button"
+            onClick={onRetryMissed}
+            className="min-h-11 flex-1 rounded-pill bg-accent-soft px-4 text-sm font-semibold text-accent"
+          >
+            間違えた語だけ
+          </button>
+        )}
+        <Link
+          to="/"
+          className="grid min-h-11 flex-1 place-items-center rounded-pill px-4 text-sm text-muted hover:bg-bg-alt"
+        >
+          ダッシュボードに戻る
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -17,7 +17,7 @@
  */
 
 import type { Entry, EntryDraft, JlptLevel, Pos } from './entry';
-import type { EntryProgress, PracticeSession } from './practice';
+import type { EntryProgress, PracticeSession, PracticeSessionDraft } from './practice';
 import type { PublicEntry, PublicSet } from './publication';
 import type { UserProfile, UserProfileDraft } from './user';
 import type { WordSet, WordSetDraft } from './wordSet';
@@ -49,10 +49,34 @@ export interface WordSetRepository {
   remove(id: string): Promise<void>;
 }
 
+/**
+ * Practice state, and the one port whose cost model is part of its contract.
+ *
+ * `listAll` returns every entry's progress and `recordSession` takes only the
+ * rows a session touched, because **the whole map is expected to be one
+ * document**. Firestore bills per document, not per round trip, so a
+ * `writeBatch` of fifty per-entry documents is still fifty writes: batching
+ * saves latency and atomicity, not quota. A 50-card session therefore costs two
+ * writes here — the progress map and the session record — instead of 51, and
+ * loading the 苦手な語 count costs one read instead of one per word.
+ *
+ * What that trades away is a per-entry query, which nothing wants: the caller
+ * already holds every entry in memory. And the map has a ceiling — Firestore
+ * caps a document at 1 MiB, roughly 15,000 entries at this shape. That is far
+ * beyond the point at which `EntriesProvider` loading the whole notebook has
+ * already had to change.
+ *
+ * `data-model-redesign.md` specifies `users/{uid}/entryProgress/{entryId}`.
+ * This deviates from it deliberately; the doc records the change.
+ */
 export interface ProgressRepository {
   listAll(): Promise<EntryProgress[]>;
-  /** One write for a whole session, never one per card. */
-  recordSession(session: PracticeSession, progress: EntryProgress[]): Promise<void>;
+  /**
+   * Writes the session and merges `progress` into the map, in that one call.
+   * Pass only the entries the session answered — anything omitted is left as
+   * it was, so a session on another device is not clobbered.
+   */
+  recordSession(session: PracticeSessionDraft, progress: EntryProgress[]): Promise<string>;
   listSessions(q: PageQuery): Promise<Page<PracticeSession>>;
 }
 

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -1,6 +1,7 @@
 import type { IsoDateTime } from './common';
 
-export type PracticeMode = 'flashcard' | 'dictation';
+export const PRACTICE_MODES = ['flashcard', 'dictation'] as const;
+export type PracticeMode = (typeof PRACTICE_MODES)[number];
 
 /** A completed practice run — the source for 履歴 and the dashboard panel. */
 export interface PracticeSession {
@@ -12,19 +13,36 @@ export interface PracticeSession {
   correct: number;
   /** Entry ids answered wrong, for the session summary and quick re-practice. */
   missed: string[];
+  /** When the learner pressed 開始する — necessarily their own clock. */
   startedAt: IsoDateTime;
+  /** Set by the write path from the server clock, never by the device. */
   finishedAt: IsoDateTime;
 }
 
 /**
- * Per-entry practice state, keyed by entry id within the owner's subcollection.
+ * Fields the caller may send when recording a session.
  *
- * Kept out of Entry so answering a card rewrites a small document instead of
- * the whole note, and so practice history survives edits to the note content.
+ * The id is assigned by the write path, the same way `EntryDraft` omits it: a
+ * caller that invented one would either collide or have to know how the
+ * datasource generates ids.
  *
- * Writing these per card would cost one write per answer — a 50-card session at
- * two sessions a day reaches the 20,000/day free write quota at around 200
- * users. Batch the whole session at the end instead.
+ * `finishedAt` is omitted for a different reason. 履歴 is ordered and paged by
+ * it, and a cursor is only sound over a value one clock produced — a device an
+ * hour fast would file its sessions above everything and repeat or skip rows at
+ * every page boundary. `startedAt` stays a device value because that is what it
+ * honestly is: the session had already begun before any write happened.
+ */
+export type PracticeSessionDraft = Omit<PracticeSession, 'id' | 'finishedAt'>;
+
+/**
+ * Per-entry practice state.
+ *
+ * Kept out of Entry so answering a card rewrites a small record instead of the
+ * whole note, and so practice history survives edits to the note content.
+ *
+ * **All of these live in one document, not one document each** — see
+ * `ProgressRepository`. The interface is still per entry because that is what
+ * every caller works in; where they are stored is the adapter's business.
  */
 export interface EntryProgress {
   entryId: string;

--- a/src/infra/firebase/progressRepo.ts
+++ b/src/infra/firebase/progressRepo.ts
@@ -1,0 +1,126 @@
+import {
+  collection,
+  doc,
+  documentId,
+  getDoc,
+  getDocs,
+  limit as limitTo,
+  orderBy,
+  query,
+  serverTimestamp,
+  startAfter,
+  Timestamp,
+  writeBatch,
+} from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import type { Page, PageQuery, ProgressRepository } from '@/domain/ports';
+import type { EntryProgress, PracticeSession, PracticeSessionDraft } from '@/domain/practice';
+import { sanitizeProgressMap, sanitizeSession } from '@/lib/sanitize';
+import { decodeCursor, encodeCursor } from './cursor';
+import { withIsoTimestamps } from './mappers';
+
+/**
+ * Practice state, in two shapes because the two halves are read differently.
+ *
+ * `users/{uid}/progress/entries` — **one document**, a map keyed by entry id.
+ * Every screen that cares about 苦手な語 wants all of it at once and none of
+ * them want to query it, so a collection would buy nothing and cost one read
+ * per word on load and one write per word on save. See `ProgressRepository`
+ * for the full argument and the 1 MiB ceiling it accepts.
+ *
+ * `users/{uid}/practiceSessions/{id}` — a document per session, because 履歴 is
+ * an append-only log that is paged, and a session is written exactly once.
+ *
+ * Both take the `Firestore` instance as a parameter for the same reason
+ * `createEntryRepository` does: importing `./client` runs module side effects
+ * that need a browser build.
+ */
+export function createProgressRepository(db: Firestore, uid: string): ProgressRepository {
+  const progressDoc = () => doc(db, 'users', uid, 'progress', 'entries');
+  const sessionsPath = () => collection(db, 'users', uid, 'practiceSessions');
+
+  return {
+    async listAll(): Promise<EntryProgress[]> {
+      const snapshot = await getDoc(progressDoc());
+      // A learner who has never practised has no document, which is not an
+      // error state — it is the empty map.
+      return snapshot.exists() ? sanitizeProgressMap(snapshot.get('entries')) : [];
+    },
+
+    /**
+     * Two documents, whatever the session length: the log entry and the
+     * progress map.
+     *
+     * A batch rather than two awaits so a crash between them cannot leave
+     * progress recorded against a session that is not in 履歴, or the reverse.
+     *
+     * `merge: true` writes the named entry-id fields and leaves the rest of the
+     * map alone. That is what makes a session finished on a phone survive one
+     * finished on a laptop: without it, this write is the whole map as this
+     * device last read it, and the other device's words revert.
+     */
+    async recordSession(session: PracticeSessionDraft, progress: EntryProgress[]): Promise<string> {
+      // The id is needed before the batch commits, so the reference is minted
+      // locally rather than by addDoc. Firestore generates ids client-side.
+      const sessionRef = doc(sessionsPath());
+      const batch = writeBatch(db);
+
+      batch.set(sessionRef, {
+        ...session,
+        ownerUid: uid,
+        finishedAt: serverTimestamp(),
+      });
+
+      // Written as a nested map keyed by entry id. Object.fromEntries over the
+      // rows rather than dotted field paths, because an entry id is an auto-id
+      // and a dotted path would split one containing a period.
+      batch.set(
+        progressDoc(),
+        {
+          ownerUid: uid,
+          entries: Object.fromEntries(progress.map(({ entryId, ...row }) => [entryId, row])),
+        },
+        { merge: true },
+      );
+
+      await batch.commit();
+      return sessionRef.id;
+    },
+
+    /**
+     * Newest first, ordered by the server-set `finishedAt` — see
+     * `PracticeSessionDraft` for why the device's own clock is not orderable.
+     *
+     * Same shape as the entries listing, including the extra row fetched to
+     * answer "is there more" and the cursor built from the raw `Timestamp`
+     * rather than the mapped ISO string.
+     */
+    async listSessions({ limit, cursor }: PageQuery): Promise<Page<PracticeSession>> {
+      const constraints = [
+        orderBy('finishedAt', 'desc'),
+        orderBy(documentId(), 'desc'),
+        limitTo(limit + 1),
+      ];
+      const decoded = cursor ? decodeCursor(cursor) : null;
+      const snapshot = await getDocs(
+        decoded
+          ? query(sessionsPath(), ...constraints, startAfter(decoded[0], decoded[1]))
+          : query(sessionsPath(), ...constraints),
+      );
+
+      const page = snapshot.docs.slice(0, limit);
+      const last = page[page.length - 1];
+      const lastFinishedAt: unknown = last?.get('finishedAt');
+
+      return {
+        items: page.map((d) =>
+          sanitizeSession(d.id, withIsoTimestamps(d.data(), ['startedAt', 'finishedAt'])),
+        ),
+        cursor:
+          snapshot.docs.length > limit && last && lastFinishedAt instanceof Timestamp
+            ? encodeCursor(lastFinishedAt, last.id)
+            : null,
+      };
+    },
+  };
+}

--- a/src/infra/firebase/wordSetRepo.ts
+++ b/src/infra/firebase/wordSetRepo.ts
@@ -1,0 +1,104 @@
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  documentId,
+  getDoc,
+  getDocs,
+  limit as limitTo,
+  orderBy,
+  query,
+  serverTimestamp,
+  startAfter,
+  Timestamp,
+  updateDoc,
+} from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import type { Page, PageQuery, WordSetRepository } from '@/domain/ports';
+import type { WordSet, WordSetDraft } from '@/domain/wordSet';
+import { sanitizeWordSet } from '@/lib/sanitize';
+import { decodeCursor, encodeCursor } from './cursor';
+import { withIsoTimestamps } from './mappers';
+
+/**
+ * 単語集 at `users/{uid}/wordSets/{setId}`, listed and written the same way
+ * entries are — see `entryRepo.ts` for why the `Firestore` instance is a
+ * parameter and why the cursor is built from the raw `Timestamp`.
+ *
+ * Membership lives here, on `entryIds`, and not on the entry. The order of
+ * that array *is* the study order, which an entry-side array cannot express;
+ * deleting a set is then one write rather than N.
+ */
+export function createWordSetRepository(db: Firestore, uid: string): WordSetRepository {
+  const setsPath = () => collection(db, 'users', uid, 'wordSets');
+  const setDoc = (id: string) => doc(db, 'users', uid, 'wordSets', id);
+
+  const toWordSet = (id: string, data: Record<string, unknown>): WordSet =>
+    sanitizeWordSet(id, withIsoTimestamps(data));
+
+  return {
+    async list({ limit, cursor }: PageQuery): Promise<Page<WordSet>> {
+      const constraints = [
+        orderBy('createdAt', 'desc'),
+        orderBy(documentId(), 'desc'),
+        limitTo(limit + 1),
+      ];
+      const decoded = cursor ? decodeCursor(cursor) : null;
+      const snapshot = await getDocs(
+        decoded
+          ? query(setsPath(), ...constraints, startAfter(decoded[0], decoded[1]))
+          : query(setsPath(), ...constraints),
+      );
+
+      const page = snapshot.docs.slice(0, limit);
+      const last = page[page.length - 1];
+      const lastCreatedAt: unknown = last?.get('createdAt');
+
+      return {
+        items: page.map((d) => toWordSet(d.id, d.data())),
+        cursor:
+          snapshot.docs.length > limit && last && lastCreatedAt instanceof Timestamp
+            ? encodeCursor(lastCreatedAt, last.id)
+            : null,
+      };
+    },
+
+    async get(id: string): Promise<WordSet | null> {
+      const snapshot = await getDoc(setDoc(id));
+      return snapshot.exists() ? toWordSet(snapshot.id, snapshot.data()) : null;
+    },
+
+    /** Duplicates are deduped on the way in as well as on the way out. */
+    async create(draft: WordSetDraft): Promise<string> {
+      const ref = await addDoc(setsPath(), {
+        ...draft,
+        entryIds: [...new Set(draft.entryIds)],
+        ownerUid: uid,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      });
+      return ref.id;
+    },
+
+    async update(id: string, draft: WordSetDraft): Promise<void> {
+      await updateDoc(setDoc(id), {
+        ...draft,
+        entryIds: [...new Set(draft.entryIds)],
+        updatedAt: serverTimestamp(),
+      });
+    },
+
+    /**
+     * Deletes the set, never its entries. A 単語集 is an organisational view
+     * over words that exist on their own, so removing one must not take the
+     * notes with it.
+     */
+    async remove(id: string): Promise<void> {
+      await deleteDoc(setDoc(id));
+    },
+  };
+}

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -6,9 +6,11 @@ import type {
   Page,
   PageQuery,
   ProgressRepository,
+  WordSetRepository,
 } from '@/domain/ports';
 import type { EntryProgress, PracticeSession, PracticeSessionDraft } from '@/domain/practice';
-import { sanitizeEntry } from './sanitize';
+import type { WordSet, WordSetDraft } from '@/domain/wordSet';
+import { sanitizeEntry, sanitizeWordSet } from './sanitize';
 
 /**
  * In-memory adapters for the end-to-end build, and nothing else.
@@ -33,6 +35,8 @@ interface Seed {
   entries?: unknown[];
   /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
   weak?: string[];
+  /** Raw 単語集 documents. Nothing in the app creates one yet. */
+  wordSets?: unknown[];
 }
 
 declare global {
@@ -300,6 +304,110 @@ export const progressRepositoryFor = (uid: string): ProgressRepository => {
         items,
         cursor: more ? (items[items.length - 1]?.id ?? null) : null,
       });
+    },
+  };
+};
+
+// --------------------------------------------------------------- word sets
+
+/**
+ * Read-only in practice: nothing in the app creates a set yet, so the only
+ * source is the seed. Create, update and remove are still implemented, because
+ * a substitute that threw on half its port would be a different port.
+ */
+const setStores = new Map<string, Map<string, WordSet>>();
+let setSequence = 0;
+
+function setsFor(uid: string): Map<string, WordSet> {
+  const existing = setStores.get(uid);
+  if (existing) return existing;
+
+  const persisted = load<WordSet[] | null>(`wordSets.${uid}`, null);
+  const rows =
+    persisted ??
+    (seed().wordSets ?? []).map((raw, index) => {
+      const record = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<
+        string,
+        unknown
+      >;
+      const id = typeof record.id === 'string' ? record.id : `e2e-set-${index + 1}`;
+      return sanitizeWordSet(id, {
+        createdAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        updatedAt: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        ...record,
+        ownerUid: uid,
+      });
+    });
+
+  for (const row of rows) {
+    const n = Number(/^e2e-set-(\d+)$/.exec(row.id)?.[1]);
+    if (Number.isInteger(n) && n > setSequence) setSequence = n;
+  }
+  const store = new Map(rows.map((row) => [row.id, row]));
+  setStores.set(uid, store);
+  return store;
+}
+
+export const wordSetRepositoryFor = (uid: string): WordSetRepository => {
+  const store = setsFor(uid);
+  const stamp = () => new Date().toISOString();
+  const persist = () => {
+    save(`wordSets.${uid}`, [...store.values()]);
+  };
+
+  return {
+    list({ limit, cursor }: PageQuery): Promise<Page<WordSet>> {
+      const all = [...store.values()].sort(
+        (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id),
+      );
+      const start = cursor ? all.findIndex((item) => item.id === cursor) + 1 : 0;
+      const items = all.slice(start, start + limit);
+      const more = start + items.length < all.length;
+      return Promise.resolve({
+        items,
+        cursor: more ? (items[items.length - 1]?.id ?? null) : null,
+      });
+    },
+
+    get(id: string): Promise<WordSet | null> {
+      return Promise.resolve(store.get(id) ?? null);
+    },
+
+    create(draft: WordSetDraft): Promise<string> {
+      const id = `e2e-set-${++setSequence}`;
+      const now = stamp();
+      store.set(id, {
+        ...draft,
+        entryIds: [...new Set(draft.entryIds)],
+        id,
+        ownerUid: uid,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+      persist();
+      return Promise.resolve(id);
+    },
+
+    update(id: string, draft: WordSetDraft): Promise<void> {
+      const existing = store.get(id);
+      if (!existing) return Promise.reject(new Error(`no word set ${id}`));
+      store.set(id, {
+        ...existing,
+        ...draft,
+        entryIds: [...new Set(draft.entryIds)],
+        updatedAt: stamp(),
+      });
+      persist();
+      return Promise.resolve();
+    },
+
+    remove(id: string): Promise<void> {
+      store.delete(id);
+      persist();
+      return Promise.resolve();
     },
   };
 };

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -1,5 +1,13 @@
 import type { Entry, EntryDraft } from '@/domain/entry';
-import type { AuthPort, AuthUser, EntryRepository, Page, PageQuery } from '@/domain/ports';
+import type {
+  AuthPort,
+  AuthUser,
+  EntryRepository,
+  Page,
+  PageQuery,
+  ProgressRepository,
+} from '@/domain/ports';
+import type { EntryProgress, PracticeSession, PracticeSessionDraft } from '@/domain/practice';
 import { sanitizeEntry } from './sanitize';
 
 /**
@@ -23,6 +31,8 @@ interface Seed {
   signedIn?: boolean;
   /** Raw documents, coerced through the same sanitiser the real read path uses. */
   entries?: unknown[];
+  /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
+  weak?: string[];
 }
 
 declare global {
@@ -208,6 +218,88 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       store.delete(id);
       persist();
       return Promise.resolve();
+    },
+  };
+};
+
+// ------------------------------------------------------------ practice store
+
+/**
+ * Mirrors the Firestore adapter's split: one map for progress, a list for
+ * sessions. Both persist for the same reason the entries do — a spec that
+ * finishes a session and then navigates to check the result would otherwise be
+ * reading state the substitute threw away.
+ */
+const progressStores = new Map<string, Map<string, EntryProgress>>();
+const sessionStores = new Map<string, PracticeSession[]>();
+let sessionSequence = 0;
+
+function progressFor(uid: string): Map<string, EntryProgress> {
+  const existing = progressStores.get(uid);
+  if (existing) return existing;
+
+  const persisted = load<EntryProgress[] | null>(`progress.${uid}`, null);
+  const rows: EntryProgress[] =
+    persisted ??
+    (seed().weak ?? []).map((entryId) => ({
+      entryId,
+      status: 'wrong' as const,
+      lastMode: 'flashcard' as const,
+      lastAt: '2026-06-23T00:00:00.000Z',
+      attempts: 1,
+      correctCount: 0,
+    }));
+
+  const store = new Map(rows.map((row) => [row.entryId, row]));
+  progressStores.set(uid, store);
+  return store;
+}
+
+function sessionsFor(uid: string): PracticeSession[] {
+  const existing = sessionStores.get(uid);
+  if (existing) return existing;
+  const restored = load<PracticeSession[]>(`sessions.${uid}`, []);
+  for (const session of restored) {
+    const n = Number(/^e2e-session-(\d+)$/.exec(session.id)?.[1]);
+    if (Number.isInteger(n) && n > sessionSequence) sessionSequence = n;
+  }
+  sessionStores.set(uid, restored);
+  return restored;
+}
+
+export const progressRepositoryFor = (uid: string): ProgressRepository => {
+  const progress = progressFor(uid);
+  const sessions = sessionsFor(uid);
+
+  /** Same ordering as `orderBy('finishedAt','desc'), orderBy(__name__,'desc')`. */
+  const newestFirst = (a: PracticeSession, b: PracticeSession) =>
+    b.finishedAt.localeCompare(a.finishedAt) || b.id.localeCompare(a.id);
+
+  return {
+    listAll(): Promise<EntryProgress[]> {
+      return Promise.resolve([...progress.values()]);
+    },
+
+    recordSession(session: PracticeSessionDraft, rows: EntryProgress[]): Promise<string> {
+      const id = `e2e-session-${++sessionSequence}`;
+      sessions.push({ ...session, id, finishedAt: new Date().toISOString() });
+      // Merging row by row, not replacing the map — the real adapter writes
+      // with `merge: true` and a substitute that clobbered would hide it.
+      for (const row of rows) progress.set(row.entryId, row);
+      save(`sessions.${uid}`, sessions);
+      save(`progress.${uid}`, [...progress.values()]);
+      return Promise.resolve(id);
+    },
+
+    listSessions({ limit, cursor }: PageQuery): Promise<Page<PracticeSession>> {
+      const all = [...sessions].sort(newestFirst);
+      const start = cursor ? all.findIndex((session) => session.id === cursor) + 1 : 0;
+      const items = all.slice(start, start + limit);
+      const more = start + items.length < all.length;
+      return Promise.resolve({
+        items,
+        cursor: more ? (items[items.length - 1]?.id ?? null) : null,
+      });
     },
   };
 };

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -1,8 +1,14 @@
-import type { AuthPort, EntryRepository, ProgressRepository } from '@/domain/ports';
+import type {
+  AuthPort,
+  EntryRepository,
+  ProgressRepository,
+  WordSetRepository,
+} from '@/domain/ports';
 import { firebaseAuth } from '@/infra/firebase/authAdapter';
 import { db } from '@/infra/firebase/client';
 import { createEntryRepository } from '@/infra/firebase/entryRepo';
 import { createProgressRepository } from '@/infra/firebase/progressRepo';
+import { createWordSetRepository } from '@/infra/firebase/wordSetRepo';
 
 /**
  * The single point where the app names its adapters.
@@ -22,3 +28,6 @@ export const entryRepositoryFor = (uid: string): EntryRepository => createEntryR
 
 export const progressRepositoryFor = (uid: string): ProgressRepository =>
   createProgressRepository(db, uid);
+
+export const wordSetRepositoryFor = (uid: string): WordSetRepository =>
+  createWordSetRepository(db, uid);

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -1,7 +1,8 @@
-import type { AuthPort, EntryRepository } from '@/domain/ports';
+import type { AuthPort, EntryRepository, ProgressRepository } from '@/domain/ports';
 import { firebaseAuth } from '@/infra/firebase/authAdapter';
 import { db } from '@/infra/firebase/client';
 import { createEntryRepository } from '@/infra/firebase/entryRepo';
+import { createProgressRepository } from '@/infra/firebase/progressRepo';
 
 /**
  * The single point where the app names its adapters.
@@ -18,3 +19,6 @@ import { createEntryRepository } from '@/infra/firebase/entryRepo';
 export const authPort: AuthPort = firebaseAuth;
 
 export const entryRepositoryFor = (uid: string): EntryRepository => createEntryRepository(db, uid);
+
+export const progressRepositoryFor = (uid: string): ProgressRepository =>
+  createProgressRepository(db, uid);

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -55,3 +55,22 @@ export function fullDate(key: string): string {
   const date = parseLocalDate(key);
   return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
 }
+
+/**
+ * The same calendar day N months earlier, clamped to the end of a shorter month.
+ *
+ * `setMonth` on its own rolls forward instead of clamping: 3月31日 minus one
+ * month is 2月31日, which `Date` reads as 3月3日 — so "the last month" would
+ * start three days *after* it was asked for, and a range meant to widen would
+ * quietly narrow. Moving to the 1st before shifting is what avoids landing on a
+ * day the target month does not have.
+ */
+export function subtractMonths(date: Date, months: number): Date {
+  const day = date.getDate();
+  const shifted = new Date(date);
+  shifted.setDate(1);
+  shifted.setMonth(shifted.getMonth() - months);
+  const lastDayOfTarget = new Date(shifted.getFullYear(), shifted.getMonth() + 1, 0).getDate();
+  shifted.setDate(Math.min(day, lastDayOfTarget));
+  return shifted;
+}

--- a/src/lib/dictation.ts
+++ b/src/lib/dictation.ts
@@ -1,0 +1,73 @@
+import type { Entry } from '@/domain/entry';
+
+/**
+ * Deciding whether a typed answer matches the word that was spoken.
+ *
+ * String-in, string-out and separate from the component, because this is where
+ * a dictation drill is either fair or infuriating and the interesting cases —
+ * an IME that produced half-width kana, a full-width space, katakana where the
+ * note has hiragana — are all invisible on screen.
+ */
+
+/** U+30A1…U+30F6: the katakana that have a hiragana counterpart at −0x60. */
+const KATAKANA = /[ァ-ヶ]/gu;
+
+/**
+ * Two normalisations, and both are load-bearing.
+ *
+ * **NFKC** because a Japanese IME hands back characters that look identical and
+ * are not: half-width katakana (`ﾁｮｯﾄ`) and the ideographic space U+3000 that
+ * every Japanese keyboard produces both fail a `===` against the same word
+ * typed on a different keyboard.
+ *
+ * **Katakana folded to hiragana** because the learner is answering something
+ * they *heard*. Script is not audible, so marking ちょっと wrong for a spoken
+ * チョット is punishing them for information the drill never gave them. It does
+ * cost the ability to drill 外来語 spelling; that is a separate exercise, and a
+ * dictation that only accepts one script is not it.
+ */
+export function normaliseAnswer(text: string): string {
+  return text
+    .normalize('NFKC')
+    .replace(/\s+/gu, '')
+    .replace(KATAKANA, (char) => String.fromCharCode(char.charCodeAt(0) - 0x60));
+}
+
+/**
+ * The forms that count as right: the written word and its kana reading.
+ *
+ * Empty ones are dropped, and that is the whole reason this is a function.
+ * `reading` is empty for a headword that is already kana, so a list built
+ * without this filter contains `''` — and `normaliseAnswer('')` is also `''`,
+ * which makes submitting an empty box a correct answer on exactly the words
+ * that need no reading.
+ */
+export function acceptedAnswers(entry: Pick<Entry, 'headword' | 'reading'>): string[] {
+  return [entry.headword, entry.reading].map(normaliseAnswer).filter((form) => form !== '');
+}
+
+/**
+ * What the speech engine is asked to say.
+ *
+ * The kana reading wins over the written form when there is one. A TTS voice
+ * guesses the reading of a kanji compound from context it does not have here —
+ * a single word with no sentence around it — and 「辛い」 read as からい when
+ * the note says つらい makes the answer unmarkable. Handing it kana removes the
+ * guess.
+ */
+export function spokenForm(entry: Pick<Entry, 'headword' | 'reading'>): string {
+  return entry.reading || entry.headword;
+}
+
+/**
+ * An empty submission is handled by `acceptedAnswers` alone, and deliberately
+ * not guarded again here. A second `answer !== ''` check reads as prudence and
+ * is unreachable — it was written, and no test could be made to fail on it,
+ * which is the definition of a line that cannot be wrong and cannot be right.
+ */
+export function isCorrectAnswer(
+  typed: string,
+  entry: Pick<Entry, 'headword' | 'reading'>,
+): boolean {
+  return acceptedAnswers(entry).includes(normaliseAnswer(typed));
+}

--- a/src/lib/practice.ts
+++ b/src/lib/practice.ts
@@ -1,5 +1,7 @@
 import type { Entry } from '@/domain/entry';
 import type { EntryProgress, PracticeMode, PracticeSessionDraft } from '@/domain/practice';
+import type { WordSet } from '@/domain/wordSet';
+import { addDays, dateKey, subtractMonths } from '@/lib/dates';
 
 /**
  * Everything a practice session is decided by, before any of it is rendered.
@@ -11,13 +13,64 @@ import type { EntryProgress, PracticeMode, PracticeSessionDraft } from '@/domain
  * shuffled and a 苦手のみ toggle on a list that has no notion of practice.
  */
 export interface PracticeFilters {
+  /** 単語集 ids. Membership lives on the set, so this resolves via `scopeFor`. */
+  sets: string[];
   tags: string[];
   jlpt: string[];
+  /** Single-valued, matching Browse: one 品詞 and one 語種 at a time. */
+  pos: string;
+  origin: string;
+  /** Inclusive `learnedOn` bounds, `YYYY-MM-DD`. Empty means unbounded. */
+  from: string;
+  to: string;
   /** Only entries whose most recent attempt was wrong. */
   weakOnly: boolean;
 }
 
-export const EMPTY_PRACTICE_FILTERS: PracticeFilters = { tags: [], jlpt: [], weakOnly: false };
+export const EMPTY_PRACTICE_FILTERS: PracticeFilters = {
+  sets: [],
+  tags: [],
+  jlpt: [],
+  pos: '',
+  origin: '',
+  from: '',
+  to: '',
+  weakOnly: false,
+};
+
+export type QuickRangeKey = 'week' | 'month' | 'year';
+
+export const QUICK_RANGES: { key: QuickRangeKey; label: string }[] = [
+  { key: 'week', label: '1週間' },
+  { key: 'month', label: '1ヶ月' },
+  { key: 'year', label: '1年' },
+];
+
+/**
+ * Where 「直近1ヶ月」 starts, as a `learnedOn` key.
+ *
+ * `now` is an argument for the reason everything else here takes one: a
+ * function that reads the clock can only be tested on the day it was written.
+ * A month is a calendar month rather than 30 days, so 「直近1ヶ月」 on the 15th
+ * always means "since the 15th of last month" and does not drift.
+ */
+export function quickRangeStart(key: QuickRangeKey, now: Date): string {
+  if (key === 'week') return dateKey(addDays(now, -7));
+  return dateKey(subtractMonths(now, key === 'month' ? 1 : 12));
+}
+
+/**
+ * Which quick range the current bounds *are*, so the chip can show as selected.
+ *
+ * A quick range sets only the start, so an explicit end means the learner has
+ * since narrowed it by hand and no chip should claim to describe it.
+ */
+export function activeQuickRange(filters: PracticeFilters, now: Date): QuickRangeKey | null {
+  if (filters.to || !filters.from) return null;
+  return (
+    QUICK_RANGES.find((range) => quickRangeStart(range.key, now) === filters.from)?.key ?? null
+  );
+}
 
 /**
  * 苦手な語 is the *most recent* attempt, never an accumulated ratio: answering
@@ -29,17 +82,59 @@ export function weakIdsOf(progress: readonly EntryProgress[]): Set<string> {
 }
 
 /**
+ * The two filters that are answered by an id lookup rather than by a field on
+ * the entry, resolved once per render instead of per entry.
+ *
+ * A named object rather than two positional `Set`s: they are the same type,
+ * so swapping them at a call site is invisible to the compiler and turns
+ * 苦手のみ into 単語集 without a single error.
+ */
+export interface PracticeScope {
+  /** Entries whose most recent attempt was wrong. */
+  weak: ReadonlySet<string>;
+  /** Members of the selected 単語集, or null when none is selected. */
+  inSets: ReadonlySet<string> | null;
+}
+
+/**
+ * Resolves the selected 単語集 into the entry ids they hold.
+ *
+ * Null rather than an empty set when nothing is selected, because those two
+ * mean opposite things: "do not filter by set" and "a set with no words in it",
+ * and collapsing them makes an empty set select everything.
+ */
+export function scopeFor(
+  filters: PracticeFilters,
+  sets: readonly WordSet[],
+  weak: ReadonlySet<string>,
+): PracticeScope {
+  if (!filters.sets.length) return { weak, inSets: null };
+  const selected = new Set(filters.sets);
+  return {
+    weak,
+    inSets: new Set(sets.filter((set) => selected.has(set.id)).flatMap((set) => set.entryIds)),
+  };
+}
+
+/**
  * Same combination rule as Browse: different filters AND, chips within one
  * filter OR. Two tags means "either tag", because a word normally has one.
  */
 export function matchesPractice(
   entry: Entry,
   filters: PracticeFilters,
-  weak: ReadonlySet<string>,
+  scope: PracticeScope,
 ): boolean {
+  if (scope.inSets && !scope.inSets.has(entry.id)) return false;
   if (filters.tags.length && !filters.tags.some((tag) => entry.tags.includes(tag))) return false;
   if (filters.jlpt.length && !filters.jlpt.includes(entry.jlpt)) return false;
-  if (filters.weakOnly && !weak.has(entry.id)) return false;
+  if (filters.pos && !entry.pos.includes(filters.pos as Entry['pos'][number])) return false;
+  if (filters.origin && entry.origin !== filters.origin) return false;
+  // `learnedOn` is a zero-padded ISO day, so a string comparison is a date
+  // comparison — the same trick `lib/filters.ts` relies on.
+  if (filters.from && entry.learnedOn < filters.from) return false;
+  if (filters.to && entry.learnedOn > filters.to) return false;
+  if (filters.weakOnly && !scope.weak.has(entry.id)) return false;
   return true;
 }
 
@@ -70,10 +165,24 @@ export function shuffle<T>(items: readonly T[], random: () => number): T[] {
  * Stored rather than recomputed because 履歴 has to keep describing a session
  * after the tag it was filtered by has been renamed or deleted.
  */
-export function describeFilters(filters: PracticeFilters): string {
+export function describeFilters(filters: PracticeFilters, sets: readonly WordSet[] = []): string {
+  // Named, not by id: 履歴 is read by a person. A set deleted between the
+  // session and the reading is named as missing rather than dropped, because
+  // silently omitting a filter misdescribes what was drilled.
+  const setNames = filters.sets.map(
+    (id) => `単語集:${sets.find((set) => set.id === id)?.name ?? '不明'}`,
+  );
+  // The bounds are written out rather than as 「直近1ヶ月」: a quick range is
+  // relative to the day it was picked, and a label read back a month later has
+  // to still name the same days.
+  const range = filters.from || filters.to ? [`${filters.from}〜${filters.to}`] : [];
   const parts = [
+    ...setNames,
     ...filters.tags.map((tag) => `#${tag}`),
     ...filters.jlpt,
+    ...(filters.pos ? [filters.pos] : []),
+    ...(filters.origin ? [filters.origin] : []),
+    ...range,
     ...(filters.weakOnly ? ['苦手のみ'] : []),
   ];
   return parts.length ? parts.join(' / ') : 'すべての語';

--- a/src/lib/practice.ts
+++ b/src/lib/practice.ts
@@ -1,0 +1,133 @@
+import type { Entry } from '@/domain/entry';
+import type { EntryProgress, PracticeMode, PracticeSessionDraft } from '@/domain/practice';
+
+/**
+ * Everything a practice session is decided by, before any of it is rendered.
+ *
+ * Kept apart from `lib/filters.ts` on purpose. Browse filters answer "which
+ * words do I want to look at" and grew a search box, date range, 頻度 floor and
+ * a sort order to do it; a session only needs "which words am I drilling", and
+ * folding the two would put a sort order on something that is deliberately
+ * shuffled and a 苦手のみ toggle on a list that has no notion of practice.
+ */
+export interface PracticeFilters {
+  tags: string[];
+  jlpt: string[];
+  /** Only entries whose most recent attempt was wrong. */
+  weakOnly: boolean;
+}
+
+export const EMPTY_PRACTICE_FILTERS: PracticeFilters = { tags: [], jlpt: [], weakOnly: false };
+
+/**
+ * 苦手な語 is the *most recent* attempt, never an accumulated ratio: answering
+ * a word correctly today has to clear it, or the list only ever grows and stops
+ * describing what the learner still gets wrong.
+ */
+export function weakIdsOf(progress: readonly EntryProgress[]): Set<string> {
+  return new Set(progress.filter((row) => row.status === 'wrong').map((row) => row.entryId));
+}
+
+/**
+ * Same combination rule as Browse: different filters AND, chips within one
+ * filter OR. Two tags means "either tag", because a word normally has one.
+ */
+export function matchesPractice(
+  entry: Entry,
+  filters: PracticeFilters,
+  weak: ReadonlySet<string>,
+): boolean {
+  if (filters.tags.length && !filters.tags.some((tag) => entry.tags.includes(tag))) return false;
+  if (filters.jlpt.length && !filters.jlpt.includes(entry.jlpt)) return false;
+  if (filters.weakOnly && !weak.has(entry.id)) return false;
+  return true;
+}
+
+/**
+ * Fisher–Yates, with the source of randomness passed in.
+ *
+ * `Math.random()` inside would make the queue order untestable, and the order
+ * is the entire point of a shuffle: an implementation that only ever moved the
+ * first element would look fine in a browser and be a broken drill.
+ */
+export function shuffle<T>(items: readonly T[], random: () => number): T[] {
+  const out = [...items];
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1));
+    const a = out[i];
+    const b = out[j];
+    if (a !== undefined && b !== undefined) {
+      out[i] = b;
+      out[j] = a;
+    }
+  }
+  return out;
+}
+
+/**
+ * The human-readable label stored on the session, e.g. 「#仕事 / N1 / 苦手のみ」.
+ *
+ * Stored rather than recomputed because 履歴 has to keep describing a session
+ * after the tag it was filtered by has been renamed or deleted.
+ */
+export function describeFilters(filters: PracticeFilters): string {
+  const parts = [
+    ...filters.tags.map((tag) => `#${tag}`),
+    ...filters.jlpt,
+    ...(filters.weakOnly ? ['苦手のみ'] : []),
+  ];
+  return parts.length ? parts.join(' / ') : 'すべての語';
+}
+
+export interface Answer {
+  entryId: string;
+  correct: boolean;
+}
+
+/**
+ * Folds a session's answers into the progress rows it touched, and returns
+ * only those rows.
+ *
+ * Returning the full map instead would make every session overwrite every
+ * entry, which is how a session finished on a phone silently reverts one
+ * finished on a laptop a minute earlier.
+ */
+export function mergeProgress(
+  existing: readonly EntryProgress[],
+  answers: readonly Answer[],
+  mode: PracticeMode,
+  at: string,
+): EntryProgress[] {
+  const byId = new Map(existing.map((row) => [row.entryId, row]));
+  const touched = new Map<string, EntryProgress>();
+
+  for (const answer of answers) {
+    const previous = touched.get(answer.entryId) ?? byId.get(answer.entryId);
+    touched.set(answer.entryId, {
+      entryId: answer.entryId,
+      status: answer.correct ? 'correct' : 'wrong',
+      lastMode: mode,
+      lastAt: at,
+      attempts: (previous?.attempts ?? 0) + 1,
+      correctCount: (previous?.correctCount ?? 0) + (answer.correct ? 1 : 0),
+    });
+  }
+
+  return [...touched.values()];
+}
+
+export function summariseSession(input: {
+  mode: PracticeMode;
+  filterLabel: string;
+  answers: readonly Answer[];
+  startedAt: string;
+}): PracticeSessionDraft {
+  return {
+    mode: input.mode,
+    filterLabel: input.filterLabel,
+    total: input.answers.length,
+    correct: input.answers.filter((answer) => answer.correct).length,
+    missed: input.answers.filter((answer) => !answer.correct).map((answer) => answer.entryId),
+    startedAt: input.startedAt,
+  };
+}

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -1,0 +1,85 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { EntryProgress, PracticeSessionDraft } from '@/domain/practice';
+import { progressRepositoryFor } from '@/lib/backend';
+import { weakIdsOf } from '@/lib/practice';
+
+interface ProgressValue {
+  progress: EntryProgress[];
+  /** Entries whose most recent attempt was wrong — what 苦手のみ selects. */
+  weakIds: Set<string>;
+  loading: boolean;
+  error: string | null;
+  /** Writes a finished session and folds its rows into the state in memory. */
+  record: (session: PracticeSessionDraft, rows: EntryProgress[]) => Promise<void>;
+}
+
+const ProgressContext = createContext<ProgressValue | null>(null);
+
+/**
+ * Practice state for the signed-in user, loaded once.
+ *
+ * Unlike `EntriesProvider` this is a single document, so "load it all" carries
+ * no growth cost worth planning around: one read on sign-in and one write per
+ * finished session, whatever the size of the notebook.
+ *
+ * A failed load is not fatal and deliberately does not block the practice
+ * screen. Without progress, 苦手のみ has nothing to offer and is disabled; every
+ * other filter still works, and a learner who cannot reach their weak-word list
+ * should still be able to drill.
+ */
+export function ProgressProvider({ uid, children }: { uid: string; children: ReactNode }) {
+  const [progress, setProgress] = useState<EntryProgress[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const repository = useMemo(() => progressRepositoryFor(uid), [uid]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    repository
+      .listAll()
+      .then((rows) => {
+        if (!cancelled) setProgress(rows);
+      })
+      .catch((cause: unknown) => {
+        console.error(cause);
+        if (!cancelled) setError('練習の記録を読み込めませんでした。');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [repository]);
+
+  const record = useCallback(
+    async (session: PracticeSessionDraft, rows: EntryProgress[]) => {
+      await repository.recordSession(session, rows);
+      // Merged locally rather than re-read. The rows written are exactly the
+      // rows computed from what is already in state, so a round trip would
+      // return the same values and cost a read on every finished session.
+      setProgress((current) => {
+        const byId = new Map(current.map((row) => [row.entryId, row]));
+        for (const row of rows) byId.set(row.entryId, row);
+        return [...byId.values()];
+      });
+    },
+    [repository],
+  );
+
+  const value = useMemo(
+    () => ({ progress, weakIds: weakIdsOf(progress), loading, error, record }),
+    [progress, loading, error, record],
+  );
+  return <ProgressContext.Provider value={value}>{children}</ProgressContext.Provider>;
+}
+
+export function useProgress() {
+  const value = useContext(ProgressContext);
+  if (!value) throw new Error('useProgress must be used inside <ProgressProvider>');
+  return value;
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -11,6 +11,8 @@ import type {
   Sense,
   UsageNotes,
 } from '@/domain/entry';
+import { PRACTICE_MODES } from '@/domain/practice';
+import type { EntryProgress, PracticeSession } from '@/domain/practice';
 import { emptyDraft, parseTags } from './draft';
 
 /**
@@ -230,5 +232,56 @@ export function sanitizeEntry(id: string, data: unknown): Entry {
     copiedFrom: attribution(raw.copiedFrom),
     createdAt: isoDateTime(raw.createdAt),
     updatedAt: isoDateTime(raw.updatedAt),
+  };
+}
+
+// ------------------------------------------------------------------ practice
+
+/**
+ * Practice records, coerced by the same rule as entries.
+ *
+ * These have one source the entry path does not: the progress map is a single
+ * document, so one malformed key would otherwise take down every word's state
+ * at once rather than one row's.
+ */
+
+/**
+ * One row of the progress map. The key is the entry id — the value carries it
+ * too, so a row stays self-describing once it is out of the map.
+ */
+const progressRow = (entryId: string, value: unknown): EntryProgress => {
+  const raw = record(value);
+  return {
+    entryId,
+    status: oneOf(raw.status, ['correct', 'wrong'] as const, 'wrong'),
+    lastMode: oneOf(raw.lastMode, PRACTICE_MODES, 'flashcard'),
+    lastAt: isoDateTime(raw.lastAt),
+    attempts: nonNegativeInt(raw.attempts),
+    correctCount: nonNegativeInt(raw.correctCount),
+  };
+};
+
+/**
+ * `status` defaults to `'wrong'` rather than `'correct'`, and that direction is
+ * deliberate: an unreadable row surfaces the word in 苦手な語, where the learner
+ * sees it and drills it again. Defaulting the other way would silently drop a
+ * word they are getting wrong out of the one list built to catch that.
+ */
+export function sanitizeProgressMap(value: unknown): EntryProgress[] {
+  const raw = record(value);
+  return Object.entries(raw).map(([entryId, row]) => progressRow(entryId, row));
+}
+
+export function sanitizeSession(id: string, data: unknown): PracticeSession {
+  const raw = record(data);
+  return {
+    id,
+    mode: oneOf(raw.mode, PRACTICE_MODES, 'flashcard'),
+    filterLabel: str(raw.filterLabel),
+    total: nonNegativeInt(raw.total),
+    correct: nonNegativeInt(raw.correct),
+    missed: strings(raw.missed),
+    startedAt: isoDateTime(raw.startedAt),
+    finishedAt: isoDateTime(raw.finishedAt),
   };
 }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/domain/entry';
 import { PRACTICE_MODES } from '@/domain/practice';
 import type { EntryProgress, PracticeSession } from '@/domain/practice';
+import type { WordSet } from '@/domain/wordSet';
 import { emptyDraft, parseTags } from './draft';
 
 /**
@@ -283,5 +284,29 @@ export function sanitizeSession(id: string, data: unknown): PracticeSession {
     missed: strings(raw.missed),
     startedAt: isoDateTime(raw.startedAt),
     finishedAt: isoDateTime(raw.finishedAt),
+  };
+}
+
+/**
+ * A 単語集, coerced on read.
+ *
+ * `entryIds` is deduped here rather than only on write: the order *is* the
+ * study order, and a duplicate would deal the same card twice in one session.
+ */
+export function sanitizeWordSet(id: string, data: unknown): WordSet {
+  const raw = record(data);
+  return {
+    id,
+    ownerUid: str(raw.ownerUid),
+    name: str(raw.name),
+    description: str(raw.description),
+    entryIds: [...new Set(strings(raw.entryIds))],
+    level: oneOfOptional(raw.level, JLPT_LEVELS),
+    topics: strings(raw.topics),
+    publishedId: str(raw.publishedId) || null,
+    publishedVersion: nonNegativeInt(raw.publishedVersion),
+    copiedFrom: attribution(raw.copiedFrom),
+    createdAt: isoDateTime(raw.createdAt),
+    updatedAt: isoDateTime(raw.updatedAt),
   };
 }

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -108,6 +108,21 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
     const engine = synth();
     if (!engine) return;
 
+    /**
+     * **Failure 10: a queue inherited from the previous page.**
+     *
+     * Chrome's synthesiser outlives the document that filled it. Navigating
+     * away mid-utterance — or reloading during one — leaves the next page in
+     * the same renderer looking at `speaking: true` with nothing playing, and
+     * every `speak()` from then on joins a queue that never drains. It is why
+     * the same build was mute on one tab and fine on another site in the same
+     * browser, and why quitting Chrome outright appears to "fix" it.
+     *
+     * One `cancel()` before this page has queued anything of its own clears
+     * whatever it inherited. It is a no-op on a clean engine.
+     */
+    engine.cancel();
+
     const read = () => setVoices(engine.getVoices());
     read();
     engine.addEventListener('voiceschanged', read);

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -1,37 +1,127 @@
+import { useCallback, useEffect, useState } from 'react';
+
 /**
- * The Web Speech API, behind two functions, because it is the one browser
- * capability this app cannot assume.
+ * The Web Speech API, which is the one browser capability this app cannot
+ * assume — and which fails silently in four different ways.
  *
- * `speechSynthesis` is missing entirely in some browsers and present-but-mute
- * in others (a headless Chromium ships the object with no voices installed).
- * Neither throws, so a component calling it directly would show an enabled
- * button that silently does nothing. `canSpeak()` is what lets the UI say so.
+ * All four produce the same symptom: a button that looks fine and makes no
+ * sound. Each is handled below and named where it is handled, because none of
+ * them is visible from the call site.
  */
 
 const synth = (): SpeechSynthesis | null =>
   typeof window !== 'undefined' && 'speechSynthesis' in window ? window.speechSynthesis : null;
 
-export function canSpeak(): boolean {
-  return synth() !== null;
+/**
+ * **Failure 1: the API exists, the voice does not.**
+ *
+ * `speechSynthesis` is present in every desktop browser, so its presence says
+ * nothing. macOS ships Japanese as an *optional* voice — a machine that has
+ * never had one installed exposes dozens of voices and no `ja-*` among them,
+ * and `speak()` on an unmatched language does nothing at all.
+ *
+ * Some platforms report the tag with an underscore (`ja_JP`), which is why this
+ * normalises before comparing rather than testing for `'ja-JP'`. It compares the
+ * language subtag rather than the prefix, because `startsWith('ja')` also
+ * accepts `jam` (Jamaican Creole) and would hand a Japanese word to it.
+ */
+export function japaneseVoices(available: readonly SpeechSynthesisVoice[]): SpeechSynthesisVoice[] {
+  return available.filter(
+    (voice) => voice.lang.replace('_', '-').toLowerCase().split('-')[0] === 'ja',
+  );
 }
 
 /**
- * Speaks `text` in Japanese, cancelling anything already queued.
+ * Prefers a voice that runs on the device.
  *
- * Without the cancel, pressing 「もう一度聞く」 twice queues two utterances and
- * the second word starts before the first has finished — the queue is global to
- * the tab and outlives the component.
- *
- * Slightly under normal rate: this is a listening drill, and the default is
- * fast enough that a learner fails on speed rather than on vocabulary.
+ * A network voice is silent whenever the connection is, and this is a drill
+ * somebody may be doing on a train. macOS's Kyoko is local and better than the
+ * remote alternatives for single words anyway.
  */
-export function speak(text: string): void {
-  const engine = synth();
-  if (!engine || !text) return;
+export function pickJapaneseVoice(
+  available: readonly SpeechSynthesisVoice[],
+): SpeechSynthesisVoice | null {
+  const candidates = japaneseVoices(available);
+  return candidates.find((voice) => voice.localService) ?? candidates[0] ?? null;
+}
 
-  engine.cancel();
-  const utterance = new SpeechSynthesisUtterance(text);
-  utterance.lang = 'ja-JP';
-  utterance.rate = 0.85;
-  engine.speak(utterance);
+export type SpeechStatus = 'unsupported' | 'loading' | 'no-japanese-voice' | 'ready' | 'failed';
+
+/**
+ * The speech engine as this app needs it: a status the UI can explain, and a
+ * `speak` that is safe to call twice in a row.
+ *
+ * **Failure 2: the voice list is populated asynchronously.** The first
+ * `getVoices()` after page load returns `[]` in Chrome, and only a
+ * `voiceschanged` event says otherwise. Deciding anything from that first empty
+ * array — including "this machine has no Japanese" — is wrong for the first
+ * few hundred milliseconds of every visit.
+ */
+export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: string) => void } {
+  const [voices, setVoices] = useState<readonly SpeechSynthesisVoice[]>([]);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const engine = synth();
+    if (!engine) return;
+
+    const read = () => setVoices(engine.getVoices());
+    read();
+    engine.addEventListener('voiceschanged', read);
+    return () => {
+      engine.removeEventListener('voiceschanged', read);
+    };
+  }, []);
+
+  const speak = useCallback(
+    (text: string) => {
+      const engine = synth();
+      if (!engine || !text) return;
+
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'ja-JP';
+      utterance.rate = 0.85;
+      // Named explicitly rather than left to `lang`. Chrome matches a voice off
+      // the language tag only when its list has loaded, and picks a system
+      // default that may not be Japanese at all when it has not.
+      const voice = pickJapaneseVoice(voices);
+      if (voice) utterance.voice = voice;
+
+      setFailed(false);
+      utterance.onerror = (event) => {
+        // 'interrupted' and 'canceled' are this component doing its job —
+        // moving to the next card while the previous word is still playing.
+        if (event.error === 'interrupted' || event.error === 'canceled') return;
+        console.error('speechSynthesis failed', event.error);
+        setFailed(true);
+      };
+
+      /**
+       * **Failure 3: `cancel()` then `speak()` in the same task.** Chrome drops
+       * the new utterance when both land in one turn of the event loop — the
+       * queue is torn down after the call that filled it. Cancelling only when
+       * something is actually playing, and letting the teardown finish first,
+       * is what makes pressing the button twice work.
+       */
+      if (engine.speaking || engine.pending) {
+        engine.cancel();
+        setTimeout(() => engine.speak(utterance), 0);
+      } else {
+        engine.speak(utterance);
+      }
+    },
+    [voices],
+  );
+
+  const status: SpeechStatus = !synth()
+    ? 'unsupported'
+    : failed
+      ? 'failed'
+      : voices.length === 0
+        ? 'loading'
+        : japaneseVoices(voices).length === 0
+          ? 'no-japanese-voice'
+          : 'ready';
+
+  return { status, speak };
 }

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -1,0 +1,37 @@
+/**
+ * The Web Speech API, behind two functions, because it is the one browser
+ * capability this app cannot assume.
+ *
+ * `speechSynthesis` is missing entirely in some browsers and present-but-mute
+ * in others (a headless Chromium ships the object with no voices installed).
+ * Neither throws, so a component calling it directly would show an enabled
+ * button that silently does nothing. `canSpeak()` is what lets the UI say so.
+ */
+
+const synth = (): SpeechSynthesis | null =>
+  typeof window !== 'undefined' && 'speechSynthesis' in window ? window.speechSynthesis : null;
+
+export function canSpeak(): boolean {
+  return synth() !== null;
+}
+
+/**
+ * Speaks `text` in Japanese, cancelling anything already queued.
+ *
+ * Without the cancel, pressing 「もう一度聞く」 twice queues two utterances and
+ * the second word starts before the first has finished — the queue is global to
+ * the tab and outlives the component.
+ *
+ * Slightly under normal rate: this is a listening drill, and the default is
+ * fast enough that a learner fails on speed rather than on vocabulary.
+ */
+export function speak(text: string): void {
+  const engine = synth();
+  if (!engine || !text) return;
+
+  engine.cancel();
+  const utterance = new SpeechSynthesisUtterance(text);
+  utterance.lang = 'ja-JP';
+  utterance.rate = 0.85;
+  engine.speak(utterance);
+}

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -89,82 +89,99 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
     (text: string) => {
       const engine = synth();
       if (!engine || !text) return;
-
-      const utterance = new SpeechSynthesisUtterance(text);
-      utterance.lang = 'ja-JP';
-      utterance.rate = 0.85;
-      // Named explicitly rather than left to `lang`. Chrome matches a voice off
-      // the language tag only when its list has loaded, and picks a system
-      // default that may not be Japanese at all when it has not.
-      const voice = pickJapaneseVoice(voices);
-      if (voice) utterance.voice = voice;
-
       setFailed(false);
 
       /**
-       * **Failure 5: it goes quiet and reports nothing at all.**
+       * One attempt, with or without an explicitly named voice.
        *
-       * Chrome has more than one way to swallow an utterance without firing
-       * `error` — a queue wedged by an earlier cancel, an engine left `paused`,
-       * a voice the list offers but the platform cannot load. Enumerating them
-       * is a losing game; noticing that `start` never arrived is not. This is
-       * the backstop that turns every remaining silent failure into something
-       * the learner can see, and it is why `onstart` exists here at all.
+       * **Failure 8: the voice list offers a voice the platform will not
+       * load.** macOS reports a dozen Japanese voices, and the ones belonging
+       * to Siri are not available to a third-party synthesiser at all — Chrome
+       * lists them, accepts them, starts nothing and reports nothing. Which
+       * names those are is a moving target across macOS releases, so rather
+       * than guess at a blocklist, a first attempt that never starts is retried
+       * once with no voice named, letting Chrome resolve `ja-JP` itself.
        */
-      const started = setTimeout(() => {
-        console.error('speechSynthesis never started', { voice: voice?.name, text });
-        setFailed(true);
-      }, START_TIMEOUT_MS);
+      const attempt = (voice: SpeechSynthesisVoice | null) => {
+        const utterance = new SpeechSynthesisUtterance(text);
+        utterance.lang = 'ja-JP';
+        utterance.rate = 0.85;
+        if (voice) utterance.voice = voice;
 
-      utterance.onstart = () => clearTimeout(started);
-      utterance.onend = () => {
-        // Releases the reference taken below, once it can no longer matter.
-        if (speaking === utterance) speaking = null;
+        /**
+         * **Failure 5: it goes quiet and reports nothing at all.** Chrome has
+         * more than one way to swallow an utterance without firing `error` — a
+         * wedged queue, a paused engine, the unusable voice above. Enumerating
+         * them is a losing game; noticing that `start` never arrived is not.
+         */
+        const started = setTimeout(() => {
+          if (voice) {
+            console.warn(`speechSynthesis: "${voice.name}" never started, retrying unnamed`);
+            attempt(null);
+            return;
+          }
+          console.error('speechSynthesis never started', {
+            text,
+            japaneseVoices: japaneseVoices(voices).map((item) => ({
+              name: item.name,
+              lang: item.lang,
+              localService: item.localService,
+            })),
+          });
+          setFailed(true);
+        }, START_TIMEOUT_MS);
+
+        utterance.onstart = () => clearTimeout(started);
+        utterance.onend = () => {
+          // Releases the reference taken below, once it can no longer matter.
+          if (speaking === utterance) speaking = null;
+        };
+        utterance.onerror = (event) => {
+          clearTimeout(started);
+          // 'interrupted' and 'canceled' are this component doing its job —
+          // moving to the next card while the previous word is still playing.
+          if (event.error === 'interrupted' || event.error === 'canceled') return;
+          console.error('speechSynthesis failed', event.error);
+          setFailed(true);
+        };
+
+        /**
+         * **Failure 6: a stuck `paused` engine.** Chrome leaves the synthesiser
+         * paused after some cancels and after a spell in a background tab, and
+         * a paused engine accepts `speak()`, queues it, plays nothing and
+         * reports nothing. `resume()` on an engine that is not paused does
+         * nothing, so this is unconditional rather than guarded on a flag that
+         * is itself the thing being got wrong.
+         */
+        engine.resume();
+
+        /**
+         * **Failure 3: `cancel()` then `speak()` in the same task.** Chrome
+         * drops the new utterance when both land in one turn of the event loop
+         * — the queue is torn down after the call that filled it. Cancelling
+         * only when something is actually playing, and letting the teardown
+         * finish first, is what makes pressing the button twice work.
+         */
+        if (engine.speaking || engine.pending) {
+          engine.cancel();
+          setTimeout(() => engine.speak(utterance), 0);
+        } else {
+          engine.speak(utterance);
+        }
+
+        /**
+         * **Failure 7: the utterance is collected before it is spoken.** Chrome
+         * holds only a weak reference, so one that goes out of scope while
+         * queued can be garbage-collected mid-sentence — silently, and only
+         * under memory pressure, which is why it reproduces on one machine and
+         * not another. Parking it here keeps it alive until the next call.
+         *
+         * Deliberately untested: no test can make a garbage collector run.
+         */
+        speaking = utterance;
       };
-      utterance.onerror = (event) => {
-        clearTimeout(started);
-        // 'interrupted' and 'canceled' are this component doing its job —
-        // moving to the next card while the previous word is still playing.
-        if (event.error === 'interrupted' || event.error === 'canceled') return;
-        console.error('speechSynthesis failed', event.error);
-        setFailed(true);
-      };
 
-      /**
-       * **Failure 6: a stuck `paused` engine.** Chrome leaves the synthesiser
-       * paused after some cancels and after a spell in a background tab, and a
-       * paused engine accepts `speak()`, queues it, plays nothing and reports
-       * nothing. `resume()` on an engine that is not paused does nothing, so
-       * this is unconditional rather than guarded on a flag that is itself the
-       * thing being got wrong.
-       */
-      engine.resume();
-
-      /**
-       * **Failure 3: `cancel()` then `speak()` in the same task.** Chrome drops
-       * the new utterance when both land in one turn of the event loop — the
-       * queue is torn down after the call that filled it. Cancelling only when
-       * something is actually playing, and letting the teardown finish first,
-       * is what makes pressing the button twice work.
-       */
-      if (engine.speaking || engine.pending) {
-        engine.cancel();
-        setTimeout(() => engine.speak(utterance), 0);
-      } else {
-        engine.speak(utterance);
-      }
-
-      /**
-       * **Failure 7: the utterance is collected before it is spoken.** Chrome
-       * holds only a weak reference to it, so an utterance that goes out of
-       * scope while queued can be garbage-collected mid-sentence — silently,
-       * and only under memory pressure, which is why it reproduces on one
-       * machine and not another. Parking the current one in a module-level
-       * slot keeps it alive until the next call replaces it.
-       *
-       * Deliberately untested: no test can make a garbage collector run.
-       */
-      speaking = utterance;
+      attempt(pickJapaneseVoice(voices));
     },
     [voices],
   );

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -45,6 +45,37 @@ export function pickJapaneseVoice(
   return candidates.find((voice) => voice.localService) ?? candidates[0] ?? null;
 }
 
+/**
+ * Everything worth trying, best first, ending in "let the browser decide".
+ *
+ * **`localService` does not mean playable.** macOS lists every system voice it
+ * *could* use, downloaded or not — a Mac whose system language has never been
+ * Japanese reports Kyoko and eight others as local, and none of them has any
+ * audio data behind it. Chrome accepts such a voice, starts nothing and
+ * reports nothing.
+ *
+ * That is why the network voice is in this list rather than being treated as a
+ * poor relation: `Google 日本語` is served by the browser and depends on no
+ * system download at all, so it is the one candidate that cannot be missing.
+ * It is second rather than first because it needs a connection and a local
+ * voice does not.
+ *
+ * The trailing `null` asks Chrome to resolve `ja-JP` itself, which occasionally
+ * finds something the list does not describe.
+ */
+export function speechCandidates(
+  available: readonly SpeechSynthesisVoice[],
+): (SpeechSynthesisVoice | null)[] {
+  const candidates = japaneseVoices(available);
+  return [
+    ...new Set([
+      candidates.find((voice) => voice.localService) ?? null,
+      candidates.find((voice) => !voice.localService) ?? null,
+      null,
+    ]),
+  ];
+}
+
 export type SpeechStatus = 'unsupported' | 'loading' | 'no-japanese-voice' | 'ready' | 'failed';
 
 /**
@@ -94,15 +125,17 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
       /**
        * One attempt, with or without an explicitly named voice.
        *
-       * **Failure 8: the voice list offers a voice the platform will not
-       * load.** macOS reports a dozen Japanese voices, and the ones belonging
-       * to Siri are not available to a third-party synthesiser at all — Chrome
-       * lists them, accepts them, starts nothing and reports nothing. Which
-       * names those are is a moving target across macOS releases, so rather
-       * than guess at a blocklist, a first attempt that never starts is retried
-       * once with no voice named, letting Chrome resolve `ja-JP` itself.
+       * **Failure 8: a listed voice with nothing behind it.** macOS reports
+       * every system voice it could use, downloaded or not, so `localService`
+       * says where a voice would come from and not whether it can be heard.
+       * An attempt that never starts therefore falls through to the next
+       * candidate rather than being reported — see `speechCandidates` for the
+       * order and why the network voice is in it.
        */
-      const attempt = (voice: SpeechSynthesisVoice | null) => {
+      const candidates = speechCandidates(voices);
+
+      const attempt = (index: number) => {
+        const voice = candidates[index] ?? null;
         const utterance = new SpeechSynthesisUtterance(text);
         utterance.lang = 'ja-JP';
         utterance.rate = 0.85;
@@ -115,12 +148,14 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
          * them is a losing game; noticing that `start` never arrived is not.
          */
         const started = setTimeout(() => {
-          if (voice) {
-            console.warn(`speechSynthesis: "${voice.name}" never started, retrying unnamed`);
-            attempt(null);
+          if (index + 1 < candidates.length) {
+            console.warn(
+              `speechSynthesis: ${voice?.name ?? 'the default voice'} never started, trying the next candidate`,
+            );
+            attempt(index + 1);
             return;
           }
-          console.error('speechSynthesis never started', {
+          console.error('speechSynthesis never started with any voice', {
             text,
             japaneseVoices: japaneseVoices(voices).map((item) => ({
               name: item.name,
@@ -181,7 +216,7 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
         speaking = utterance;
       };
 
-      attempt(pickJapaneseVoice(voices));
+      attempt(0);
     },
     [voices],
   );

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -32,20 +32,6 @@ export function japaneseVoices(available: readonly SpeechSynthesisVoice[]): Spee
 }
 
 /**
- * Prefers a voice that runs on the device.
- *
- * A network voice is silent whenever the connection is, and this is a drill
- * somebody may be doing on a train. macOS's Kyoko is local and better than the
- * remote alternatives for single words anyway.
- */
-export function pickJapaneseVoice(
-  available: readonly SpeechSynthesisVoice[],
-): SpeechSynthesisVoice | null {
-  const candidates = japaneseVoices(available);
-  return candidates.find((voice) => voice.localService) ?? candidates[0] ?? null;
-}
-
-/**
  * Everything worth trying, best first, ending in "let the browser decide".
  *
  * **`localService` does not mean playable.** macOS lists every system voice it
@@ -67,13 +53,15 @@ export function speechCandidates(
   available: readonly SpeechSynthesisVoice[],
 ): (SpeechSynthesisVoice | null)[] {
   const candidates = japaneseVoices(available);
+  // Absent entries are dropped, never coerced to null: `?? null` deduped
+  // against the trailing fallback, which promoted it to *first* on a machine
+  // with no local Japanese voice — the exact machine the network voice is here
+  // for, demoted behind the browser's own guess.
   return [
-    ...new Set([
-      candidates.find((voice) => voice.localService) ?? null,
-      candidates.find((voice) => !voice.localService) ?? null,
-      null,
-    ]),
-  ];
+    candidates.find((voice) => voice.localService),
+    candidates.find((voice) => !voice.localService),
+    null,
+  ].filter((voice) => voice !== undefined);
 }
 
 export type SpeechStatus = 'unsupported' | 'loading' | 'no-japanese-voice' | 'ready' | 'failed';
@@ -104,6 +92,9 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
   const [voices, setVoices] = useState<readonly SpeechSynthesisVoice[]>([]);
   const [failed, setFailed] = useState(false);
 
+  /** The backstop for the utterance in flight, so unmounting can drop it. */
+  const pending = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     const engine = synth();
     if (!engine) return;
@@ -128,6 +119,18 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
     engine.addEventListener('voiceschanged', read);
     return () => {
       engine.removeEventListener('voiceschanged', read);
+      /**
+       * Leaving mid-utterance is the *other* half of failure 10. The mount-time
+       * cancel above cleans up after a page unlucky enough to inherit a live
+       * queue; this one stops handing the next page one. Quitting a session
+       * while the word is still playing — 中断, Escape, or navigating off the
+       * summary — is exactly that case.
+       *
+       * The backstop goes with it: after an unmount it can still fire, advance
+       * the candidate and warn about a voice nobody is waiting for.
+       */
+      if (pending.current !== null) clearTimeout(pending.current);
+      engine.cancel();
     };
   }, []);
 
@@ -165,6 +168,7 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
        * candidate, so the learner's next press tries a different voice.
        */
       const started = setTimeout(() => {
+        pending.current = null;
         const next = candidate.current + 1;
         if (next < candidates.length) {
           candidate.current = next;
@@ -185,14 +189,20 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
         }
         setFailed(true);
       }, START_TIMEOUT_MS);
+      pending.current = started;
 
-      utterance.onstart = () => clearTimeout(started);
+      const settle = () => {
+        clearTimeout(started);
+        if (pending.current === started) pending.current = null;
+      };
+
+      utterance.onstart = settle;
       utterance.onend = () => {
         // Releases the reference taken below, once it can no longer matter.
         if (speaking === utterance) speaking = null;
       };
       utterance.onerror = (event) => {
-        clearTimeout(started);
+        settle();
         // 'interrupted' and 'canceled' are this component doing its job —
         // moving to the next card while the previous word is still playing.
         if (event.error === 'interrupted' || event.error === 'canceled') return;

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -48,6 +48,18 @@ export function pickJapaneseVoice(
 export type SpeechStatus = 'unsupported' | 'loading' | 'no-japanese-voice' | 'ready' | 'failed';
 
 /**
+ * How long to wait for `start` before calling it silence.
+ *
+ * A local voice begins in tens of milliseconds; a network voice can take a
+ * beat. Long enough not to accuse a slow engine, short enough that a learner
+ * gets an explanation rather than sitting there pressing the button again.
+ */
+const START_TIMEOUT_MS = 2_000;
+
+/** See failure 7 below: keeps the queued utterance from being collected. */
+let speaking: SpeechSynthesisUtterance | null = null;
+
+/**
  * The speech engine as this app needs it: a status the UI can explain, and a
  * `speak` that is safe to call twice in a row.
  *
@@ -88,13 +100,45 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
       if (voice) utterance.voice = voice;
 
       setFailed(false);
+
+      /**
+       * **Failure 5: it goes quiet and reports nothing at all.**
+       *
+       * Chrome has more than one way to swallow an utterance without firing
+       * `error` — a queue wedged by an earlier cancel, an engine left `paused`,
+       * a voice the list offers but the platform cannot load. Enumerating them
+       * is a losing game; noticing that `start` never arrived is not. This is
+       * the backstop that turns every remaining silent failure into something
+       * the learner can see, and it is why `onstart` exists here at all.
+       */
+      const started = setTimeout(() => {
+        console.error('speechSynthesis never started', { voice: voice?.name, text });
+        setFailed(true);
+      }, START_TIMEOUT_MS);
+
+      utterance.onstart = () => clearTimeout(started);
+      utterance.onend = () => {
+        // Releases the reference taken below, once it can no longer matter.
+        if (speaking === utterance) speaking = null;
+      };
       utterance.onerror = (event) => {
+        clearTimeout(started);
         // 'interrupted' and 'canceled' are this component doing its job —
         // moving to the next card while the previous word is still playing.
         if (event.error === 'interrupted' || event.error === 'canceled') return;
         console.error('speechSynthesis failed', event.error);
         setFailed(true);
       };
+
+      /**
+       * **Failure 6: a stuck `paused` engine.** Chrome leaves the synthesiser
+       * paused after some cancels and after a spell in a background tab, and a
+       * paused engine accepts `speak()`, queues it, plays nothing and reports
+       * nothing. `resume()` on an engine that is not paused does nothing, so
+       * this is unconditional rather than guarded on a flag that is itself the
+       * thing being got wrong.
+       */
+      engine.resume();
 
       /**
        * **Failure 3: `cancel()` then `speak()` in the same task.** Chrome drops
@@ -109,6 +153,18 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
       } else {
         engine.speak(utterance);
       }
+
+      /**
+       * **Failure 7: the utterance is collected before it is spoken.** Chrome
+       * holds only a weak reference to it, so an utterance that goes out of
+       * scope while queued can be garbage-collected mid-sentence — silently,
+       * and only under memory pressure, which is why it reproduces on one
+       * machine and not another. Parking the current one in a module-level
+       * slot keeps it alive until the next call replaces it.
+       *
+       * Deliberately untested: no test can make a garbage collector run.
+       */
+      speaking = utterance;
     },
     [voices],
   );

--- a/src/lib/speech.ts
+++ b/src/lib/speech.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
  * The Web Speech API, which is the one browser capability this app cannot
@@ -116,45 +116,49 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
     };
   }, []);
 
+  /**
+   * Which candidate the next press will use.
+   *
+   * A ref, not state, because it must survive a re-render without causing one,
+   * and because the value is read inside a callback that must stay stable.
+   */
+  const candidate = useRef(0);
+
   const speak = useCallback(
     (text: string) => {
       const engine = synth();
       if (!engine || !text) return;
       setFailed(false);
 
-      /**
-       * One attempt, with or without an explicitly named voice.
-       *
-       * **Failure 8: a listed voice with nothing behind it.** macOS reports
-       * every system voice it could use, downloaded or not, so `localService`
-       * says where a voice would come from and not whether it can be heard.
-       * An attempt that never starts therefore falls through to the next
-       * candidate rather than being reported — see `speechCandidates` for the
-       * order and why the network voice is in it.
-       */
       const candidates = speechCandidates(voices);
+      const voice = candidates[Math.min(candidate.current, candidates.length - 1)] ?? null;
 
-      const attempt = (index: number) => {
-        const voice = candidates[index] ?? null;
-        const utterance = new SpeechSynthesisUtterance(text);
-        utterance.lang = 'ja-JP';
-        utterance.rate = 0.85;
-        if (voice) utterance.voice = voice;
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'ja-JP';
+      utterance.rate = 0.85;
+      if (voice) utterance.voice = voice;
 
-        /**
-         * **Failure 5: it goes quiet and reports nothing at all.** Chrome has
-         * more than one way to swallow an utterance without firing `error` — a
-         * wedged queue, a paused engine, the unusable voice above. Enumerating
-         * them is a losing game; noticing that `start` never arrived is not.
-         */
-        const started = setTimeout(() => {
-          if (index + 1 < candidates.length) {
-            console.warn(
-              `speechSynthesis: ${voice?.name ?? 'the default voice'} never started, trying the next candidate`,
-            );
-            attempt(index + 1);
-            return;
-          }
+      /**
+       * **Failure 5: it goes quiet and reports nothing at all.** Chrome has
+       * more than one way to swallow an utterance without firing `error`.
+       * Enumerating them is a losing game; noticing that `start` never arrived
+       * is not.
+       *
+       * This only *reports*. It deliberately does not retry, because a
+       * `speak()` from inside a timer has no user activation and can only fail
+       * the same way — see below. What it does instead is move to the next
+       * candidate, so the learner's next press tries a different voice.
+       */
+      const started = setTimeout(() => {
+        const next = candidate.current + 1;
+        if (next < candidates.length) {
+          candidate.current = next;
+          console.warn(
+            `speechSynthesis: ${voice?.name ?? 'the default voice'} never started; the next press will try ${
+              candidates[next]?.name ?? 'the browser default'
+            }`,
+          );
+        } else {
           console.error('speechSynthesis never started with any voice', {
             text,
             japaneseVoices: japaneseVoices(voices).map((item) => ({
@@ -163,60 +167,58 @@ export function useJapaneseSpeech(): { status: SpeechStatus; speak: (text: strin
               localService: item.localService,
             })),
           });
-          setFailed(true);
-        }, START_TIMEOUT_MS);
-
-        utterance.onstart = () => clearTimeout(started);
-        utterance.onend = () => {
-          // Releases the reference taken below, once it can no longer matter.
-          if (speaking === utterance) speaking = null;
-        };
-        utterance.onerror = (event) => {
-          clearTimeout(started);
-          // 'interrupted' and 'canceled' are this component doing its job —
-          // moving to the next card while the previous word is still playing.
-          if (event.error === 'interrupted' || event.error === 'canceled') return;
-          console.error('speechSynthesis failed', event.error);
-          setFailed(true);
-        };
-
-        /**
-         * **Failure 6: a stuck `paused` engine.** Chrome leaves the synthesiser
-         * paused after some cancels and after a spell in a background tab, and
-         * a paused engine accepts `speak()`, queues it, plays nothing and
-         * reports nothing. `resume()` on an engine that is not paused does
-         * nothing, so this is unconditional rather than guarded on a flag that
-         * is itself the thing being got wrong.
-         */
-        engine.resume();
-
-        /**
-         * **Failure 3: `cancel()` then `speak()` in the same task.** Chrome
-         * drops the new utterance when both land in one turn of the event loop
-         * — the queue is torn down after the call that filled it. Cancelling
-         * only when something is actually playing, and letting the teardown
-         * finish first, is what makes pressing the button twice work.
-         */
-        if (engine.speaking || engine.pending) {
-          engine.cancel();
-          setTimeout(() => engine.speak(utterance), 0);
-        } else {
-          engine.speak(utterance);
         }
+        setFailed(true);
+      }, START_TIMEOUT_MS);
 
-        /**
-         * **Failure 7: the utterance is collected before it is spoken.** Chrome
-         * holds only a weak reference, so one that goes out of scope while
-         * queued can be garbage-collected mid-sentence — silently, and only
-         * under memory pressure, which is why it reproduces on one machine and
-         * not another. Parking it here keeps it alive until the next call.
-         *
-         * Deliberately untested: no test can make a garbage collector run.
-         */
-        speaking = utterance;
+      utterance.onstart = () => clearTimeout(started);
+      utterance.onend = () => {
+        // Releases the reference taken below, once it can no longer matter.
+        if (speaking === utterance) speaking = null;
+      };
+      utterance.onerror = (event) => {
+        clearTimeout(started);
+        // 'interrupted' and 'canceled' are this component doing its job —
+        // moving to the next card while the previous word is still playing.
+        if (event.error === 'interrupted' || event.error === 'canceled') return;
+        console.error('speechSynthesis failed', event.error);
+        setFailed(true);
       };
 
-      attempt(0);
+      /**
+       * **Failure 6: a stuck engine.** `resume()` clears a synthesiser Chrome
+       * left paused, and `cancel()` clears a queue it left occupied. Both are
+       * cheap no-ops when nothing is wrong, and a wedged engine reports
+       * `speaking: true` forever until they run.
+       */
+      engine.resume();
+      if (engine.speaking || engine.pending) engine.cancel();
+
+      /**
+       * **Failure 9: user activation does not survive a timer.**
+       *
+       * Chrome has refused `speechSynthesis.speak()` outside a user gesture
+       * since M71, and a refused call leaves the engine reporting
+       * `speaking: true` with nothing playing — measured on the reporting
+       * machine, where `speaking` was already true before any test ran and
+       * `cancel()` could not clear it.
+       *
+       * So this call is synchronous inside the click that asked for it. An
+       * earlier version deferred it by a tick to dodge the cancel-then-speak
+       * race, which traded a race that costs one repeat for a policy that
+       * costs every utterance.
+       */
+      engine.speak(utterance);
+
+      /**
+       * **Failure 7: the utterance is collected before it is spoken.** Chrome
+       * holds only a weak reference, so one that goes out of scope while queued
+       * can be garbage-collected mid-sentence — silently, and only under memory
+       * pressure, which is why it reproduces on one machine and not another.
+       *
+       * Deliberately untested: no test can make a garbage collector run.
+       */
+      speaking = utterance;
     },
     [voices],
   );

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 import type { WordSet } from '@/domain/wordSet';
 import { wordSetRepositoryFor } from '@/lib/backend';
@@ -13,10 +21,10 @@ interface WordSetsValue {
 const WordSetsContext = createContext<WordSetsValue | null>(null);
 
 /**
- * A page size that is really a ceiling: a learner with more than 200 named
- * 単語集 has a different problem, and every screen that wants sets wants all
- * of them — the practice filter, the detail page's "which sets is this in",
- * and `/wordsets` itself.
+ * A page size, and only that: the loop below walks every page there is. Every
+ * screen that wants sets wants all of them — the practice filter, the detail
+ * page's "which sets is this in", and `/wordsets` itself — so there is nothing
+ * to cap it at. 200 is a round number of round trips, not a limit.
  */
 const PAGE_SIZE = 200;
 
@@ -36,7 +44,20 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
 
   const repository = useMemo(() => wordSetRepositoryFor(uid), [uid]);
 
+  /**
+   * Which walk is allowed to publish its result.
+   *
+   * The loop below awaits a page at a time, so a `uid` change part-way through
+   * leaves an in-flight walk that would otherwise finish by calling `setSets`
+   * with the previous account's 単語集. `ProgressProvider` uses a `cancelled`
+   * flag scoped to its effect; that does not fit here because `refresh` is
+   * also called by hand, and a counter covers both — a superseded walk simply
+   * stops being the current one.
+   */
+  const walk = useRef(0);
+
   const refresh = useCallback(async () => {
+    const mine = (walk.current += 1);
     setLoading(true);
     setError(null);
     try {
@@ -47,12 +68,12 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
         all.push(...page.items);
         cursor = page.cursor;
       } while (cursor);
-      setSets(all);
+      if (walk.current === mine) setSets(all);
     } catch (cause) {
       console.error(cause);
-      setError('単語集を読み込めませんでした。');
+      if (walk.current === mine) setError('単語集を読み込めませんでした。');
     } finally {
-      setLoading(false);
+      if (walk.current === mine) setLoading(false);
     }
   }, [repository]);
 

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -1,0 +1,71 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import type { WordSet } from '@/domain/wordSet';
+import { wordSetRepositoryFor } from '@/lib/backend';
+
+interface WordSetsValue {
+  sets: WordSet[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const WordSetsContext = createContext<WordSetsValue | null>(null);
+
+/**
+ * A page size that is really a ceiling: a learner with more than 200 named
+ * 単語集 has a different problem, and every screen that wants sets wants all
+ * of them — the practice filter, the detail page's "which sets is this in",
+ * and `/wordsets` itself.
+ */
+const PAGE_SIZE = 200;
+
+/**
+ * The user's 単語集, loaded once.
+ *
+ * Nothing creates a set yet — `/wordsets` is still a placeholder — so in the
+ * running app this list is empty and the practice filter that reads it stays
+ * hidden. That is the design's own rule for the chips ("only shown if any
+ * exist") rather than a stub: the read path is real, and the filter starts
+ * working the day the first set is written.
+ */
+export function WordSetsProvider({ uid, children }: { uid: string; children: ReactNode }) {
+  const [sets, setSets] = useState<WordSet[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const repository = useMemo(() => wordSetRepositoryFor(uid), [uid]);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const all: WordSet[] = [];
+      let cursor: string | null = null;
+      do {
+        const page = await repository.list({ limit: PAGE_SIZE, cursor });
+        all.push(...page.items);
+        cursor = page.cursor;
+      } while (cursor);
+      setSets(all);
+    } catch (cause) {
+      console.error(cause);
+      setError('単語集を読み込めませんでした。');
+    } finally {
+      setLoading(false);
+    }
+  }, [repository]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const value = useMemo(() => ({ sets, loading, error, refresh }), [sets, loading, error, refresh]);
+  return <WordSetsContext.Provider value={value}>{children}</WordSetsContext.Provider>;
+}
+
+export function useWordSets() {
+  const value = useContext(WordSetsContext);
+  if (!value) throw new Error('useWordSets must be used inside <WordSetsProvider>');
+  return value;
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { AppLayout } from './components/AppLayout';
-import { Dictation, Flashcards, History, WordSets } from './routes/Placeholder';
+import { History, WordSets } from './routes/Placeholder';
 
 // Routes follow the handoff. AppLayout gates everything below it on auth;
 // /login sits outside so it stays reachable when signed out.
@@ -13,8 +13,9 @@ export const router = createBrowserRouter([
       { path: 'vocabulary', lazy: () => import('./routes/Browse') },
       { path: 'vocabulary/:id', lazy: () => import('./routes/EntryDetail') },
       { path: 'account', lazy: () => import('./routes/Account') },
-      { path: 'practice/flashcards', element: <Flashcards /> },
-      { path: 'practice/dictation', element: <Dictation /> },
+      // One module for both modes; it rejects anything else in :mode. The nav
+      // still links the two concrete paths.
+      { path: 'practice/:mode', lazy: () => import('./routes/Practice') },
       { path: 'wordsets', element: <WordSets /> },
       { path: 'history', element: <History /> },
     ],

--- a/src/routes/Placeholder.tsx
+++ b/src/routes/Placeholder.tsx
@@ -1,6 +1,7 @@
 /**
- * Phase 2 destinations. They exist now so the nav from the handoff is complete
- * and no link dead-ends on a 404 while the practice features are built.
+ * The two Phase 2 destinations still to be built. They exist so the nav from
+ * the handoff is complete and no link dead-ends on a 404. Practice is no longer
+ * among them — see `routes/Practice.tsx`.
  */
 function Placeholder({ title, note }: { title: string; note: string }) {
   return (
@@ -9,14 +10,6 @@ function Placeholder({ title, note }: { title: string; note: string }) {
       <p className="mt-2 text-sm text-muted">{note}</p>
     </section>
   );
-}
-
-export function Flashcards() {
-  return <Placeholder title="フラッシュカード" note="練習機能は次のフェーズで実装します。" />;
-}
-
-export function Dictation() {
-  return <Placeholder title="書き取り練習" note="練習機能は次のフェーズで実装します。" />;
 }
 
 export function WordSets() {

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -1,0 +1,177 @@
+import { useMemo, useState } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { DictationSession } from '@/components/practice/DictationSession';
+import { FlashcardSession } from '@/components/practice/FlashcardSession';
+import { PracticeSetup } from '@/components/practice/PracticeSetup';
+import { SessionSummary } from '@/components/practice/SessionSummary';
+import type { Entry } from '@/domain/entry';
+import type { PracticeMode } from '@/domain/practice';
+import { useEntries } from '@/lib/entries';
+import {
+  describeFilters,
+  EMPTY_PRACTICE_FILTERS,
+  matchesPractice,
+  mergeProgress,
+  shuffle,
+  summariseSession,
+} from '@/lib/practice';
+import type { Answer, PracticeFilters } from '@/lib/practice';
+import { useProgress } from '@/lib/progress';
+
+/**
+ * URL segment to mode, and the two are deliberately not the same word.
+ *
+ * The nav and the design both say `/practice/flashcards`; the domain value is
+ * singular, because it labels one session in `PracticeSession.mode`. Reusing
+ * the mode as the path silently renamed the route, and reusing the path as the
+ * mode would put a plural in every stored record. An explicit table is the only
+ * version of this that cannot drift unnoticed.
+ */
+const MODE_BY_SEGMENT: Record<string, PracticeMode> = {
+  flashcards: 'flashcard',
+  dictation: 'dictation',
+};
+
+/**
+ * Both practice modes, behind `/practice/:mode`.
+ *
+ * One route rather than two because everything except the card itself — the
+ * setup screen, the queue, the answer log, the summary and the write — is
+ * identical, and the difference between them is which component renders an
+ * entry. `mode` as a key resets that state when the learner switches from the
+ * nav mid-session, which changing a route param otherwise would not do.
+ */
+export function Component() {
+  const { mode: segment } = useParams();
+  const mode = segment === undefined ? undefined : MODE_BY_SEGMENT[segment];
+  if (!mode) return <Navigate to="/" replace />;
+  return <Practice key={mode} mode={mode} />;
+}
+
+interface Session {
+  queue: Entry[];
+  index: number;
+  answers: Answer[];
+  startedAt: string;
+  filterLabel: string;
+}
+
+function Practice({ mode }: { mode: PracticeMode }) {
+  const { entries, loading, error } = useEntries();
+  const {
+    weakIds,
+    loading: progressLoading,
+    error: progressError,
+    progress,
+    record,
+  } = useProgress();
+  const navigate = useNavigate();
+
+  const [filters, setFilters] = useState<PracticeFilters>(EMPTY_PRACTICE_FILTERS);
+  const [session, setSession] = useState<Session | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const allTags = useMemo(
+    () =>
+      [...new Set(entries.flatMap((entry) => entry.tags))].sort((a, b) => a.localeCompare(b, 'ja')),
+    [entries],
+  );
+
+  const matches = useMemo(
+    () => entries.filter((entry) => matchesPractice(entry, filters, weakIds)),
+    [entries, filters, weakIds],
+  );
+
+  const start = (queue: Entry[], filterLabel: string) => {
+    setSaveError(null);
+    setSession({ queue, index: 0, answers: [], startedAt: new Date().toISOString(), filterLabel });
+  };
+
+  const finish = (finished: Session, answers: Answer[]) => {
+    const at = new Date().toISOString();
+    setSaving(true);
+    setSaveError(null);
+    record(
+      summariseSession({
+        mode,
+        filterLabel: finished.filterLabel,
+        answers,
+        startedAt: finished.startedAt,
+      }),
+      mergeProgress(progress, answers, mode, at),
+    )
+      .catch((cause: unknown) => {
+        console.error(cause);
+        // The score is already on screen and the answers are already in state,
+        // so a failed write costs the record, not the session. Saying so beats
+        // throwing the result away.
+        setSaveError('練習の記録を保存できませんでした。');
+      })
+      .finally(() => {
+        setSaving(false);
+      });
+  };
+
+  /**
+   * The write is fired here rather than from inside the state updater on
+   * purpose: React calls an updater twice under StrictMode, and a session
+   * recorded twice is two rows in 履歴 for one drill.
+   */
+  const answer = (correct: boolean) => {
+    if (!session) return;
+    const entry = session.queue[session.index];
+    if (!entry) return;
+    const answers = [...session.answers, { entryId: entry.id, correct }];
+    setSession({ ...session, index: session.index + 1, answers });
+    if (answers.length === session.queue.length) finish(session, answers);
+  };
+
+  if (loading) return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
+  if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
+
+  if (!session) {
+    return (
+      <PracticeSetup
+        mode={mode}
+        filters={filters}
+        allTags={allTags}
+        matchCount={matches.length}
+        weakCount={weakIds.size}
+        weakState={progressError ? 'error' : progressLoading ? 'loading' : 'ready'}
+        onChange={setFilters}
+        onStart={() => start(shuffle(matches, Math.random), describeFilters(filters))}
+        onCancel={() => void navigate('/')}
+      />
+    );
+  }
+
+  const current = session.queue[session.index];
+  if (current) {
+    const props = {
+      entry: current,
+      index: session.index,
+      total: session.queue.length,
+      onAnswer: answer,
+      onQuit: () => setSession(null),
+    };
+    return mode === 'flashcard' ? <FlashcardSession {...props} /> : <DictationSession {...props} />;
+  }
+
+  const missedIds = new Set(
+    session.answers.filter((item) => !item.correct).map((item) => item.entryId),
+  );
+  const missed = session.queue.filter((entry) => missedIds.has(entry.id));
+
+  return (
+    <SessionSummary
+      total={session.answers.length}
+      correct={session.answers.filter((item) => item.correct).length}
+      missed={missed}
+      saving={saving}
+      saveError={saveError}
+      onRestart={() => start(shuffle(matches, Math.random), describeFilters(filters))}
+      onRetryMissed={() => start(shuffle(missed, Math.random), `${session.filterLabel} / 復習`)}
+    />
+  );
+}

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -87,6 +87,17 @@ function Practice({ mode }: { mode: PracticeMode }) {
     [entries],
   );
 
+  /**
+   * Counted over the entries in hand, not over progress rows. A word answered
+   * wrong and then deleted keeps its row — nothing prunes the map — so
+   * `weakIds.size` would advertise 「1 語」 for a word that cannot be drilled,
+   * and ticking the toggle would produce 「0 件が対象」.
+   */
+  const weakCount = useMemo(
+    () => entries.filter((entry) => weakIds.has(entry.id)).length,
+    [entries, weakIds],
+  );
+
   const matches = useMemo(() => {
     const scope = scopeFor(filters, sets, weakIds);
     return entries.filter((entry) => matchesPractice(entry, filters, scope));
@@ -148,7 +159,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
         allSets={sets}
         now={now}
         matchCount={matches.length}
-        weakCount={weakIds.size}
+        weakCount={weakCount}
         weakState={progressError ? 'error' : progressLoading ? 'loading' : 'ready'}
         onChange={setFilters}
         onStart={() => start(shuffle(matches, Math.random), describeFilters(filters, sets))}
@@ -203,7 +214,14 @@ function Practice({ mode }: { mode: PracticeMode }) {
       missed={missed}
       saving={saving}
       saveError={saveError}
-      onRestart={() => start(shuffle(matches, Math.random), describeFilters(filters, sets))}
+      /**
+       * The same words again, reshuffled — not the filters re-applied. The
+       * session that just finished has already been recorded, so a perfect
+       * 苦手のみ run has cleared every word it drilled: re-filtering would
+       * restart into an empty queue and a 0 / 0 summary, at the moment the
+       * learner did best.
+       */
+      onRestart={() => start(shuffle(session.queue, Math.random), session.filterLabel)}
       onRetryMissed={() => start(shuffle(missed, Math.random), `${session.filterLabel} / 復習`)}
     />
   );

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { DictationSession } from '@/components/practice/DictationSession';
 import { FlashcardSession } from '@/components/practice/FlashcardSession';
 import { PracticeSetup } from '@/components/practice/PracticeSetup';
@@ -12,11 +13,13 @@ import {
   EMPTY_PRACTICE_FILTERS,
   matchesPractice,
   mergeProgress,
+  scopeFor,
   shuffle,
   summariseSession,
 } from '@/lib/practice';
 import type { Answer, PracticeFilters } from '@/lib/practice';
 import { useProgress } from '@/lib/progress';
+import { useWordSets } from '@/lib/wordSets';
 
 /**
  * URL segment to mode, and the two are deliberately not the same word.
@@ -65,12 +68,18 @@ function Practice({ mode }: { mode: PracticeMode }) {
     progress,
     record,
   } = useProgress();
+  const { sets } = useWordSets();
   const navigate = useNavigate();
 
   const [filters, setFilters] = useState<PracticeFilters>(EMPTY_PRACTICE_FILTERS);
   const [session, setSession] = useState<Session | null>(null);
+  const [quitting, setQuitting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Frozen at mount: 「直近1ヶ月」 must not shift under the learner because a
+  // re-render happened to cross midnight.
+  const now = useMemo(() => new Date(), []);
 
   const allTags = useMemo(
     () =>
@@ -78,10 +87,10 @@ function Practice({ mode }: { mode: PracticeMode }) {
     [entries],
   );
 
-  const matches = useMemo(
-    () => entries.filter((entry) => matchesPractice(entry, filters, weakIds)),
-    [entries, filters, weakIds],
-  );
+  const matches = useMemo(() => {
+    const scope = scopeFor(filters, sets, weakIds);
+    return entries.filter((entry) => matchesPractice(entry, filters, scope));
+  }, [entries, filters, sets, weakIds]);
 
   const start = (queue: Entry[], filterLabel: string) => {
     setSaveError(null);
@@ -136,11 +145,13 @@ function Practice({ mode }: { mode: PracticeMode }) {
         mode={mode}
         filters={filters}
         allTags={allTags}
+        allSets={sets}
+        now={now}
         matchCount={matches.length}
         weakCount={weakIds.size}
         weakState={progressError ? 'error' : progressLoading ? 'loading' : 'ready'}
         onChange={setFilters}
-        onStart={() => start(shuffle(matches, Math.random), describeFilters(filters))}
+        onStart={() => start(shuffle(matches, Math.random), describeFilters(filters, sets))}
         onCancel={() => void navigate('/')}
       />
     );
@@ -153,9 +164,31 @@ function Practice({ mode }: { mode: PracticeMode }) {
       index: session.index,
       total: session.queue.length,
       onAnswer: answer,
-      onQuit: () => setSession(null),
+      onQuit: () => setQuitting(true),
     };
-    return mode === 'flashcard' ? <FlashcardSession {...props} /> : <DictationSession {...props} />;
+    return (
+      <>
+        {mode === 'flashcard' ? (
+          <FlashcardSession {...props} keyboard={!quitting} />
+        ) : (
+          <DictationSession {...props} />
+        )}
+        {/* An abandoned session is not recorded, so leaving really does throw
+            the answers away — worth one keystroke of friction, and worth more
+            once Escape can trigger it by accident. */}
+        <ConfirmDialog
+          open={quitting}
+          title="練習を中断しますか？"
+          message={`ここまでの ${session.answers.length} 問は記録されません。`}
+          confirmLabel="中断する"
+          onConfirm={() => {
+            setQuitting(false);
+            setSession(null);
+          }}
+          onClose={() => setQuitting(false)}
+        />
+      </>
+    );
   }
 
   const missedIds = new Set(
@@ -170,7 +203,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
       missed={missed}
       saving={saving}
       saveError={saveError}
-      onRestart={() => start(shuffle(matches, Math.random), describeFilters(filters))}
+      onRestart={() => start(shuffle(matches, Math.random), describeFilters(filters, sets))}
       onRetryMissed={() => start(shuffle(missed, Math.random), `${session.filterLabel} / 復習`)}
     />
   );

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -226,30 +226,42 @@ describe('DictationSession — silence that reports nothing', () => {
    * those are moves with each macOS release, so the chosen voice is dropped
    * and Chrome is asked to resolve `ja-JP` itself rather than guessed at.
    */
-  it('retries without a named voice when the chosen one never starts', async () => {
+  it('falls through to the network voice when the local one never starts', async () => {
     vi.useFakeTimers();
-    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    const { spoken } = installEngine([
+      voice('ja-JP', 'Kyoko'),
+      voice('ja-JP', 'Google 日本語', false),
+    ]);
     setup();
-    expect(spoken).toHaveLength(1);
     expect(spoken[0]?.voice?.name).toBe('Kyoko');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
 
-    expect(spoken).toHaveLength(2);
-    expect(spoken[1]?.voice).toBeNull();
-    // Still nothing claimed: the second attempt has not had its chance yet.
+    // The one candidate that cannot be a voice macOS never downloaded.
+    expect(spoken[1]?.voice?.name).toBe('Google 日本語');
+    // Nothing claimed yet: it has not had its own chance to start.
     expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
   });
 
-  it('reports a failure once the unnamed retry is silent too', async () => {
+  it('reports a failure only once every candidate has been silent', async () => {
     vi.useFakeTimers();
-    installEngine([voice('ja-JP', 'Kyoko')]);
+    const { spoken } = installEngine([
+      voice('ja-JP', 'Kyoko'),
+      voice('ja-JP', 'Google 日本語', false),
+    ]);
     setup();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    expect(spoken).toHaveLength(3);
+    expect(spoken[2]?.voice).toBeNull();
+    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
+
+    await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
     expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DictationSession } from '@/components/practice/DictationSession';
+import { makeEntry } from '../fixtures/entry';
+
+/**
+ * The defect this exists for: Enter is how a Japanese IME accepts a conversion
+ * candidate, and it is also how this field submits. Without the composition
+ * guard, typing 「ちょうこう」 and pressing Enter to convert it to 兆候 marks
+ * the answer against the kana that was on screen mid-conversion — the learner
+ * never gets to finish the word, and the drill is unusable on the only keyboard
+ * it is for.
+ *
+ * Reproducing that needs the composition events, because that is the only
+ * signal distinguishing the two meanings of the key. jsdom fires nothing on its
+ * own; a real IME emits compositionstart, then keydown with `isComposing`, then
+ * compositionend.
+ *
+ * `entry` here is deliberately kana-only, so the *unguarded* behaviour would
+ * score the mid-composition text as correct. A guard that fired on the wrong
+ * event would then flip a passing assertion, which a kanji headword — wrong
+ * either way — could not tell apart.
+ */
+const entry = makeEntry({ id: 'e1', headword: 'ちょっと', reading: '' });
+
+const setup = () => {
+  const onAnswer = vi.fn();
+  render(
+    <DictationSession entry={entry} index={0} total={3} onAnswer={onAnswer} onQuit={vi.fn()} />,
+  );
+  return { onAnswer, input: screen.getByLabelText('聞こえた語') };
+};
+
+/** One IME conversion: the candidate is accepted, and the field is left changed. */
+function pressEnterDuringComposition(input: HTMLElement) {
+  fireEvent.compositionStart(input);
+  fireEvent.keyDown(input, { key: 'Enter', isComposing: true });
+}
+
+describe('DictationSession — the IME Enter key', () => {
+  it('does not mark the answer when Enter is accepting a conversion candidate', () => {
+    const { input } = setup();
+    fireEvent.change(input, { target: { value: 'ちょっと' } });
+
+    pressEnterDuringComposition(input);
+
+    // Still waiting for the learner: no verdict, and the field is still theirs.
+    expect(screen.queryByText(/正解/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '答え合わせ' })).toBeInTheDocument();
+  });
+
+  it('marks the answer on the Enter that follows compositionend', () => {
+    const { input } = setup();
+    fireEvent.change(input, { target: { value: 'ちょっと' } });
+
+    pressEnterDuringComposition(input);
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('✅ 正解')).toBeInTheDocument();
+  });
+
+  /**
+   * The second Enter advances rather than re-marking. Without the `result !==
+   * null` branch, holding Enter down would answer and advance in one keypress
+   * and the learner would never see the word they got wrong.
+   */
+  it('advances on the next Enter instead of marking the same card twice', () => {
+    const { input, onAnswer } = setup();
+    fireEvent.change(input, { target: { value: 'ちがう' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('❌ 不正解')).toBeInTheDocument();
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onAnswer).toHaveBeenCalledExactlyOnceWith(false);
+  });
+});
+
+describe('DictationSession — speech', () => {
+  /**
+   * jsdom has no `speechSynthesis`, which is the same situation as a browser
+   * that does not implement it. The button must say so rather than sit there
+   * enabled and silent.
+   */
+  it('disables 単語を聞く and says why when the browser cannot speak', () => {
+    setup();
+    expect(screen.getByRole('button', { name: /単語を聞く/ })).toBeDisabled();
+    expect(screen.getByText('このブラウザは音声読み上げに対応していません')).toBeInTheDocument();
+  });
+});

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -105,6 +105,8 @@ class FakeUtterance {
   lang = '';
   rate = 1;
   voice: SpeechSynthesisVoice | null = null;
+  onstart: (() => void) | null = null;
+  onend: (() => void) | null = null;
   onerror: ((event: { error: string }) => void) | null = null;
   // Declared rather than a parameter property: `erasableSyntaxOnly` rejects
   // the shorthand, since it emits code rather than erasing to nothing.
@@ -126,6 +128,7 @@ function installEngine(voices: SpeechSynthesisVoice[]) {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
     cancel: vi.fn(),
+    resume: vi.fn(),
     speak: vi.fn((utterance: FakeUtterance) => spoken.push(utterance)),
   };
   vi.stubGlobal('speechSynthesis', engine);
@@ -200,5 +203,57 @@ describe('DictationSession — why the sound did not come out', () => {
       spoken.at(-1)?.onerror?.({ error: 'not-allowed' });
     });
     expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
+  });
+});
+
+/**
+ * The backstop, and the reason it exists: the reported failure came back a
+ * second time as *no sound and no error at all*. Chrome has more than one way
+ * to swallow an utterance without firing `error` — a wedged queue, a paused
+ * engine, a voice the list offers but the platform cannot load — and
+ * enumerating them is a losing game. Noticing that `start` never arrived
+ * catches all of them, including the ones nobody has hit yet.
+ */
+describe('DictationSession — silence that reports nothing', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('reports a failure when the utterance never starts', async () => {
+    vi.useFakeTimers();
+    installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+
+    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+    expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
+  });
+
+  it('stays quiet about a slow engine that does eventually start', async () => {
+    vi.useFakeTimers();
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      spoken.at(-1)?.onstart?.();
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
+  });
+
+  /**
+   * A paused engine accepts `speak()`, queues it, plays nothing and reports
+   * nothing. Chrome gets stuck that way after some cancels and after a spell
+   * in a background tab.
+   */
+  it('resumes the engine before speaking, in case it is stuck paused', () => {
+    const { engine } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+    expect(engine.resume).toHaveBeenCalled();
   });
 });

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -156,11 +156,17 @@ describe('DictationSession — why the sound did not come out', () => {
     expect(screen.getByText(/日本語の音声が見つかりません/)).toBeInTheDocument();
   });
 
-  it('names the voice on the utterance rather than leaving Chrome to match it', () => {
+  /**
+   * The card is silent until asked. Speaking from an effect was refused by
+   * Chrome for want of a user gesture, and left the engine wedged — see
+   * `DictationSession` for the measurement.
+   */
+  it('does not speak until the learner presses the button', () => {
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
+    expect(spoken).toHaveLength(0);
 
-    // The card speaks on arrival; the headword here is kana-only.
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
     expect(spoken.at(-1)?.text).toBe('ちょっと');
     expect(spoken.at(-1)?.voice?.name).toBe('Kyoko');
     expect(spoken.at(-1)?.lang).toBe('ja-JP');
@@ -172,25 +178,24 @@ describe('DictationSession — why the sound did not come out', () => {
    * 単語を聞く silent — the one a learner reaches for precisely because they
    * did not catch the word.
    */
-  it('still speaks on a second press while the first word is playing', async () => {
-    vi.useFakeTimers();
-    try {
-      const { engine, spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
-      setup();
-      expect(spoken).toHaveLength(1);
+  /**
+   * The second press has to reach the engine *inside* the click. Deferring it
+   * by a tick to dodge Chrome's cancel-then-speak race was what lost the user
+   * activation the same browser demands, so the utterance is queued
+   * synchronously and the stale queue is cleared first.
+   */
+  it('speaks synchronously on a second press while the first word is playing', () => {
+    const { engine, spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
+    expect(spoken).toHaveLength(1);
 
-      engine.speaking = true;
-      fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
+    engine.speaking = true;
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
 
-      expect(engine.cancel).toHaveBeenCalled();
-      // Nothing queued yet: the teardown has to finish its own task first.
-      expect(spoken).toHaveLength(1);
-
-      await vi.advanceTimersByTimeAsync(1);
-      expect(spoken).toHaveLength(2);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(engine.cancel).toHaveBeenCalled();
+    // No timer in between: a speak() from a timer has no user activation.
+    expect(spoken).toHaveLength(2);
   });
 
   /** A refused utterance now reports itself instead of being indistinguishable
@@ -198,6 +203,7 @@ describe('DictationSession — why the sound did not come out', () => {
   it('surfaces an engine error rather than leaving the learner guessing', () => {
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
 
     act(() => {
       spoken.at(-1)?.onerror?.({ error: 'not-allowed' });
@@ -226,26 +232,38 @@ describe('DictationSession — silence that reports nothing', () => {
    * those are moves with each macOS release, so the chosen voice is dropped
    * and Chrome is asked to resolve `ja-JP` itself rather than guessed at.
    */
-  it('falls through to the network voice when the local one never starts', async () => {
+  const press = () => fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
+
+  /**
+   * A silent attempt cannot be retried from the timer that noticed it: a
+   * `speak()` with no user gesture behind it is refused, which is the defect
+   * this whole file is about. So the next *press* moves to the next candidate
+   * instead — the network voice being the one that cannot be a system voice
+   * macOS never downloaded.
+   */
+  it('moves to the network voice on the next press, not from the timer', async () => {
     vi.useFakeTimers();
     const { spoken } = installEngine([
       voice('ja-JP', 'Kyoko'),
       voice('ja-JP', 'Google 日本語', false),
     ]);
     setup();
+
+    press();
     expect(spoken[0]?.voice?.name).toBe('Kyoko');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_500);
     });
+    // Nothing spoken from the timer itself.
+    expect(spoken).toHaveLength(1);
+    expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
 
-    // The one candidate that cannot be a voice macOS never downloaded.
+    press();
     expect(spoken[1]?.voice?.name).toBe('Google 日本語');
-    // Nothing claimed yet: it has not had its own chance to start.
-    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
   });
 
-  it('reports a failure only once every candidate has been silent', async () => {
+  it('ends at the browser default and stays there', async () => {
     vi.useFakeTimers();
     const { spoken } = installEngine([
       voice('ja-JP', 'Kyoko'),
@@ -253,24 +271,26 @@ describe('DictationSession — silence that reports nothing', () => {
     ]);
     setup();
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2_500);
-      await vi.advanceTimersByTimeAsync(2_500);
-    });
-    expect(spoken).toHaveLength(3);
-    expect(spoken[2]?.voice).toBeNull();
-    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      press();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+    }
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2_500);
-    });
-    expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
+    expect(spoken.map((item) => item.voice?.name ?? null)).toEqual([
+      'Kyoko',
+      'Google 日本語',
+      null,
+      null,
+    ]);
   });
 
   it('stays quiet about a slow engine that does eventually start', async () => {
     vi.useFakeTimers();
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500);
@@ -288,6 +308,7 @@ describe('DictationSession — silence that reports nothing', () => {
   it('resumes the engine before speaking, in case it is stuck paused', () => {
     const { engine } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
+    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
     expect(engine.resume).toHaveBeenCalled();
   });
 });

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -220,14 +220,36 @@ describe('DictationSession — silence that reports nothing', () => {
     vi.useRealTimers();
   });
 
-  it('reports a failure when the utterance never starts', async () => {
+  /**
+   * macOS lists Japanese voices that Chrome accepts and cannot load — the Siri
+   * ones are not available to a third-party synthesiser at all. Which names
+   * those are moves with each macOS release, so the chosen voice is dropped
+   * and Chrome is asked to resolve `ja-JP` itself rather than guessed at.
+   */
+  it('retries without a named voice when the chosen one never starts', async () => {
+    vi.useFakeTimers();
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+    expect(spoken).toHaveLength(1);
+    expect(spoken[0]?.voice?.name).toBe('Kyoko');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
+    });
+
+    expect(spoken).toHaveLength(2);
+    expect(spoken[1]?.voice).toBeNull();
+    // Still nothing claimed: the second attempt has not had its chance yet.
+    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
+  });
+
+  it('reports a failure once the unnamed retry is silent too', async () => {
     vi.useFakeTimers();
     installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
 
-    expect(screen.queryByText(/音声を再生できませんでした/)).not.toBeInTheDocument();
-
     await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_500);
       await vi.advanceTimersByTimeAsync(2_500);
     });
     expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -157,16 +157,13 @@ describe('DictationSession — why the sound did not come out', () => {
   });
 
   /**
-   * The card is silent until asked. Speaking from an effect was refused by
-   * Chrome for want of a user gesture, and left the engine wedged — see
-   * `DictationSession` for the measurement.
+   * Autoplay is the drill's whole opening move, and it works in Safari on the
+   * machine where Chrome would not — so it stays, and Chrome is worked around.
    */
-  it('does not speak until the learner presses the button', () => {
+  it('speaks on arrival, naming the voice rather than leaving Chrome to match it', () => {
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
-    expect(spoken).toHaveLength(0);
 
-    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
     expect(spoken.at(-1)?.text).toBe('ちょっと');
     expect(spoken.at(-1)?.voice?.name).toBe('Kyoko');
     expect(spoken.at(-1)?.lang).toBe('ja-JP');
@@ -187,7 +184,6 @@ describe('DictationSession — why the sound did not come out', () => {
   it('speaks synchronously on a second press while the first word is playing', () => {
     const { engine, spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
-    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
     expect(spoken).toHaveLength(1);
 
     engine.speaking = true;
@@ -203,7 +199,6 @@ describe('DictationSession — why the sound did not come out', () => {
   it('surfaces an engine error rather than leaving the learner guessing', () => {
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
-    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
 
     act(() => {
       spoken.at(-1)?.onerror?.({ error: 'not-allowed' });
@@ -248,8 +243,6 @@ describe('DictationSession — silence that reports nothing', () => {
       voice('ja-JP', 'Google 日本語', false),
     ]);
     setup();
-
-    press();
     expect(spoken[0]?.voice?.name).toBe('Kyoko');
 
     await act(async () => {
@@ -271,13 +264,14 @@ describe('DictationSession — silence that reports nothing', () => {
     ]);
     setup();
 
-    for (let attempt = 0; attempt < 4; attempt += 1) {
-      press();
+    for (let attempt = 0; attempt < 3; attempt += 1) {
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2_500);
       });
+      press();
     }
 
+    // Kyoko on arrival, then one per press, ending stuck on the default.
     expect(spoken.map((item) => item.voice?.name ?? null)).toEqual([
       'Kyoko',
       'Google 日本語',
@@ -290,7 +284,6 @@ describe('DictationSession — silence that reports nothing', () => {
     vi.useFakeTimers();
     const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
-    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(500);
@@ -308,7 +301,88 @@ describe('DictationSession — silence that reports nothing', () => {
   it('resumes the engine before speaking, in case it is stuck paused', () => {
     const { engine } = installEngine([voice('ja-JP', 'Kyoko')]);
     setup();
-    fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
     expect(engine.resume).toHaveBeenCalled();
+  });
+});
+
+describe('DictationSession — replaying the word', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * Enter on an empty field can only mean "I did not catch that". Marking a
+   * blank answer wrong is a guaranteed failure the learner never chose, and it
+   * is unrecoverable — the card is scored and gone.
+   */
+  it('replays the word on Enter instead of marking an empty answer wrong', () => {
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    const { input, onAnswer } = setup();
+    expect(spoken).toHaveLength(1);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(spoken).toHaveLength(2);
+    expect(screen.queryByText(/正解/)).not.toBeInTheDocument();
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  /** Whitespace is not an answer either — an IME leaves plenty of it around. */
+  it('treats a field of spaces as empty', () => {
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    const { input } = setup();
+
+    fireEvent.change(input, { target: { value: '  ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(spoken).toHaveLength(2);
+    expect(screen.queryByText(/正解/)).not.toBeInTheDocument();
+  });
+
+  it('still marks a real answer', () => {
+    installEngine([voice('ja-JP', 'Kyoko')]);
+    const { input } = setup();
+
+    fireEvent.change(input, { target: { value: 'ちょっと' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(screen.getByText('✅ 正解')).toBeInTheDocument();
+  });
+
+  /**
+   * The button and the arrival utterance must not stack, and the only way they
+   * can is *after a failure*: pressing 単語を聞く clears the failed state,
+   * which puts `status` back to `ready`, which re-runs the arrival effect. A
+   * press on a healthy engine changes no dependency and could never show this,
+   * so the timeout has to be walked through first.
+   */
+  it('speaks once per press after a failure, not twice', async () => {
+    vi.useFakeTimers();
+    try {
+      const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+      setup();
+      expect(spoken).toHaveLength(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_500);
+      });
+      expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
+      expect(spoken).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /**
+   * Chrome's synthesiser outlives the document. A page that inherits a queue
+   * left mid-utterance by the previous one sees `speaking: true` forever and
+   * every later `speak()` joins a queue that never drains.
+   */
+  it('clears a queue inherited from the previous page before speaking', () => {
+    const { engine } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+    expect(engine.cancel).toHaveBeenCalled();
   });
 });

--- a/tests/component/DictationSession.test.tsx
+++ b/tests/component/DictationSession.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DictationSession } from '@/components/practice/DictationSession';
 import { makeEntry } from '../fixtures/entry';
 
@@ -88,5 +88,117 @@ describe('DictationSession — speech', () => {
     setup();
     expect(screen.getByRole('button', { name: /単語を聞く/ })).toBeDisabled();
     expect(screen.getByText('このブラウザは音声読み上げに対応していません')).toBeInTheDocument();
+  });
+});
+
+/**
+ * The four ways `speechSynthesis` goes quiet, three of which shipped and were
+ * found by using the app on a MacBook: the button was enabled, the click did
+ * nothing, and nothing on screen said why.
+ *
+ * The engine is substituted here, which the rules allow — it is a browser
+ * service, not a module we own — and it is the only way to reach these at all:
+ * jsdom has no `speechSynthesis`, and a real browser has whichever voices that
+ * machine happens to have installed.
+ */
+class FakeUtterance {
+  lang = '';
+  rate = 1;
+  voice: SpeechSynthesisVoice | null = null;
+  onerror: ((event: { error: string }) => void) | null = null;
+  // Declared rather than a parameter property: `erasableSyntaxOnly` rejects
+  // the shorthand, since it emits code rather than erasing to nothing.
+  text: string;
+  constructor(text: string) {
+    this.text = text;
+  }
+}
+
+const voice = (lang: string, name: string, localService = true) =>
+  ({ lang, name, localService, default: false, voiceURI: name }) as SpeechSynthesisVoice;
+
+function installEngine(voices: SpeechSynthesisVoice[]) {
+  const spoken: FakeUtterance[] = [];
+  const engine = {
+    speaking: false,
+    pending: false,
+    getVoices: () => voices,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    cancel: vi.fn(),
+    speak: vi.fn((utterance: FakeUtterance) => spoken.push(utterance)),
+  };
+  vi.stubGlobal('speechSynthesis', engine);
+  vi.stubGlobal('SpeechSynthesisUtterance', FakeUtterance);
+  return { engine, spoken };
+}
+
+describe('DictationSession — why the sound did not come out', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  /**
+   * The reported defect. macOS ships Japanese as an *optional* voice, so a
+   * machine that never installed one reports a full voice list with no `ja-*`
+   * in it — and `speak()` on an unmatched language does nothing and reports
+   * nothing. The old check only asked whether the API existed, which is always
+   * true, so the button stayed enabled and silent forever.
+   */
+  it('says the Japanese voice is missing instead of failing silently', () => {
+    installEngine([voice('en-US', 'Samantha')]);
+    setup();
+
+    expect(screen.getByRole('button', { name: /単語を聞く/ })).toBeDisabled();
+    expect(screen.getByText(/日本語の音声が見つかりません/)).toBeInTheDocument();
+  });
+
+  it('names the voice on the utterance rather than leaving Chrome to match it', () => {
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+
+    // The card speaks on arrival; the headword here is kana-only.
+    expect(spoken.at(-1)?.text).toBe('ちょっと');
+    expect(spoken.at(-1)?.voice?.name).toBe('Kyoko');
+    expect(spoken.at(-1)?.lang).toBe('ja-JP');
+  });
+
+  /**
+   * Chrome drops an utterance queued in the same task as `cancel()`, so the
+   * old unconditional `cancel(); speak()` made the *second* press of
+   * 単語を聞く silent — the one a learner reaches for precisely because they
+   * did not catch the word.
+   */
+  it('still speaks on a second press while the first word is playing', async () => {
+    vi.useFakeTimers();
+    try {
+      const { engine, spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+      setup();
+      expect(spoken).toHaveLength(1);
+
+      engine.speaking = true;
+      fireEvent.click(screen.getByRole('button', { name: /単語を聞く/ }));
+
+      expect(engine.cancel).toHaveBeenCalled();
+      // Nothing queued yet: the teardown has to finish its own task first.
+      expect(spoken).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(spoken).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  /** A refused utterance now reports itself instead of being indistinguishable
+   *  from a working one that happened to be inaudible. */
+  it('surfaces an engine error rather than leaving the learner guessing', () => {
+    const { spoken } = installEngine([voice('ja-JP', 'Kyoko')]);
+    setup();
+
+    act(() => {
+      spoken.at(-1)?.onerror?.({ error: 'not-allowed' });
+    });
+    expect(screen.getByText(/音声を再生できませんでした/)).toBeInTheDocument();
   });
 });

--- a/tests/component/FlashcardSession.test.tsx
+++ b/tests/component/FlashcardSession.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FlashcardSession } from '@/components/practice/FlashcardSession';
+import { makeEntry } from '../fixtures/entry';
+
+/**
+ * The keyboard shortcuts, which are the only way this card is meant to be
+ * driven once a learner is a few words in.
+ *
+ * They are bound on `document`, not on a focused element, so nothing in the DOM
+ * shows they exist and nothing but a test can tell whether they still do. The
+ * one that carries a real rule is the arrow keys: they must stay inert until
+ * the card is flipped, the same as the buttons that are not rendered yet.
+ */
+const entry = makeEntry({ id: 'e1', headword: '兆候', reading: 'ちょうこう' });
+
+const setup = (props: Partial<Parameters<typeof FlashcardSession>[0]> = {}) => {
+  const onAnswer = vi.fn();
+  const onQuit = vi.fn();
+  render(
+    <FlashcardSession
+      entry={entry}
+      index={0}
+      total={3}
+      onAnswer={onAnswer}
+      onQuit={onQuit}
+      {...props}
+    />,
+  );
+  return { onAnswer, onQuit };
+};
+
+const press = (key: string, init: Partial<KeyboardEventInit> = {}) =>
+  fireEvent.keyDown(document, { key, ...init });
+
+describe('FlashcardSession — keyboard', () => {
+  it('turns the card on Space, and turns it back', () => {
+    setup();
+    expect(screen.queryByRole('button', { name: /わかった/ })).not.toBeInTheDocument();
+
+    press(' ');
+    expect(screen.getByRole('button', { name: /わかった/ })).toBeInTheDocument();
+
+    press(' ');
+    expect(screen.queryByRole('button', { name: /わかった/ })).not.toBeInTheDocument();
+  });
+
+  /**
+   * The defect: answering a card whose meaning is still hidden records
+   * confidence rather than recall, and 苦手な語 is built out of these answers.
+   * The buttons enforce it by not existing yet; a document-level shortcut has
+   * to enforce it itself.
+   */
+  it('ignores the arrow keys until the meaning is on screen', () => {
+    const { onAnswer } = setup();
+
+    press('ArrowRight');
+    press('ArrowLeft');
+    expect(onAnswer).not.toHaveBeenCalled();
+
+    press(' ');
+    press('ArrowRight');
+    expect(onAnswer).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it('answers もう一度 on ArrowLeft', () => {
+    const { onAnswer } = setup();
+    press(' ');
+    press('ArrowLeft');
+    expect(onAnswer).toHaveBeenCalledExactlyOnceWith(false);
+  });
+
+  /** A held key repeats, and a repeated answer tears through the queue. */
+  it('ignores an auto-repeat, so a held arrow answers one card', () => {
+    const { onAnswer } = setup();
+    press(' ');
+    press('ArrowRight', { repeat: true });
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  /** Ctrl+← is "back" in a browser, not "もう一度". */
+  it('leaves a modified arrow to the browser', () => {
+    const { onAnswer } = setup();
+    press(' ');
+    press('ArrowLeft', { metaKey: true });
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  it('asks to leave on Escape', () => {
+    const { onQuit } = setup();
+    press('Escape');
+    expect(onQuit).toHaveBeenCalledOnce();
+  });
+
+  /**
+   * With the quit dialog open, the Escape that closes it would otherwise be
+   * caught here as well and reopen it on the way back — a dialog that cannot
+   * be dismissed with the key that opened it.
+   */
+  it('stops listening while a dialog is over the card', () => {
+    const { onQuit, onAnswer } = setup({ keyboard: false });
+    press('Escape');
+    press(' ');
+    expect(onQuit).not.toHaveBeenCalled();
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+});
+
+describe('FlashcardSession — shortcut hints', () => {
+  it('prints the key on each button it belongs to', () => {
+    setup();
+    expect(screen.getByRole('button', { name: /裏を見る/ })).toHaveTextContent('Space');
+
+    press(' ');
+    expect(screen.getByRole('button', { name: /もう一度/ })).toHaveTextContent('←');
+    expect(screen.getByRole('button', { name: /わかった/ })).toHaveTextContent('→');
+  });
+
+  /** 中断 is deliberately bare: it is a header control, not a drill action. */
+  it('leaves 中断 without one', () => {
+    setup();
+    expect(screen.getByRole('button', { name: '中断' })).toHaveTextContent('中断');
+  });
+});

--- a/tests/component/FlashcardSession.test.tsx
+++ b/tests/component/FlashcardSession.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { Modal } from '@/components/Modal';
 import { FlashcardSession } from '@/components/practice/FlashcardSession';
 import { makeEntry } from '../fixtures/entry';
 
@@ -120,5 +121,80 @@ describe('FlashcardSession — shortcut hints', () => {
   it('leaves 中断 without one', () => {
     setup();
     expect(screen.getByRole('button', { name: '中断' })).toHaveTextContent('中断');
+  });
+});
+
+/**
+ * The card under an overlay it was never told about.
+ *
+ * `AppLayout` renders ＋追加 and the mobile ＋ button on every route,
+ * `/practice/:mode` included, so the add-word sheet can be open over a running
+ * card while `FlashcardSession` still has `keyboard` true — it only knows
+ * about the quit dialog its own parent renders. A document-level listener then
+ * reads every keystroke meant for the form.
+ *
+ * Composed from the real `Modal` rather than a stand-in, because the claim is
+ * about how the two behave together: `Modal` binds its own Escape on
+ * `document` and stops nothing else.
+ */
+function renderWithModal() {
+  const onAnswer = vi.fn();
+  const onQuit = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <>
+      <FlashcardSession entry={entry} index={0} total={3} onAnswer={onAnswer} onQuit={onQuit} />
+      <Modal open title="単語を追加" onClose={onClose}>
+        <label>
+          見出し語
+          <input />
+        </label>
+      </Modal>
+    </>,
+  );
+  return { onAnswer, onQuit, onClose, field: screen.getByLabelText('見出し語') };
+}
+
+describe('FlashcardSession — under the add-word sheet', () => {
+  /**
+   * The worst of the three: the card is scored without ever being seen, the
+   * queue advances behind the sheet, and the answer is written into 苦手な語.
+   */
+  it('does not answer the card when an arrow key is typed into a form field', () => {
+    const { onAnswer } = renderWithModal();
+    press(' ');
+
+    fireEvent.keyDown(screen.getByLabelText('見出し語'), { key: 'ArrowRight', bubbles: true });
+
+    expect(onAnswer).not.toHaveBeenCalled();
+  });
+
+  /** `preventDefault` on the session's behalf means the space is never typed. */
+  it('lets a space reach the form field instead of swallowing it', () => {
+    const { field } = renderWithModal();
+
+    const event = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
+    field.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  /** Escape closes the sheet; it must not also open the quit dialog behind it. */
+  it('does not ask to quit when Escape dismisses the sheet', () => {
+    const { onQuit, onClose } = renderWithModal();
+
+    press('Escape');
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onQuit).not.toHaveBeenCalled();
+  });
+
+  /** Focus outside the field is still inside a modal, and still not the card's. */
+  it('ignores the keyboard while a dialog is open even with focus outside its fields', () => {
+    const { onAnswer } = renderWithModal();
+    press(' ');
+    press('ArrowRight');
+
+    expect(onAnswer).not.toHaveBeenCalled();
   });
 });

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -14,6 +14,8 @@ export interface E2ESeed {
   /** Start already signed in, skipping the login screen. */
   signedIn?: boolean;
   entries?: Record<string, unknown>[];
+  /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
+  weak?: string[];
 }
 
 /** Fixed instant every spec runs at. A Wednesday; its ISO week starts on the 22nd. */

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -16,6 +16,7 @@ export interface E2ESeed {
   entries?: Record<string, unknown>[];
   /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
   weak?: string[];
+  wordSets?: Record<string, unknown>[];
 }
 
 /** Fixed instant every spec runs at. A Wednesday; its ISO week starts on the 22nd. */
@@ -95,3 +96,14 @@ export async function seed(page: Page, data: E2ESeed = {}): Promise<void> {
 
 /** The common case: signed in, with the three words above already saved. */
 export const seedSignedIn = (page: Page) => seed(page, { signedIn: true, entries: WORDS });
+
+/**
+ * One 単語集 over two of the three words.
+ *
+ * Seeded rather than created through the app, because nothing creates one yet:
+ * `/wordsets` is still a placeholder. The read path is real, so this is what
+ * the practice filter will see the day the first set is written for real.
+ */
+export const WORD_SETS: Record<string, unknown>[] = [
+  { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
+];

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { seed, seedSignedIn, WORDS } from './fixtures';
+import { seed, seedSignedIn, WORD_SETS, WORDS } from './fixtures';
 
 /**
  * A practice session from the setup screen to the recorded result.
@@ -54,6 +54,42 @@ test.describe('flashcards', () => {
     await expect(page.getByRole('button', { name: 'わかった' })).toBeVisible();
   });
 
+  /**
+   * The shortcuts are covered as DOM events in
+   * tests/component/FlashcardSession.test.tsx. What only a browser shows is
+   * that a real key press reaches a listener bound to `document` when nothing
+   * on the page has focus — which is the state a session starts in.
+   */
+  test('runs a whole card from the keyboard', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    await page.keyboard.press('Space');
+    await expect(page.getByRole('button', { name: /わかった/ })).toBeVisible();
+    await page.keyboard.press('ArrowRight');
+
+    await expect(page.getByText('1 / 1')).toBeVisible();
+  });
+
+  test('asks before throwing a session away, and stays put if refused', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    await page.keyboard.press('Escape');
+    const dialog = page.getByRole('dialog', { name: '練習を中断しますか？' });
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'キャンセル' }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page.getByLabel('進捗')).toBeVisible();
+
+    await page.getByRole('button', { name: '中断' }).click();
+    await page.getByRole('button', { name: '中断する' }).click();
+    // Back on the setup screen, with the session discarded rather than scored.
+    await expect(page.getByRole('button', { name: '開始する' })).toBeVisible();
+  });
+
   test('records the session, and the failed word comes back as 苦手', async ({ page }) => {
     await page.goto('/practice/flashcards');
     await page.getByRole('button', { name: '#仕事' }).click();
@@ -105,6 +141,63 @@ test.describe('the practice setup screen', () => {
 
     await page.getByRole('button', { name: '開始する' }).click();
     await expect(page.getByText('兆候')).toBeVisible();
+  });
+
+  /**
+   * The quick range is the one filter whose value the learner never types, so
+   * it is the one where the control and the count can disagree without anyone
+   * noticing. The clock is frozen at 2026-06-24 by `seed`, which is what makes
+   * 「直近1週間」 a fixed window here rather than a moving one.
+   */
+  test('narrows to the last week from a single chip', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/flashcards');
+    await expect(page.getByText('3 件が対象')).toBeVisible();
+
+    await page.getByRole('button', { name: '直近1週間' }).click();
+
+    // 2026-06-17 onward: two words are in this week, ちょっと is from January.
+    await expect(page.getByLabel('開始日')).toHaveValue('2026-06-17');
+    await expect(page.getByText('2 件が対象')).toBeVisible();
+  });
+
+  test('filters on 品詞 and 語種', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/flashcards');
+
+    await page.getByLabel('品詞').selectOption('副詞');
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+
+    await page.getByLabel('品詞').selectOption('');
+    await page.getByLabel('語種').selectOption('漢語');
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+  });
+
+  /**
+   * The 単語集 row is absent whenever there are none, which is the design's
+   * rule and — until `/wordsets` exists — the state of the running app. The
+   * pair of cases is what stops the row being quietly dropped altogether.
+   */
+  test('hides the 単語集 row when the learner has no sets', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/flashcards');
+
+    // Scoped to main: 単語集 is also a nav link, which is always there.
+    await expect(page.getByRole('main').getByText('JLPTレベル')).toBeVisible();
+    await expect(page.getByRole('main').getByText('単語集')).toBeHidden();
+  });
+
+  test('narrows the drill to the members of a 単語集', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/practice/flashcards');
+    await expect(page.getByText('3 件が対象')).toBeVisible();
+
+    await page.getByRole('button', { name: /仕事セット/ }).click();
+    await expect(page.getByText('2 件が対象')).toBeVisible();
+
+    // And it composes with the other chips rather than replacing them.
+    await page.getByRole('button', { name: 'N1' }).click();
+    await expect(page.getByText('1 件が対象')).toBeVisible();
   });
 
   /** `:mode` is user-editable, and the app has exactly two modes. */

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -90,6 +90,31 @@ test.describe('flashcards', () => {
     await expect(page.getByRole('button', { name: '開始する' })).toBeVisible();
   });
 
+  /**
+   * もう一度 means "those words again", not "run the filters again". The
+   * session has already been recorded by the time the summary renders, so a
+   * perfect 苦手のみ run has cleared every word it drilled — re-filtering
+   * restarts into an empty queue and a 0 / 0 summary, at the moment the learner
+   * did best.
+   */
+  test('restarts a perfect 苦手のみ session with the same words, not an empty queue', async ({
+    page,
+  }) => {
+    await seed(page, { signedIn: true, entries: WORDS, weak: ['w-choukou'] });
+    await page.goto('/practice/flashcards');
+    await page.getByRole('checkbox').check();
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    await page.getByRole('button', { name: '裏を見る' }).click();
+    await page.getByRole('button', { name: /わかった/ }).click();
+    await expect(page.getByText('1 / 1')).toBeVisible();
+
+    await page.getByRole('button', { name: 'もう一度' }).click();
+
+    await expect(page.getByLabel('進捗')).toHaveText('1 / 1');
+    await expect(page.getByRole('button', { name: /裏を見る/ })).toBeVisible();
+  });
+
   test('records the session, and the failed word comes back as 苦手', async ({ page }) => {
     await page.goto('/practice/flashcards');
     await page.getByRole('button', { name: '#仕事' }).click();
@@ -171,6 +196,19 @@ test.describe('the practice setup screen', () => {
     await page.getByLabel('品詞').selectOption('');
     await page.getByLabel('語種').selectOption('漢語');
     await expect(page.getByText('1 件が対象')).toBeVisible();
+  });
+
+  /**
+   * `weakIdsOf` counts progress rows and the drill counts entries. A word
+   * answered wrong and then deleted keeps its row — nothing prunes the map —
+   * so a count taken from the rows alone advertises words that cannot be
+   * drilled, and ticking the toggle yields nothing.
+   */
+  test('counts only the weak words that still exist', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, weak: ['w-choukou', 'deleted-long-ago'] });
+    await page.goto('/practice/flashcards');
+
+    await expect(page.getByText('苦手な語のみ')).toContainText('1 語');
   });
 
   /**

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test';
+import { seed, seedSignedIn, WORDS } from './fixtures';
+
+/**
+ * A practice session from the setup screen to the recorded result.
+ *
+ * What is only observable here: the setup screen's count agreeing with the
+ * queue it starts, the session surviving a route param change, and the fact
+ * that a finished session actually reaches the store — the 苦手のみ count on
+ * the next visit is read back from the same place the write went.
+ *
+ * What is deliberately not here: which words a filter selects, how the shuffle
+ * orders them, and whether a typed answer matches. Those are pure functions,
+ * exhaustively covered in tests/unit/practice.test.ts and
+ * tests/unit/dictation.test.ts, and a Playwright case for another filter
+ * combination costs seconds and proves less.
+ */
+
+test.describe('flashcards', () => {
+  test.beforeEach(async ({ page }) => {
+    await seedSignedIn(page);
+  });
+
+  test('counts the matches, then deals exactly that many cards', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await expect(page.getByText('3 件が対象')).toBeVisible();
+
+    // A tag chip narrows it; the count is the promise the queue has to keep.
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+
+    await page.getByRole('button', { name: '開始する' }).click();
+    await expect(page.getByLabel('進捗')).toHaveText('1 / 1');
+  });
+
+  test('blocks starting a session with nothing in it', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await page.getByRole('button', { name: 'N5' }).click();
+
+    await expect(page.getByText('0 件が対象')).toBeVisible();
+    await expect(page.getByText('条件に合う語がありません')).toBeVisible();
+    await expect(page.getByRole('button', { name: '開始する' })).toBeDisabled();
+  });
+
+  test('hides the answer buttons until the card is flipped', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    // Recording 「わかった」 before the meaning is on screen would measure
+    // confidence rather than recall, and 苦手な語 is built out of these.
+    await expect(page.getByRole('button', { name: 'わかった' })).toBeHidden();
+    await page.getByRole('button', { name: '裏を見る' }).click();
+    await expect(page.getByRole('button', { name: 'わかった' })).toBeVisible();
+  });
+
+  test('records the session, and the failed word comes back as 苦手', async ({ page }) => {
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    await page.getByRole('button', { name: '裏を見る' }).click();
+    await page.getByRole('button', { name: 'もう一度' }).click();
+
+    await expect(page.getByText('0 / 1')).toBeVisible();
+    // Matched by destination, not by name: furigana splits 切り分け into
+    // separate ruby elements, so the accessible name interleaves the readings
+    // (「切 き り 分 わ け」) and no substring of the headword survives.
+    await expect(page.getByRole('list').getByRole('link')).toHaveAttribute(
+      'href',
+      '/vocabulary/w-kiriwake',
+    );
+
+    // Read back through a fresh load of the store, not from the summary that
+    // is still on screen: the claim is that the write happened.
+    await page.goto('/practice/dictation');
+    await expect(page.getByText('苦手な語のみ')).toContainText('1 語');
+  });
+});
+
+test.describe('dictation', () => {
+  test('marks a typed answer and advances to the next word', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/dictation');
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await page.getByRole('button', { name: '開始する' }).click();
+
+    await page.getByLabel('聞こえた語').fill('きりわけ');
+    await page.getByRole('button', { name: '答え合わせ' }).click();
+
+    await expect(page.getByText('✅ 正解')).toBeVisible();
+    await page.getByRole('button', { name: '次へ' }).click();
+    await expect(page.getByText('1 / 1')).toBeVisible();
+  });
+});
+
+test.describe('the practice setup screen', () => {
+  test('offers 苦手のみ against the words already recorded wrong', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, weak: ['w-choukou'] });
+    await page.goto('/practice/flashcards');
+
+    await expect(page.getByText('苦手な語のみ')).toContainText('1 語');
+    await page.getByRole('checkbox').check();
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+
+    await page.getByRole('button', { name: '開始する' }).click();
+    await expect(page.getByText('兆候')).toBeVisible();
+  });
+
+  /** `:mode` is user-editable, and the app has exactly two modes. */
+  test('sends an unknown mode back to the dashboard', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/nonsense');
+    await expect(page).toHaveURL('/');
+  });
+});

--- a/tests/integration/progressRepo.test.ts
+++ b/tests/integration/progressRepo.test.ts
@@ -1,0 +1,208 @@
+import { randomUUID } from 'node:crypto';
+import { deleteApp, initializeApp } from 'firebase/app';
+import type { FirebaseApp } from 'firebase/app';
+import { connectFirestoreEmulator, doc, getDoc, getFirestore, Timestamp } from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { ProgressRepository } from '@/domain/ports';
+import type { EntryProgress, PracticeSessionDraft } from '@/domain/practice';
+import { createProgressRepository } from '@/infra/firebase/progressRepo';
+
+/**
+ * The progress adapter, against a real Firestore.
+ *
+ * Two claims here are unreachable from any cheaper layer, and both are about
+ * how the write lands rather than about what was computed:
+ *
+ *  - `merge: true` on the progress map. A substitute that stored objects in a
+ *    Map merges by definition; only a real write can lose the other device's
+ *    rows.
+ *  - `finishedAt` as a server value, and the cursor built from the raw
+ *    `Timestamp`. The same pairing was the pagination defect in the entries
+ *    adapter, where `tests/unit/cursor.test.ts` stayed green throughout.
+ *
+ * Same conventions as `entryRepo.test.ts`: rules bypassed with
+ * `mockUserToken`, a fresh uid per test instead of cleanup, and no parallelism
+ * with the rules file.
+ */
+
+let app: FirebaseApp;
+let db: Firestore;
+
+const freshUid = () => `it-progress-${randomUUID()}`;
+const freshRepo = (uid = freshUid()): { repo: ProgressRepository; uid: string } => ({
+  repo: createProgressRepository(db, uid),
+  uid,
+});
+
+const session = (overrides: Partial<PracticeSessionDraft> = {}): PracticeSessionDraft => ({
+  mode: 'flashcard',
+  filterLabel: 'すべての語',
+  total: 1,
+  correct: 1,
+  missed: [],
+  startedAt: '2026-06-24T09:59:00.000Z',
+  ...overrides,
+});
+
+const row = (entryId: string, overrides: Partial<EntryProgress> = {}): EntryProgress => ({
+  entryId,
+  status: 'correct',
+  lastMode: 'flashcard',
+  lastAt: '2026-06-24T10:00:00.000Z',
+  attempts: 1,
+  correctCount: 1,
+  ...overrides,
+});
+
+beforeAll(() => {
+  app = initializeApp({ projectId: 'demo-goitei' }, `progressRepo-${randomUUID()}`);
+  db = getFirestore(app);
+  connectFirestoreEmulator(db, '127.0.0.1', 8080, { mockUserToken: 'owner' });
+});
+
+afterAll(async () => {
+  await deleteApp(app);
+});
+
+describe('the progress map', () => {
+  it('reads back as the empty map for a learner who has never practised', async () => {
+    const { repo } = freshRepo();
+    await expect(repo.listAll()).resolves.toEqual([]);
+  });
+
+  it('round-trips a row through the nested map, keyed by entry id', async () => {
+    const { repo } = freshRepo();
+    await repo.recordSession(session(), [row('entry-a', { attempts: 3, correctCount: 2 })]);
+
+    const all = await repo.listAll();
+    expect(all).toEqual([
+      {
+        entryId: 'entry-a',
+        status: 'correct',
+        lastMode: 'flashcard',
+        lastAt: '2026-06-24T10:00:00.000Z',
+        attempts: 3,
+        correctCount: 2,
+      },
+    ]);
+  });
+
+  /**
+   * The defect: a write without `merge: true` replaces the whole `entries` map
+   * with whatever this session touched, so every word the learner practised in
+   * an earlier session — or on another device a minute ago — silently reverts
+   * to unpractised. Nothing on screen would show it until 苦手のみ came back
+   * with a smaller number than it had.
+   */
+  it('leaves rows this session did not answer exactly as they were', async () => {
+    const uid = freshUid();
+    const first = createProgressRepository(db, uid);
+    await first.recordSession(session(), [row('kept', { status: 'wrong', attempts: 5 })]);
+
+    // A second repository over the same uid, standing in for a second device
+    // that never read the first session's rows.
+    const second = createProgressRepository(db, uid);
+    await second.recordSession(session(), [row('added')]);
+
+    const all = await second.listAll();
+    expect(all.map((item) => item.entryId).sort()).toEqual(['added', 'kept']);
+    expect(all.find((item) => item.entryId === 'kept')).toMatchObject({
+      status: 'wrong',
+      attempts: 5,
+    });
+  });
+
+  it('overwrites a row the new session did answer', async () => {
+    const { repo } = freshRepo();
+    await repo.recordSession(session(), [row('e', { status: 'wrong', attempts: 1 })]);
+    await repo.recordSession(session(), [row('e', { status: 'correct', attempts: 2 })]);
+
+    expect(await repo.listAll()).toEqual([
+      expect.objectContaining({ status: 'correct', attempts: 2 }),
+    ]);
+  });
+});
+
+describe('recording a session', () => {
+  it('returns the new session id and files it under the owner', async () => {
+    const { repo, uid } = freshRepo();
+    const id = await repo.recordSession(
+      session({ filterLabel: '#仕事', total: 4, correct: 3 }),
+      [],
+    );
+
+    expect(id).toBeTruthy();
+    const stored = await getDoc(doc(db, 'users', uid, 'practiceSessions', id));
+    expect(stored.exists()).toBe(true);
+    expect(stored.get('ownerUid')).toBe(uid);
+    expect(stored.get('filterLabel')).toBe('#仕事');
+  });
+
+  /**
+   * `PracticeSessionDraft` omits `finishedAt` so the caller cannot supply one.
+   * A device an hour fast would otherwise file its sessions above every other
+   * row and repeat or skip them at each page boundary.
+   */
+  it('stores finishedAt as a Timestamp, which a device-written string is not', async () => {
+    const { repo, uid } = freshRepo();
+    const id = await repo.recordSession(session(), []);
+
+    // Read raw, before the mapper turns it into a string. Comparing the mapped
+    // value against `Date.now()` proves nothing: a clock an hour fast produces
+    // a plausible-looking instant and passes, and the cursor still breaks.
+    const stored = await getDoc(doc(db, 'users', uid, 'practiceSessions', id));
+    expect(stored.get('finishedAt')).toBeInstanceOf(Timestamp);
+    expect(stored.get('startedAt')).toBe('2026-06-24T09:59:00.000Z');
+  });
+
+  /** The two documents are one batch, so a listing can never see half of it. */
+  it('writes the session and the progress map together', async () => {
+    const { repo } = freshRepo();
+    await repo.recordSession(session(), [row('e')]);
+
+    expect((await repo.listSessions({ limit: 5, cursor: null })).items).toHaveLength(1);
+    expect(await repo.listAll()).toHaveLength(1);
+  });
+});
+
+describe('paging through 履歴', () => {
+  it('returns sessions newest first', async () => {
+    const { repo } = freshRepo();
+    for (const label of ['一', '二', '三']) {
+      await repo.recordSession(session({ filterLabel: label }), []);
+    }
+
+    const page = await repo.listSessions({ limit: 5, cursor: null });
+    expect(page.items.map((item) => item.filterLabel)).toEqual(['三', '二', '一']);
+    expect(page.cursor).toBeNull();
+  });
+
+  /**
+   * Walked one page at a time, asserting every row is seen exactly once. The
+   * page guard is not decoration: under the cursor defect this adapter's shape
+   * inherits, the loop never terminates and the test times out instead of
+   * failing — which reads as flake rather than as the regression it is.
+   */
+  it('walks every session exactly once across page boundaries', async () => {
+    const { repo } = freshRepo();
+    const labels = ['a', 'b', 'c', 'd', 'e'];
+    for (const label of labels) await repo.recordSession(session({ filterLabel: label }), []);
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      const page: Awaited<ReturnType<ProgressRepository['listSessions']>> = await repo.listSessions(
+        { limit: 2, cursor },
+      );
+      seen.push(...page.items.map((item) => item.filterLabel));
+      cursor = page.cursor;
+      pages += 1;
+      expect(pages).toBeLessThanOrEqual(10);
+    } while (cursor);
+
+    expect(seen).toHaveLength(labels.length);
+    expect(new Set(seen).size).toBe(labels.length);
+  });
+});

--- a/tests/integration/wordSetRepo.test.ts
+++ b/tests/integration/wordSetRepo.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto';
+import { deleteApp, initializeApp } from 'firebase/app';
+import type { FirebaseApp } from 'firebase/app';
+import { connectFirestoreEmulator, doc, getDoc, getFirestore } from 'firebase/firestore';
+import type { Firestore } from 'firebase/firestore';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { WordSetRepository } from '@/domain/ports';
+import type { WordSetDraft } from '@/domain/wordSet';
+import { createWordSetRepository } from '@/infra/firebase/wordSetRepo';
+
+/**
+ * The 単語集 adapter, against a real Firestore.
+ *
+ * Thin by design — it is the entries adapter's shape with a different
+ * collection — so this covers only what is specific to it: that `entryIds`
+ * survives a round trip in order, that a duplicate cannot get in, and that
+ * deleting a set does not touch the words in it. Everything about cursors is
+ * already proved on `entryRepo`, whose query this copies verbatim.
+ *
+ * Same conventions as the other integration files: rules bypassed with
+ * `mockUserToken`, a fresh uid per test instead of cleanup.
+ */
+
+let app: FirebaseApp;
+let db: Firestore;
+
+const freshUid = () => `it-sets-${randomUUID()}`;
+
+const draft = (overrides: Partial<WordSetDraft> = {}): WordSetDraft => ({
+  name: '仕事の語',
+  description: '',
+  entryIds: [],
+  level: '',
+  topics: [],
+  ...overrides,
+});
+
+beforeAll(() => {
+  app = initializeApp({ projectId: 'demo-goitei' }, `wordSetRepo-${randomUUID()}`);
+  db = getFirestore(app);
+  connectFirestoreEmulator(db, '127.0.0.1', 8080, { mockUserToken: 'owner' });
+});
+
+afterAll(async () => {
+  await deleteApp(app);
+});
+
+const freshRepo = (uid = freshUid()): { repo: WordSetRepository; uid: string } => ({
+  repo: createWordSetRepository(db, uid),
+  uid,
+});
+
+describe('membership', () => {
+  /**
+   * The order of `entryIds` *is* the study order — it is why membership lives
+   * on the set rather than on the entry — so an adapter that let Firestore or
+   * the sanitiser reorder it would silently discard the one thing this shape
+   * was chosen for.
+   */
+  it('round-trips entryIds in the order they were given', async () => {
+    const { repo } = freshRepo();
+    const id = await repo.create(draft({ entryIds: ['c', 'a', 'b'] }));
+
+    expect((await repo.get(id))?.entryIds).toEqual(['c', 'a', 'b']);
+  });
+
+  /** A duplicate would deal the same card twice inside one session. */
+  it('drops a repeated id on the way in', async () => {
+    const { repo } = freshRepo();
+    const id = await repo.create(draft({ entryIds: ['a', 'b', 'a'] }));
+
+    expect((await repo.get(id))?.entryIds).toEqual(['a', 'b']);
+  });
+
+  it('stamps ownership and publication state the caller never supplied', async () => {
+    const { repo, uid } = freshRepo();
+    const id = await repo.create(draft());
+
+    const stored = await repo.get(id);
+    expect(stored?.ownerUid).toBe(uid);
+    expect(stored?.publishedId).toBeNull();
+    expect(stored?.publishedVersion).toBe(0);
+  });
+
+  it('replaces the member list on update, keeping createdAt', async () => {
+    const { repo } = freshRepo();
+    const id = await repo.create(draft({ entryIds: ['a'] }));
+    const before = await repo.get(id);
+
+    await repo.update(id, draft({ name: '改名', entryIds: ['b', 'c'] }));
+
+    const after = await repo.get(id);
+    expect(after?.entryIds).toEqual(['b', 'c']);
+    expect(after?.name).toBe('改名');
+    expect(after?.createdAt).toBe(before?.createdAt);
+  });
+});
+
+describe('deleting a set', () => {
+  /**
+   * A 単語集 is a view over words that exist on their own. Firestore has no
+   * cascade, so nothing here *could* remove the entries — this asserts that
+   * the adapter does not go looking for them either.
+   */
+  it('removes the set and leaves the entries it named alone', async () => {
+    const { repo, uid } = freshRepo();
+    const id = await repo.create(draft({ entryIds: ['kept-entry'] }));
+
+    await repo.remove(id);
+
+    expect(await repo.get(id)).toBeNull();
+    // The id is only ever a reference; nothing under entries/ was written by
+    // this repository, so the check is that the set document is what went.
+    const gone = await getDoc(doc(db, 'users', uid, 'wordSets', id));
+    expect(gone.exists()).toBe(false);
+  });
+});
+
+describe('listing', () => {
+  it('returns sets newest first', async () => {
+    const { repo } = freshRepo();
+    for (const name of ['一', '二', '三']) await repo.create(draft({ name }));
+
+    const page = await repo.list({ limit: 10, cursor: null });
+    expect(page.items.map((item) => item.name)).toEqual(['三', '二', '一']);
+    expect(page.cursor).toBeNull();
+  });
+
+  it('walks every set exactly once across page boundaries', async () => {
+    const { repo } = freshRepo();
+    const names = ['a', 'b', 'c', 'd', 'e'];
+    for (const name of names) await repo.create(draft({ name }));
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      const page: Awaited<ReturnType<WordSetRepository['list']>> = await repo.list({
+        limit: 2,
+        cursor,
+      });
+      seen.push(...page.items.map((item) => item.name));
+      cursor = page.cursor;
+      pages += 1;
+      // Without this the cursor defect hangs the test instead of failing it.
+      expect(pages).toBeLessThanOrEqual(10);
+    } while (cursor);
+
+    expect(new Set(seen).size).toBe(names.length);
+  });
+});

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -92,7 +92,10 @@ describe('private data under users/{uid}', () => {
   it('denies the subcollections too, not just the top document', async () => {
     const db = as(BOB);
     await assertFails(db.doc(`users/${ALICE}/wordSets/s1`).get());
-    await assertFails(db.doc(`users/${ALICE}/entryProgress/e1`).set({ attempts: 1 }));
+    // The practice paths the app actually writes: one document holding every
+    // word's progress, and one document per finished session.
+    await assertFails(db.doc(`users/${ALICE}/progress/entries`).get());
+    await assertFails(db.doc(`users/${ALICE}/progress/entries`).set({ entries: {} }));
     await assertFails(db.doc(`users/${ALICE}/practiceSessions/p1`).set({ total: 1 }));
   });
 

--- a/tests/unit/dictation.test.ts
+++ b/tests/unit/dictation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { acceptedAnswers, isCorrectAnswer, normaliseAnswer, spokenForm } from '@/lib/dictation';
+
+/**
+ * Marking a typed answer. Every case here is one where the screen shows two
+ * identical-looking strings and `===` disagrees, or where the drill would be
+ * unfair for a reason the learner cannot see.
+ */
+describe('normaliseAnswer', () => {
+  /**
+   * Half-width katakana is what a Japanese keyboard produces in half-width
+   * mode, and what several Windows IMEs still emit by default.
+   */
+  it('folds half-width katakana ﾁｮｯﾄ onto the same value as ちょっと', () => {
+    expect(normaliseAnswer('ﾁｮｯﾄ')).toBe(normaliseAnswer('ちょっと'));
+  });
+
+  it('drops the ideographic space U+3000 that a Japanese keyboard produces', () => {
+    expect(normaliseAnswer('兆　候')).toBe('兆候');
+    expect(normaliseAnswer('  ちょうこう ')).toBe('ちょうこう');
+  });
+
+  it('folds katakana onto hiragana, because script is not audible', () => {
+    expect(normaliseAnswer('チョット')).toBe('ちょっと');
+    expect(normaliseAnswer('ヴァイオリン')).toBe('ゔぁいおりん');
+  });
+
+  /**
+   * The prolonged sound mark and the middle dot have no hiragana counterpart at
+   * −0x60, so a fold that walked the whole katakana block would map them into
+   * unrelated characters and quietly break every 外来語.
+   */
+  it('leaves ー and ・ alone rather than shifting them out of the block', () => {
+    expect(normaliseAnswer('コーヒー')).toBe('こーひー');
+    expect(normaliseAnswer('ア・イ')).toBe('あ・い');
+  });
+});
+
+describe('acceptedAnswers', () => {
+  it('accepts the written form and the reading', () => {
+    expect(acceptedAnswers({ headword: '兆候', reading: 'ちょうこう' })).toEqual([
+      '兆候',
+      'ちょうこう',
+    ]);
+  });
+
+  /**
+   * `reading` is empty whenever the headword is already kana. Leaving that
+   * empty string in the list makes a blank submission match, because a blank
+   * submission also normalises to the empty string.
+   */
+  it('drops the empty reading instead of accepting an empty answer', () => {
+    expect(acceptedAnswers({ headword: 'ちょっと', reading: '' })).toEqual(['ちょっと']);
+  });
+});
+
+describe('isCorrectAnswer', () => {
+  const entry = { headword: '兆候', reading: 'ちょうこう' };
+
+  it.each(['兆候', 'ちょうこう', 'チョウコウ', '　ちょうこう　'])('accepts %s', (typed) => {
+    expect(isCorrectAnswer(typed, entry)).toBe(true);
+  });
+
+  it.each(['', '   ', 'ちょうこ', '徴候'])('rejects %o', (typed) => {
+    expect(isCorrectAnswer(typed, entry)).toBe(false);
+  });
+
+  /** The defect `acceptedAnswers` exists to prevent, asserted end to end. */
+  it('rejects an empty answer for a kana headword, which has no reading to fall back on', () => {
+    expect(isCorrectAnswer('', { headword: 'ちょっと', reading: '' })).toBe(false);
+  });
+});
+
+describe('spokenForm', () => {
+  /**
+   * A TTS voice reading 「辛い」 has no sentence to disambiguate from, so it
+   * guesses — and a guess of からい makes つらい unanswerable.
+   */
+  it('speaks the kana reading rather than the kanji it could misread', () => {
+    expect(spokenForm({ headword: '辛い', reading: 'つらい' })).toBe('つらい');
+  });
+
+  it('falls back to the headword when the word is already kana', () => {
+    expect(spokenForm({ headword: 'ちょっと', reading: '' })).toBe('ちょっと');
+  });
+});

--- a/tests/unit/practice.test.ts
+++ b/tests/unit/practice.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import type { EntryProgress } from '@/domain/practice';
+import {
+  describeFilters,
+  EMPTY_PRACTICE_FILTERS,
+  matchesPractice,
+  mergeProgress,
+  shuffle,
+  summariseSession,
+  weakIdsOf,
+} from '@/lib/practice';
+import { makeEntry } from '../fixtures/entry';
+
+const progress = (overrides: Partial<EntryProgress> & { entryId: string }): EntryProgress => ({
+  status: 'correct',
+  lastMode: 'flashcard',
+  lastAt: '2026-06-20T00:00:00.000Z',
+  attempts: 1,
+  correctCount: 1,
+  ...overrides,
+});
+
+describe('weakIdsOf', () => {
+  /**
+   * 苦手な語 is the most recent attempt, never a ratio. A word answered wrong
+   * nine times and right today is not weak any more, and a list that kept it
+   * would stop being the thing a learner drills.
+   */
+  it('takes the latest status only, so a correct answer clears a word', () => {
+    const weak = weakIdsOf([
+      progress({ entryId: 'a', status: 'wrong' }),
+      progress({ entryId: 'b', status: 'correct', attempts: 10, correctCount: 1 }),
+    ]);
+    expect([...weak]).toEqual(['a']);
+  });
+});
+
+describe('matchesPractice', () => {
+  const entry = makeEntry({ id: 'e1', tags: ['仕事'], jlpt: 'N2' });
+  const weak = new Set(['e9']);
+
+  it('selects everything when no filter is set', () => {
+    expect(matchesPractice(entry, EMPTY_PRACTICE_FILTERS, weak)).toBe(true);
+  });
+
+  /** Chips within one filter are OR, matching Browse. An AND would return nothing. */
+  it('treats two levels as "either level", not "both"', () => {
+    const filters = { ...EMPTY_PRACTICE_FILTERS, jlpt: ['N1', 'N2'] };
+    expect(matchesPractice(entry, filters, weak)).toBe(true);
+  });
+
+  it('combines different filters with AND', () => {
+    expect(
+      matchesPractice(entry, { ...EMPTY_PRACTICE_FILTERS, tags: ['仕事'], jlpt: ['N1'] }, weak),
+    ).toBe(false);
+  });
+
+  it('excludes an entry with no failed attempt when 苦手のみ is on', () => {
+    const filters = { ...EMPTY_PRACTICE_FILTERS, weakOnly: true };
+    expect(matchesPractice(entry, filters, weak)).toBe(false);
+    expect(matchesPractice(entry, filters, new Set(['e1']))).toBe(true);
+  });
+});
+
+describe('shuffle', () => {
+  /**
+   * A shuffle that only ever moved one element passes a length check and a
+   * membership check, and is a broken drill. Pinning the randomness is the only
+   * way to assert on the order it actually produces.
+   */
+  it('permutes the whole list, not just the ends', () => {
+    // Always picks index 0 as the swap target, which walks the first element
+    // to the end and moves every other element down one.
+    expect(shuffle([1, 2, 3, 4], () => 0)).toEqual([2, 3, 4, 1]);
+  });
+
+  it('keeps every element exactly once', () => {
+    const source = [1, 2, 3, 4, 5];
+    let seed = 0.17;
+    const result = shuffle(source, () => (seed = (seed * 9301 + 0.49297) % 1));
+    expect([...result].sort()).toEqual(source);
+  });
+
+  it('does not mutate its input', () => {
+    const source = [1, 2, 3];
+    shuffle(source, () => 0);
+    expect(source).toEqual([1, 2, 3]);
+  });
+});
+
+describe('describeFilters', () => {
+  it('reads back the chips that were on', () => {
+    expect(describeFilters({ tags: ['仕事'], jlpt: ['N1'], weakOnly: true })).toBe(
+      '#仕事 / N1 / 苦手のみ',
+    );
+  });
+
+  /** 履歴 shows this string, and an empty cell there says nothing. */
+  it('names the unfiltered case rather than returning an empty label', () => {
+    expect(describeFilters(EMPTY_PRACTICE_FILTERS)).toBe('すべての語');
+  });
+});
+
+describe('mergeProgress', () => {
+  const at = '2026-06-24T10:00:00.000Z';
+
+  it('adds to the previous counts instead of restarting them', () => {
+    const merged = mergeProgress(
+      [progress({ entryId: 'a', attempts: 3, correctCount: 2, status: 'wrong' })],
+      [{ entryId: 'a', correct: true }],
+      'dictation',
+      at,
+    );
+    expect(merged).toEqual([
+      {
+        entryId: 'a',
+        status: 'correct',
+        lastMode: 'dictation',
+        lastAt: at,
+        attempts: 4,
+        correctCount: 3,
+      },
+    ]);
+  });
+
+  it('starts a word that has never been practised at one attempt', () => {
+    const [row] = mergeProgress([], [{ entryId: 'new', correct: false }], 'flashcard', at);
+    expect(row).toMatchObject({ attempts: 1, correctCount: 0, status: 'wrong' });
+  });
+
+  /**
+   * The rows returned are written to Firestore with `merge: true`. Returning
+   * every known row instead of only the answered ones would make each session
+   * rewrite the whole map — which is how a session finished on one device
+   * silently reverts one finished on another.
+   */
+  it('returns only the entries this session answered', () => {
+    const merged = mergeProgress(
+      [progress({ entryId: 'a' }), progress({ entryId: 'untouched' })],
+      [{ entryId: 'a', correct: true }],
+      'flashcard',
+      at,
+    );
+    expect(merged.map((row) => row.entryId)).toEqual(['a']);
+  });
+});
+
+describe('summariseSession', () => {
+  it('counts the answers and lists the ids that were missed', () => {
+    expect(
+      summariseSession({
+        mode: 'flashcard',
+        filterLabel: '#仕事',
+        answers: [
+          { entryId: 'a', correct: true },
+          { entryId: 'b', correct: false },
+          { entryId: 'c', correct: false },
+        ],
+        startedAt: '2026-06-24T09:59:00.000Z',
+      }),
+    ).toEqual({
+      mode: 'flashcard',
+      filterLabel: '#仕事',
+      total: 3,
+      correct: 1,
+      missed: ['b', 'c'],
+      startedAt: '2026-06-24T09:59:00.000Z',
+    });
+  });
+});

--- a/tests/unit/practice.test.ts
+++ b/tests/unit/practice.test.ts
@@ -1,15 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import type { EntryProgress } from '@/domain/practice';
+import type { WordSet } from '@/domain/wordSet';
 import {
+  activeQuickRange,
   describeFilters,
   EMPTY_PRACTICE_FILTERS,
   matchesPractice,
   mergeProgress,
+  quickRangeStart,
+  scopeFor,
   shuffle,
   summariseSession,
   weakIdsOf,
 } from '@/lib/practice';
 import { makeEntry } from '../fixtures/entry';
+
+const makeSet = (id: string, name: string, entryIds: string[]): WordSet => ({
+  id,
+  ownerUid: 'uid-alice',
+  name,
+  description: '',
+  entryIds,
+  level: '',
+  topics: [],
+  publishedId: null,
+  publishedVersion: 0,
+  copiedFrom: null,
+  createdAt: '2026-06-01T00:00:00.000Z',
+  updatedAt: '2026-06-01T00:00:00.000Z',
+});
 
 const progress = (overrides: Partial<EntryProgress> & { entryId: string }): EntryProgress => ({
   status: 'correct',
@@ -37,28 +56,106 @@ describe('weakIdsOf', () => {
 
 describe('matchesPractice', () => {
   const entry = makeEntry({ id: 'e1', tags: ['仕事'], jlpt: 'N2' });
-  const weak = new Set(['e9']);
+  /** Nothing weak, no set selected — the baseline every case narrows from. */
+  const scope = { weak: new Set(['e9']), inSets: null };
 
   it('selects everything when no filter is set', () => {
-    expect(matchesPractice(entry, EMPTY_PRACTICE_FILTERS, weak)).toBe(true);
+    expect(matchesPractice(entry, EMPTY_PRACTICE_FILTERS, scope)).toBe(true);
   });
 
   /** Chips within one filter are OR, matching Browse. An AND would return nothing. */
   it('treats two levels as "either level", not "both"', () => {
     const filters = { ...EMPTY_PRACTICE_FILTERS, jlpt: ['N1', 'N2'] };
-    expect(matchesPractice(entry, filters, weak)).toBe(true);
+    expect(matchesPractice(entry, filters, scope)).toBe(true);
+  });
+
+  /** An entry carries several 品詞, so this is membership, not equality. */
+  it('matches 品詞 against every part of speech the entry carries', () => {
+    const verbal = makeEntry({ pos: ['名詞', '動詞'] });
+    expect(matchesPractice(verbal, { ...EMPTY_PRACTICE_FILTERS, pos: '動詞' }, scope)).toBe(true);
+    expect(matchesPractice(verbal, { ...EMPTY_PRACTICE_FILTERS, pos: '副詞' }, scope)).toBe(false);
+  });
+
+  it('matches 語種 exactly', () => {
+    expect(matchesPractice(entry, { ...EMPTY_PRACTICE_FILTERS, origin: '漢語' }, scope)).toBe(true);
+    expect(matchesPractice(entry, { ...EMPTY_PRACTICE_FILTERS, origin: '和語' }, scope)).toBe(
+      false,
+    );
+  });
+
+  describe('the learning-date range', () => {
+    const on = (learnedOn: string) => makeEntry({ learnedOn });
+
+    /** Both ends are inclusive, so a word learned on the boundary is in. */
+    it('includes the first and last day of the range', () => {
+      const filters = { ...EMPTY_PRACTICE_FILTERS, from: '2026-06-01', to: '2026-06-30' };
+      expect(matchesPractice(on('2026-06-01'), filters, scope)).toBe(true);
+      expect(matchesPractice(on('2026-06-30'), filters, scope)).toBe(true);
+      expect(matchesPractice(on('2026-05-31'), filters, scope)).toBe(false);
+      expect(matchesPractice(on('2026-07-01'), filters, scope)).toBe(false);
+    });
+
+    it('leaves the other end unbounded when only one is set', () => {
+      expect(
+        matchesPractice(on('2030-01-01'), { ...EMPTY_PRACTICE_FILTERS, from: '2026-06-01' }, scope),
+      ).toBe(true);
+      expect(
+        matchesPractice(on('1999-01-01'), { ...EMPTY_PRACTICE_FILTERS, to: '2026-06-01' }, scope),
+      ).toBe(true);
+    });
   });
 
   it('combines different filters with AND', () => {
     expect(
-      matchesPractice(entry, { ...EMPTY_PRACTICE_FILTERS, tags: ['仕事'], jlpt: ['N1'] }, weak),
+      matchesPractice(entry, { ...EMPTY_PRACTICE_FILTERS, tags: ['仕事'], jlpt: ['N1'] }, scope),
     ).toBe(false);
   });
 
   it('excludes an entry with no failed attempt when 苦手のみ is on', () => {
     const filters = { ...EMPTY_PRACTICE_FILTERS, weakOnly: true };
-    expect(matchesPractice(entry, filters, weak)).toBe(false);
-    expect(matchesPractice(entry, filters, new Set(['e1']))).toBe(true);
+    expect(matchesPractice(entry, filters, scope)).toBe(false);
+    expect(matchesPractice(entry, filters, { weak: new Set(['e1']), inSets: null })).toBe(true);
+  });
+});
+
+describe('scopeFor — 単語集', () => {
+  const sets = [makeSet('s1', '仕事', ['a', 'b']), makeSet('s2', '旅行', ['b', 'c'])];
+  const weak = new Set<string>();
+
+  /**
+   * Null, not an empty set. The two mean opposite things — "do not filter by
+   * set" and "a set with nothing in it" — and collapsing them makes selecting
+   * an empty 単語集 deal the entire notebook.
+   */
+  it('does not filter at all when no set is selected', () => {
+    expect(scopeFor(EMPTY_PRACTICE_FILTERS, sets, weak).inSets).toBeNull();
+  });
+
+  it('yields an empty membership for a set with no words, not a null one', () => {
+    const empty = [makeSet('s3', '空', [])];
+    const scope = scopeFor({ ...EMPTY_PRACTICE_FILTERS, sets: ['s3'] }, empty, weak);
+    expect(scope.inSets?.size).toBe(0);
+    expect(
+      matchesPractice(makeEntry({ id: 'a' }), { ...EMPTY_PRACTICE_FILTERS, sets: ['s3'] }, scope),
+    ).toBe(false);
+  });
+
+  /** Two sets is "either set", the same rule the tag and level chips follow. */
+  it('unions the members of every selected set, counting a shared word once', () => {
+    const scope = scopeFor({ ...EMPTY_PRACTICE_FILTERS, sets: ['s1', 's2'] }, sets, weak);
+    expect([...(scope.inSets ?? [])].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('ignores a selected id that no longer names a set', () => {
+    const scope = scopeFor({ ...EMPTY_PRACTICE_FILTERS, sets: ['gone'] }, sets, weak);
+    expect(scope.inSets?.size).toBe(0);
+  });
+
+  it('keeps a word out of the drill when it is in no selected set', () => {
+    const filters = { ...EMPTY_PRACTICE_FILTERS, sets: ['s1'] };
+    const scope = scopeFor(filters, sets, weak);
+    expect(matchesPractice(makeEntry({ id: 'a' }), filters, scope)).toBe(true);
+    expect(matchesPractice(makeEntry({ id: 'c' }), filters, scope)).toBe(false);
   });
 });
 
@@ -88,11 +185,74 @@ describe('shuffle', () => {
   });
 });
 
+describe('quick ranges', () => {
+  // A Tuesday, deliberately the 31st — the day the naive implementation breaks.
+  const NOW = new Date(2026, 2, 31, 10, 0, 0);
+
+  it('reads 直近1週間 as seven days back', () => {
+    expect(quickRangeStart('week', NOW)).toBe('2026-03-24');
+  });
+
+  /**
+   * The defect: `setMonth(month - 1)` on 3月31日 asks for 2月31日, which `Date`
+   * rolls forward to 3月3日. 「直近1ヶ月」 would then start three days *after*
+   * the day it was clicked, and a range meant to widen the drill would return
+   * almost nothing.
+   */
+  it('clamps 直近1ヶ月 from the 31st to the last day of a shorter month', () => {
+    expect(quickRangeStart('month', NOW)).toBe('2026-02-28');
+  });
+
+  it('reads 直近1年 as the same day twelve months back', () => {
+    expect(quickRangeStart('year', NOW)).toBe('2025-03-31');
+  });
+
+  it('reports which chip the current bounds are', () => {
+    const filters = { ...EMPTY_PRACTICE_FILTERS, from: '2026-03-24' };
+    expect(activeQuickRange(filters, NOW)).toBe('week');
+    expect(activeQuickRange({ ...EMPTY_PRACTICE_FILTERS, from: '2026-03-01' }, NOW)).toBeNull();
+    expect(activeQuickRange(EMPTY_PRACTICE_FILTERS, NOW)).toBeNull();
+  });
+
+  /**
+   * A quick range sets only the start. Once an end is typed in, no chip
+   * describes the window any more, and one showing as selected would be
+   * claiming a range the drill is not using.
+   */
+  it('reports no chip once an end date narrows the range by hand', () => {
+    const filters = { ...EMPTY_PRACTICE_FILTERS, from: '2026-03-24', to: '2026-03-28' };
+    expect(activeQuickRange(filters, NOW)).toBeNull();
+  });
+});
+
 describe('describeFilters', () => {
   it('reads back the chips that were on', () => {
-    expect(describeFilters({ tags: ['仕事'], jlpt: ['N1'], weakOnly: true })).toBe(
-      '#仕事 / N1 / 苦手のみ',
-    );
+    expect(
+      describeFilters({ ...EMPTY_PRACTICE_FILTERS, tags: ['仕事'], jlpt: ['N1'], weakOnly: true }),
+    ).toBe('#仕事 / N1 / 苦手のみ');
+  });
+
+  /**
+   * Written out as days, never as 「直近1ヶ月」. The label is stored on the
+   * session and read back in 履歴 weeks later, where a relative phrase would
+   * describe a different window every time it is read.
+   */
+  it('records a quick range as the days it resolved to', () => {
+    expect(describeFilters({ ...EMPTY_PRACTICE_FILTERS, from: '2026-02-28' })).toBe('2026-02-28〜');
+    expect(
+      describeFilters({ ...EMPTY_PRACTICE_FILTERS, pos: '動詞', origin: '和語', to: '2026-03-31' }),
+    ).toBe('動詞 / 和語 / 〜2026-03-31');
+  });
+
+  /**
+   * By name, because 履歴 is read by a person weeks later. A set deleted in
+   * between is named as missing rather than dropped: silently omitting a
+   * filter would misdescribe which words the session actually drilled.
+   */
+  it('names the 単語集, and says so when one has since been deleted', () => {
+    const sets = [makeSet('s1', '仕事', [])];
+    expect(describeFilters({ ...EMPTY_PRACTICE_FILTERS, sets: ['s1'] }, sets)).toBe('単語集:仕事');
+    expect(describeFilters({ ...EMPTY_PRACTICE_FILTERS, sets: ['s1'] }, [])).toBe('単語集:不明');
   });
 
   /** 履歴 shows this string, and an empty cell there says nothing. */

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toDraft } from '@/lib/draft';
-import { isValidIsoDate, sanitizeDraft, sanitizeEntry } from '@/lib/sanitize';
+import { isValidIsoDate, sanitizeDraft, sanitizeEntry, sanitizeProgressMap } from '@/lib/sanitize';
 import { makeEntry } from '../fixtures/entry';
 
 /**
@@ -326,5 +326,39 @@ describe('sanitizeEntry — a document from the previous schema', () => {
     expect(() => sanitizeEntry('x', {})).not.toThrow();
     expect(() => sanitizeEntry('x', null)).not.toThrow();
     expect(sanitizeEntry('x', 'corrupt').headword).toBe('');
+  });
+});
+
+/**
+ * The progress map is a single document, so unlike an entry there is no "one
+ * bad row, one bad card" containment: whatever this returns is every word's
+ * practice state at once.
+ */
+describe('sanitizeProgressMap', () => {
+  it('keeps the good rows when one key holds something unusable', () => {
+    const rows = sanitizeProgressMap({
+      good: { status: 'correct', lastMode: 'dictation', attempts: 2, correctCount: 2 },
+      broken: 'not an object',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows.find((row) => row.entryId === 'good')).toMatchObject({
+      status: 'correct',
+      attempts: 2,
+    });
+  });
+
+  /**
+   * The direction of the default is the point. An unreadable row surfaces the
+   * word in 苦手な語, where the learner sees it and drills it again; defaulting
+   * to 'correct' would drop a word they are getting wrong out of the one list
+   * built to catch that.
+   */
+  it("defaults an unreadable row to 'wrong', so it surfaces rather than disappears", () => {
+    expect(sanitizeProgressMap({ broken: null })[0]).toMatchObject({
+      entryId: 'broken',
+      status: 'wrong',
+      attempts: 0,
+    });
   });
 });

--- a/tests/unit/speech.test.ts
+++ b/tests/unit/speech.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { japaneseVoices, pickJapaneseVoice } from '@/lib/speech';
+import { japaneseVoices, pickJapaneseVoice, speechCandidates } from '@/lib/speech';
 
 /**
  * Choosing a voice, which is the step that decides whether the dictation drill
@@ -56,5 +56,37 @@ describe('pickJapaneseVoice', () => {
 
   it('returns null when nothing can read Japanese', () => {
     expect(pickJapaneseVoice(NO_JAPANESE)).toBeNull();
+  });
+});
+
+/**
+ * The order attempts are made in, which is what decides whether the drill makes
+ * a sound on a Mac that lists nine Japanese voices and can play none of them.
+ */
+describe('speechCandidates', () => {
+  const KYOKO = voice('ja-JP', 'Kyoko', true);
+  const GOOGLE = voice('ja-JP', 'Google 日本語', false);
+
+  /**
+   * The reported machine, exactly: nine local system voices and one network
+   * voice. `localService` says where a voice *would* come from, not whether
+   * macOS has ever downloaded it — so the network voice has to be reachable as
+   * a fallback, not filtered out as second-rate.
+   */
+  it('tries the local voice, then the network one, then the browser default', () => {
+    const list = [KYOKO, voice('ja-JP', 'Grandma (Japanese (Japan))'), GOOGLE];
+    expect(speechCandidates(list).map((item) => item?.name ?? null)).toEqual([
+      'Kyoko',
+      'Google 日本語',
+      null,
+    ]);
+  });
+
+  it('does not repeat the browser default when there is no network voice', () => {
+    expect(speechCandidates([KYOKO]).map((item) => item?.name ?? null)).toEqual(['Kyoko', null]);
+  });
+
+  it('still offers the default attempt when nothing Japanese is listed', () => {
+    expect(speechCandidates([voice('en-US', 'Samantha')])).toEqual([null]);
   });
 });

--- a/tests/unit/speech.test.ts
+++ b/tests/unit/speech.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { japaneseVoices, pickJapaneseVoice, speechCandidates } from '@/lib/speech';
+import { japaneseVoices, speechCandidates } from '@/lib/speech';
 
 /**
  * Choosing a voice, which is the step that decides whether the dictation drill
@@ -40,25 +40,6 @@ describe('japaneseVoices', () => {
   });
 });
 
-describe('pickJapaneseVoice', () => {
-  /**
-   * A network voice is silent whenever the connection is, and this is a drill
-   * somebody may be doing on a train.
-   */
-  it('prefers a voice that runs on the device over a network one', () => {
-    const list = [voice('ja-JP', 'Google 日本語', false), voice('ja-JP', 'Kyoko', true)];
-    expect(pickJapaneseVoice(list)?.name).toBe('Kyoko');
-  });
-
-  it('takes a network voice rather than none at all', () => {
-    expect(pickJapaneseVoice([voice('ja-JP', 'Google 日本語', false)])?.name).toBe('Google 日本語');
-  });
-
-  it('returns null when nothing can read Japanese', () => {
-    expect(pickJapaneseVoice(NO_JAPANESE)).toBeNull();
-  });
-});
-
 /**
  * The order attempts are made in, which is what decides whether the drill makes
  * a sound on a Mac that lists nine Japanese voices and can play none of them.
@@ -88,5 +69,19 @@ describe('speechCandidates', () => {
 
   it('still offers the default attempt when nothing Japanese is listed', () => {
     expect(speechCandidates([voice('en-US', 'Samantha')])).toEqual([null]);
+  });
+
+  /**
+   * The case that got through: with no local voice, `?? null` produced a null
+   * in the first slot that deduped against the trailing fallback, so the
+   * browser's own guess was tried *before* the explicitly Japanese voice — on
+   * exactly the machine the network voice exists for.
+   */
+  it('keeps the network voice ahead of the default when there is no local one', () => {
+    const list = [voice('en-US', 'Samantha'), GOOGLE];
+    expect(speechCandidates(list).map((item) => item?.name ?? null)).toEqual([
+      'Google 日本語',
+      null,
+    ]);
   });
 });

--- a/tests/unit/speech.test.ts
+++ b/tests/unit/speech.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { japaneseVoices, pickJapaneseVoice } from '@/lib/speech';
+
+/**
+ * Choosing a voice, which is the step that decides whether the dictation drill
+ * makes a sound at all.
+ *
+ * `speechSynthesis` exists in every desktop browser and reports nothing when it
+ * cannot honour a request, so every case here is one where the button looks
+ * enabled and stays silent.
+ */
+const voice = (lang: string, name: string, localService = true) =>
+  ({ lang, name, localService, default: false, voiceURI: name }) as SpeechSynthesisVoice;
+
+/** What a macOS machine with the Japanese voice never installed reports. */
+const NO_JAPANESE = [voice('en-US', 'Samantha'), voice('en-GB', 'Daniel')];
+
+describe('japaneseVoices', () => {
+  it('finds ja-JP among a list dominated by other languages', () => {
+    const list = [...NO_JAPANESE, voice('ja-JP', 'Kyoko')];
+    expect(japaneseVoices(list).map((item) => item.name)).toEqual(['Kyoko']);
+  });
+
+  /**
+   * Some platforms report the tag with an underscore. Testing for the literal
+   * `'ja-JP'` finds nothing on those, and the drill goes quiet on exactly the
+   * machines that do have a Japanese voice.
+   */
+  it.each(['ja_JP', 'JA-JP', 'ja'])('accepts the tag written as %s', (lang) => {
+    expect(japaneseVoices([voice(lang, 'x')])).toHaveLength(1);
+  });
+
+  it('finds none when the machine has no Japanese voice installed', () => {
+    expect(japaneseVoices(NO_JAPANESE)).toEqual([]);
+  });
+
+  /** `ja` must not match `jamo`, `java` or any other tag that starts with it. */
+  it('does not match an unrelated tag that merely begins with ja', () => {
+    expect(japaneseVoices([voice('jam-XX', 'Jamaican')])).toEqual([]);
+  });
+});
+
+describe('pickJapaneseVoice', () => {
+  /**
+   * A network voice is silent whenever the connection is, and this is a drill
+   * somebody may be doing on a train.
+   */
+  it('prefers a voice that runs on the device over a network one', () => {
+    const list = [voice('ja-JP', 'Google 日本語', false), voice('ja-JP', 'Kyoko', true)];
+    expect(pickJapaneseVoice(list)?.name).toBe('Kyoko');
+  });
+
+  it('takes a network voice rather than none at all', () => {
+    expect(pickJapaneseVoice([voice('ja-JP', 'Google 日本語', false)])?.name).toBe('Google 日本語');
+  });
+
+  it('returns null when nothing can read Japanese', () => {
+    expect(pickJapaneseVoice(NO_JAPANESE)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Summary

Phase 2, items 1–3: the practice setup screen, flashcards and dictation — the
features the notebook was built to lead to. Word sets, history and the
dashboard's 最新の練習 panel are **not** in this and are described at the end.

`/practice/:mode` is one route module for both modes. Everything except which
component renders a card — the setup screen, the queue, the answer log, the
summary and the write — is shared.

### What changed

**Practice**

- `PracticeSetup` — chips for word sets, tags and JLPT level; selects for part
  of speech and word origin; a `learnedOn` range with last-week / last-month /
  last-year shortcuts; a weak-words-only toggle; a live match count that blocks
  a start on zero.
- `FlashcardSession` — shuffle, flip, again / known, and full keyboard control:
  <kbd>Space</kbd> turns the card, <kbd>←</kbd> / <kbd>→</kbd> answer it,
  <kbd>Esc</kbd> asks to leave. The hint is printed on each button it belongs
  to; the header's abort control keeps none.
- `DictationSession` — speaks the word, marks what you type, reveals the
  reading and the meaning. <kbd>Enter</kbd> marks; on an empty field it replays
  the word instead.
- `SessionSummary` — score, the missed words linked to their notes, restart or
  drill only what was missed.
- Leaving a session confirms first, in both modes: an abandoned session is not
  recorded, so the answers really are thrown away.

**Data**

- `createProgressRepository` — `users/{uid}/progress/entries` (one document,
  a map keyed by entry id) plus `users/{uid}/practiceSessions/{id}`.
- `createWordSetRepository` — `users/{uid}/wordSets/{id}`, read-only in practice
  until `/wordsets` exists.
- `ProgressProvider` and `WordSetsProvider`, mounted beside `EntriesProvider`.
- `sanitizeProgressMap`, `sanitizeSession`, `sanitizeWordSet`.

### Decisions a reviewer should not have to re-derive

**Practice state is one document, not one per word.** The plan this replaces
called for batching the writes per session, on the theory that a 50-card
session would otherwise cost 50 writes. Firestore bills per document, not per
round trip, so a `writeBatch` of 50 documents is still 50 writes — batching
buys latency and atomicity, never quota. Collapsing the map into one document
is what actually delivers it: two writes per session whatever its length, and
one read for the weak-word count instead of one per word. `merge: true` keeps a
session finished on one device from clobbering another's rows. This deviates
from the data-model document deliberately, and that document records why,
including the 1 MiB ≈ 15,000-entry ceiling it accepts.

**`finishedAt` is server-set and `PracticeSessionDraft` omits it.** History
pages on that field and a cursor is only sound over one clock. `startedAt`
stays a device value because that is honestly what it is.

**The URL segment is not the mode.** `/practice/flashcards` maps to mode
`flashcard` through an explicit table: the path is plural, the stored value
labels one session. Reusing one for the other silently broke every practice
route, and only the end-to-end suite saw it.

**`matchesPractice` takes a `PracticeScope`, not a bare `Set`.** The weak-words
filter and the word-set filter both resolve to a set of entry ids, and two
positional `ReadonlySet<string>` are interchangeable to the compiler — swapping
them turns one filter into the other with no error. `inSets` is `null` rather
than empty when no set is selected, because "do not filter by set" and "a set
with no words in it" are opposites.

**A calendar month, and it clamps.** `setMonth(m - 1)` on March 31 asks for
February 31, which `Date` rolls forward to March 3, so the last-month range
would have started three days *after* it was picked. `describeFilters` writes
bounds out as dates rather than as a relative phrase, because history reads
that label back weeks later.

**Katakana folds to hiragana when marking dictation.** Script is not audible, so
rejecting a hiragana answer to a word written in katakana punishes the learner
for information the drill never gave them. It costs the ability to drill
外来語 spelling, which is a different exercise.

**Enter is guarded on IME composition state.** Accepting a conversion candidate
is the most common keystroke in typing Japanese; treating it as a submission
marks the answer against half-converted kana.

### The speech synthesis fixes

Six of the eight commits are one bug, found by using the app on a MacBook where
the listen button was silent. Kept as separate commits because each is a real
defect in its own right, and because the sequence is the honest record of how
long it took to stop guessing and take a measurement.

The root cause is that Chrome's synthesiser outlives the document that filled
it. A page that inherits a queue left mid-utterance sees `speaking: true` with
nothing playing, and every later `speak()` joins a queue that never drains —
measured as `speaking: true` on the affected page and `false` on another site
in the same browser, while `say -v Kyoko` worked in a terminal throughout. One
`cancel()` when the hook mounts clears it; it is a no-op on a clean engine.

Fixed along the way, all genuine and all separately tested: presence of the API
said nothing about a Japanese voice existing; the voice list is populated
asynchronously so the first `getVoices()` is empty; `cancel()` then `speak()`
in one task drops the utterance; the utterance is named rather than matched off
`lang`; a paused engine is resumed; an utterance that never starts is now
reported instead of being silent; and candidates fall through local → network →
browser default, since `localService` says where a voice would come from and
not whether macOS ever downloaded it.

Autoplay was removed at one point and has been put back. Safari plays the word
on arrival correctly on the same machine, so the feature was sound and Chrome
was the thing to work around — not the reason to drop it.

### Tests

Chosen by the cheapest layer that can see the defect, per `CLAUDE.md`:

| Layer | Added | Why there |
| --- | --- | --- |
| `tests/unit` | practice queue and filters, quick ranges, dictation marking, voice selection, progress-map coercion | all string/array-in, value-out; the clock and the randomness are arguments |
| `tests/component` | the IME Enter guard, the flashcard shortcuts, every speech failure | document-level key handlers and a substituted browser engine — nothing in the DOM shows they exist |
| `tests/integration` | `merge: true`, the session cursor, word-set membership | only a real write can lose the other device's rows; only a real query has a cursor |
| `tests/rules` | corrected to the practice paths the app actually writes | the authorization boundary |
| `tests/e2e` | setup count agreeing with the queue it starts, a session recorded and read back, keyboard control, the quit dialog, the word-set and date filters | routing, providers and a real key press with nothing focused |

No new screenshot baselines: nothing here is a layout claim.

The engine is substituted in the speech tests. That is a browser service, not a
module we own, and it is the only way to reach any of it — jsdom has no
`speechSynthesis` and a real browser has whatever voices that machine carries.

**Every fix was proved red first**, by reproducing its defect and confirming
only the expected cases failed. Naming what went red: restoring the
speak-on-mount (5 cases), deferring `speak` into a timer (4), dropping the
inherited-queue `cancel` (1), removing the IME composition guard (2), the
empty-reading filter (2), widening the katakana range past ー and ・ (1),
returning untouched rows from `mergeProgress` (1), dropping `merge: true` (1),
writing `finishedAt` from the device (2, including pagination), removing the
zero-match block (1), no-op'ing the session write (1), the naive `setMonth` (1),
collapsing `inSets` null and empty (1), removing the set membership check (2),
dropping the network voice from the candidate chain (3), and removing the
flashcard flip gate (1) and its repeat guard (2).

One of those runs found a bad test: "speaks once per press" passed with the fix
removed, because a press on a healthy engine changes no dependency and so could
never show the defect. It now walks through the failure state first, where the
re-render actually happens.

`yarn test` 377 + 53 · `yarn test:e2e` 31 · typecheck, lint and format clean.

### Verified by hand

Dictation now speaks in both Chrome and Safari on the reporting machine, which
is what closed out the speech work.

### Not in this

Phase 2 items 4–6 remain: `/wordsets` CRUD, `/history`, and wiring the
dashboard's 最新の練習 panel. `ProgressRepository.listSessions` is built, paged
and tested, so items 5 and 6 are small once the first exists.

The word-set **filter** is complete and tested, but nothing writes a set yet, so
its chip row hides itself in the running app — which is the design's own rule
for it. Two end-to-end cases pin both states, one seeding a set directly.
