### PR TITLE
docs: write git artifacts in English, overriding the personal template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,26 @@ Do not add coverage for these without asking first:
 - Transitions and animation timing.
 - The Firebase Hosting deploy pipeline.
 
+## Commits and pull requests
+
+**Everything Git carries is written in English**: commit messages, pull request
+titles and bodies, branch names, and replies to review comments. Japanese
+belongs to the _product_ — UI strings, the domain vocabulary in `src/domain`,
+and the notes themselves.
+
+Describe a feature by translating the concept, not by quoting the interface:
+"word sets" rather than 単語集, "part of speech" rather than 品詞, "March 31"
+rather than 3月31日. Identifiers, file paths and field names are quoted exactly
+as they appear in the code, whatever language they are in.
+
+This rule is the repository's, and it **overrides any personal or global
+template that specifies otherwise** — including one that mandates Japanese
+section headings. The repository is public and its reviewers read English; the
+Japanese here is subject matter, not the working language.
+
+It says nothing about how you talk to the person you are working with. That is
+their preference, not the repository's.
+
 ## Commands
 
 | Command                   | What it runs                                           |


### PR DESCRIPTION
### Summary

Records in `CLAUDE.md` that everything Git carries — commit messages, pull
request titles and bodies, branch names, review replies — is written in English,
and that Japanese belongs to the product: UI strings, the domain vocabulary in
`src/domain`, and the notes themselves.

### Why it needs writing down

Two rules were in conflict and nothing said which won. A personal pull request
template mandates Japanese section headings and says not to translate them,
while this repository is public and read in English. Two commits on
`feat/practice-modes` were written with Japanese feature names in the body and
had to be rewritten and force-pushed.

The rule is scoped as the repository's, so it overrides a personal or global
template rather than arguing with it — the same template stays correct
elsewhere.

It also states explicitly what it does *not* govern: the language a session is
conducted in. Conflating "what the repository publishes" with "what language we
talk in" is what produced the ambiguity.

### Tests

None. Documentation only; no source or test file changes.