### PR TITLE
feat(wordsets): create, fill, arrange and delete a word set

### DIFF
--- a/src/components/practice/PracticeSetup.tsx
+++ b/src/components/practice/PracticeSetup.tsx
@@ -1,8 +1,21 @@
 import { JLPT_LEVELS, POS, WORD_ORIGINS } from '@/domain/entry';
 import type { PracticeMode } from '@/domain/practice';
-import type { WordSet } from '@/domain/wordSet';
 import { activeQuickRange, QUICK_RANGES, quickRangeStart } from '@/lib/practice';
 import type { PracticeFilters } from '@/lib/practice';
+
+/**
+ * A 単語集 chip, already counted.
+ *
+ * `count` is the number of words the set still has in the notebook, not
+ * `entryIds.length`: deleting a word does not visit the sets that named it, so
+ * the stored array can outlive its members and the badge would promise cards
+ * the queue cannot deal.
+ */
+export interface SetChip {
+  id: string;
+  name: string;
+  count: number;
+}
 
 const MODE_TITLE: Record<PracticeMode, string> = {
   flashcard: 'フラッシュカード',
@@ -30,8 +43,7 @@ const selectClass = 'rounded-panel border-line bg-bg text-ink min-h-9 border px-
  * The screen both practice modes open on.
  *
  * The 単語集 row hides itself when there are none, which is the design's rule
- * and, until `/wordsets` exists, its permanent state in the running app: the
- * read path is real but nothing writes a set yet.
+ * for a notebook that has not organised anything yet.
  *
  * `matchCount` is computed by the caller rather than here, because the same
  * filtered list is what 開始する turns into the queue — recomputing it in two
@@ -54,7 +66,7 @@ export function PracticeSetup({
   filters: PracticeFilters;
   allTags: string[];
   /** Hidden entirely when empty, per the design — see the note above. */
-  allSets: WordSet[];
+  allSets: SetChip[];
   /** What 「直近1ヶ月」 is measured from. An argument so it can be frozen. */
   now: Date;
   matchCount: number;
@@ -100,7 +112,7 @@ export function PracticeSetup({
                 className={chipClass(filters.sets.includes(set.id))}
               >
                 {set.name}
-                <span className="ml-1.5 opacity-70">{set.entryIds.length}</span>
+                <span className="ml-1.5 opacity-70">{set.count}</span>
               </button>
             ))}
           </div>

--- a/src/components/wordsets/DragHandle.tsx
+++ b/src/components/wordsets/DragHandle.tsx
@@ -51,7 +51,11 @@ export function DragHandle({
       }}
       // 44px square: on touch this is the only way into a drag, because a row
       // that claimed the gesture could no longer scroll the panel it sits in.
-      className="grid h-11 w-11 shrink-0 cursor-grab touch-none place-items-center rounded-panel text-muted select-none hover:bg-bg-alt active:cursor-grabbing aria-disabled:cursor-default aria-disabled:opacity-40"
+      // Half-visible until the row is pointed at, then full. Present enough to
+      // be found, quiet enough that a list of twenty does not read as a column
+      // of dots — and the row it belongs to is what makes it come forward, so
+      // the grip is what teaches that the row itself is draggable.
+      className="grid h-11 w-11 shrink-0 cursor-grab touch-none place-items-center rounded-panel text-muted opacity-50 transition select-none group-hover:opacity-100 hover:bg-bg-alt hover:text-ink focus-visible:opacity-100 active:cursor-grabbing aria-disabled:cursor-default aria-disabled:opacity-30"
     >
       ⠿
     </button>

--- a/src/components/wordsets/DragHandle.tsx
+++ b/src/components/wordsets/DragHandle.tsx
@@ -49,7 +49,9 @@ export function DragHandle({
         event.preventDefault();
         onMoveBy(event.key === 'ArrowUp' ? -1 : 1);
       }}
-      className="shrink-0 cursor-grab touch-none rounded-panel px-2 py-1 text-muted select-none hover:bg-bg-alt active:cursor-grabbing aria-disabled:cursor-default aria-disabled:opacity-40"
+      // 44px square: on touch this is the only way into a drag, because a row
+      // that claimed the gesture could no longer scroll the panel it sits in.
+      className="grid h-11 w-11 shrink-0 cursor-grab touch-none place-items-center rounded-panel text-muted select-none hover:bg-bg-alt active:cursor-grabbing aria-disabled:cursor-default aria-disabled:opacity-40"
     >
       ⠿
     </button>

--- a/src/components/wordsets/DragHandle.tsx
+++ b/src/components/wordsets/DragHandle.tsx
@@ -1,0 +1,57 @@
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+/**
+ * The grip on a draggable row — and the keyboard's way to do the same thing.
+ *
+ * A real `<button>` rather than a styled `<span>`, because the arrow keys are
+ * the only way to reorder without a pointer and they need something focusable
+ * to hang off. That is also why `onMoveBy` is required rather than optional: a
+ * grip that can only be dragged is a control half the people using this app
+ * cannot operate.
+ *
+ * `touch-action: none` is what makes it work on a phone at all. Without it the
+ * browser claims the gesture for scrolling as soon as the finger moves, and the
+ * drag never receives a second pointer event.
+ */
+export function DragHandle({
+  label,
+  disabled,
+  onPointerDown,
+  onMoveBy,
+}: {
+  /** Names the row, so the control reads as 「兆候を並び替え」 rather than 「並び替え」. */
+  label: string;
+  disabled: boolean;
+  onPointerDown: (event: ReactPointerEvent) => void;
+  /** Called with -1 or 1 when the arrow keys move the row. Null where the list has no order to change. */
+  onMoveBy: ((delta: number) => void) | null;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={`${label}を並び替え`}
+      /**
+       * `aria-disabled`, not `disabled`. A disabled button drops focus, and
+       * every arrow press writes — so the real `disabled` would throw the
+       * keyboard out of the list after each single step and make the one path
+       * that exists without a pointer unusable. The guards below refuse the
+       * gesture instead, which is the same answer without the eviction.
+       */
+      aria-disabled={disabled}
+      onPointerDown={(event) => {
+        if (disabled) return;
+        onPointerDown(event);
+      }}
+      onKeyDown={(event) => {
+        if (disabled || !onMoveBy) return;
+        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+        // Otherwise the page scrolls out from under the row being moved.
+        event.preventDefault();
+        onMoveBy(event.key === 'ArrowUp' ? -1 : 1);
+      }}
+      className="shrink-0 cursor-grab touch-none rounded-panel px-2 py-1 text-muted select-none hover:bg-bg-alt active:cursor-grabbing aria-disabled:cursor-default aria-disabled:opacity-40"
+    >
+      ⠿
+    </button>
+  );
+}

--- a/src/components/wordsets/MemberList.tsx
+++ b/src/components/wordsets/MemberList.tsx
@@ -35,18 +35,29 @@ export function MemberList({
   const at = drag.at?.list === list ? drag.at.index : null;
 
   return (
-    <section className="space-y-2 rounded-card bg-card p-5 shadow-panel">
-      <div className="flex items-baseline justify-between gap-3">
+    <section className="flex min-h-0 flex-1 flex-col rounded-card bg-card shadow-panel">
+      <div className="flex shrink-0 items-baseline justify-between gap-3 border-b border-line p-4">
         <h2 className="text-sm font-semibold">収録語</h2>
         <p className="text-xs text-muted tabular-nums">{members.length} 語</p>
       </div>
 
-      <ul data-drop-list={list} data-drop-count={members.length} className="min-h-16">
+      <ul
+        data-drop-list={list}
+        data-drop-count={members.length}
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-2"
+      >
         {members.map((entry, index) => (
           <li
             key={entry.id}
             data-drop-index={index}
-            className={`flex items-center gap-2 border-y-2 border-transparent py-1.5 ${
+            {...drag.rowProps({ list, id: entry.id, index })}
+            /**
+             * `touch-pan-y`, not `touch-none`: a finger on a row scrolls the
+             * panel, because a bounded panel whose rows cannot be scrolled from
+             * is a panel that cannot be read. Touch drags start from the grip,
+             * which is the only element here that claims the gesture.
+             */
+            className={`flex touch-pan-y items-center gap-2 border-y-2 border-transparent py-1.5 ${
               at === index ? 'border-t-accent' : ''
             } ${at === members.length && index === members.length - 1 ? 'border-b-accent' : ''} ${
               drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
@@ -58,7 +69,18 @@ export function MemberList({
               onPointerDown={drag.handleProps({ list, id: entry.id, index }).onPointerDown}
               onMoveBy={(delta) => onMoveBy(index, delta)}
             />
-            <Link to={`/vocabulary/${entry.id}`} className="min-w-0 flex-1 truncate">
+            <Link
+              to={`/vocabulary/${entry.id}`}
+              /**
+               * An `<a>` is natively draggable, and the row body is now a drag
+               * source. Left alone, a press that drifts even a few pixels
+               * starts the browser's own link drag instead — which cancels the
+               * click, so the word cannot be opened, and fights our pointer
+               * drag for the gesture.
+               */
+              draggable={false}
+              className="min-w-0 flex-1 truncate select-none"
+            >
               <Ruby
                 headword={entry.headword}
                 reading={entry.reading}
@@ -78,11 +100,11 @@ export function MemberList({
 
         {members.length === 0 && (
           <li
-            className={`grid min-h-16 place-items-center rounded-panel border-2 border-dashed text-sm text-muted ${
+            className={`grid min-h-24 place-items-center rounded-panel border-2 border-dashed px-3 text-center text-sm text-muted ${
               at === 0 ? 'border-accent text-accent' : 'border-line'
             }`}
           >
-            下の一覧からドラッグ、または「＋ 追加」で入れてください
+            ここに単語をドラッグ、または「＋ 追加」で入れてください
           </li>
         )}
       </ul>

--- a/src/components/wordsets/MemberList.tsx
+++ b/src/components/wordsets/MemberList.tsx
@@ -1,0 +1,91 @@
+import { Link } from 'react-router-dom';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/domain/entry';
+import type { ListDrag } from '@/lib/listDrag';
+import { DragHandle } from './DragHandle';
+
+/**
+ * 収録語 — the set's words, in the order it stores them.
+ *
+ * That order is the study order, and until this list could be dragged there was
+ * no way to change it: words joined at the end and stayed there. It is why the
+ * rows carry a grip and the picker's rows carry one too.
+ *
+ * `border-y-2 border-transparent` is on every row rather than only the one
+ * being dropped onto. A border added on hover would grow the row by 4px, move
+ * every row below it, and hand the pointer a different target than the one the
+ * indicator was drawn for — the drop then lands a row away from where it looked.
+ */
+export function MemberList({
+  members,
+  list,
+  drag,
+  busy,
+  onRemove,
+  onMoveBy,
+}: {
+  members: readonly Entry[];
+  /** This list's name in the drag protocol; see `useListDrag`. */
+  list: string;
+  drag: ListDrag;
+  busy: boolean;
+  onRemove: (entryId: string) => void;
+  onMoveBy: (index: number, delta: number) => void;
+}) {
+  const at = drag.at?.list === list ? drag.at.index : null;
+
+  return (
+    <section className="space-y-2 rounded-card bg-card p-5 shadow-panel">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="text-sm font-semibold">収録語</h2>
+        <p className="text-xs text-muted tabular-nums">{members.length} 語</p>
+      </div>
+
+      <ul data-drop-list={list} data-drop-count={members.length} className="min-h-16">
+        {members.map((entry, index) => (
+          <li
+            key={entry.id}
+            data-drop-index={index}
+            className={`flex items-center gap-2 border-y-2 border-transparent py-1.5 ${
+              at === index ? 'border-t-accent' : ''
+            } ${at === members.length && index === members.length - 1 ? 'border-b-accent' : ''} ${
+              drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
+            }`}
+          >
+            <DragHandle
+              label={entry.headword}
+              disabled={busy}
+              onPointerDown={drag.handleProps({ list, id: entry.id, index }).onPointerDown}
+              onMoveBy={(delta) => onMoveBy(index, delta)}
+            />
+            <Link to={`/vocabulary/${entry.id}`} className="min-w-0 flex-1 truncate">
+              <Ruby
+                headword={entry.headword}
+                reading={entry.reading}
+                className="has-ruby font-display text-base font-bold"
+              />
+            </Link>
+            <button
+              type="button"
+              onClick={() => onRemove(entry.id)}
+              disabled={busy}
+              className="min-h-9 shrink-0 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger disabled:opacity-60"
+            >
+              削除
+            </button>
+          </li>
+        ))}
+
+        {members.length === 0 && (
+          <li
+            className={`grid min-h-16 place-items-center rounded-panel border-2 border-dashed text-sm text-muted ${
+              at === 0 ? 'border-accent text-accent' : 'border-line'
+            }`}
+          >
+            下の一覧からドラッグ、または「＋ 追加」で入れてください
+          </li>
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/wordsets/MemberList.tsx
+++ b/src/components/wordsets/MemberList.tsx
@@ -22,6 +22,7 @@ export function MemberList({
   drag,
   busy,
   onRemove,
+  onRemoveAll,
   onMoveBy,
 }: {
   members: readonly Entry[];
@@ -30,21 +31,48 @@ export function MemberList({
   drag: ListDrag;
   busy: boolean;
   onRemove: (entryId: string) => void;
+  /** Asks; it does not do it. The route confirms first — see `WordSetDetail`. */
+  onRemoveAll: (entryIds: string[]) => void;
   onMoveBy: (index: number, delta: number) => void;
 }) {
   const at = drag.at?.list === list ? drag.at.index : null;
 
   return (
     <section className="flex min-h-0 flex-1 flex-col rounded-card bg-card shadow-panel">
-      <div className="flex shrink-0 items-baseline justify-between gap-3 border-b border-line p-4">
-        <h2 className="text-sm font-semibold">収録語</h2>
-        <p className="text-xs text-muted tabular-nums">{members.length} 語</p>
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-line p-4">
+        <h2 className="text-sm font-semibold">
+          収録語
+          <span className="ml-2 text-xs font-normal text-muted tabular-nums">
+            {members.length} 語
+          </span>
+        </h2>
+        {/* Mirrors 表示中の N 語を追加 across the gap, and names its own count
+            for the same reason: it acts on the rows in view, not on `entryIds`,
+            so a member whose word has been deleted is not among them. */}
+        <button
+          type="button"
+          onClick={() => onRemoveAll(members.map((entry) => entry.id))}
+          disabled={busy || members.length === 0}
+          className="min-h-9 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger disabled:opacity-60"
+        >
+          表示中の {members.length} 語を削除
+        </button>
       </div>
 
       <ul
         data-drop-list={list}
         data-drop-count={members.length}
-        className="min-h-0 flex-1 overflow-y-auto px-4 py-2"
+        /**
+         * Says out loud whether this list can take what is being dragged, and
+         * whether it is about to.
+         *
+         * Not decoration: 単語を探す is a drag *source* and refuses drops, so
+         * without something marking the one list that accepts them, releasing
+         * over the wrong panel simply does nothing and looks like the feature
+         * is broken. `over` is the stronger state of the same claim.
+         */
+        data-drop-state={drag.dragging === null ? 'idle' : at === null ? 'ready' : 'over'}
+        className="min-h-0 flex-1 overflow-y-auto rounded-panel px-4 py-2 outline-2 outline-offset-[-4px] outline-transparent transition-colors data-[drop-state=over]:bg-accent-soft/40 data-[drop-state=over]:outline-accent data-[drop-state=ready]:outline-line data-[drop-state=ready]:outline-dashed"
       >
         {members.map((entry, index) => (
           <li
@@ -57,10 +85,12 @@ export function MemberList({
              * is a panel that cannot be read. Touch drags start from the grip,
              * which is the only element here that claims the gesture.
              */
-            className={`flex touch-pan-y items-center gap-2 border-y-2 border-transparent py-1.5 ${
+            className={`group flex cursor-grab touch-pan-y items-center gap-2 rounded-panel border-y-2 border-transparent py-1.5 select-none hover:bg-bg-alt ${
               at === index ? 'border-t-accent' : ''
             } ${at === members.length && index === members.length - 1 ? 'border-b-accent' : ''} ${
-              drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
+              drag.dragging?.list === list && drag.dragging.id === entry.id
+                ? 'cursor-grabbing opacity-40'
+                : ''
             }`}
           >
             <DragHandle
@@ -79,7 +109,10 @@ export function MemberList({
                * drag for the gesture.
                */
               draggable={false}
-              className="min-w-0 flex-1 truncate select-none"
+              // `cursor-grab` overrides the pointer an anchor gets by default:
+              // the row is draggable along its whole width, and a hand that
+              // changes shape halfway across it says the opposite.
+              className="min-w-0 flex-1 cursor-grab truncate select-none"
             >
               <Ruby
                 headword={entry.headword}

--- a/src/components/wordsets/MemberList.tsx
+++ b/src/components/wordsets/MemberList.tsx
@@ -29,6 +29,12 @@ export function MemberList({
   /** This list's name in the drag protocol; see `useListDrag`. */
   list: string;
   drag: ListDrag;
+  /**
+   * True while a write is in flight. It gates the rows as well as the buttons:
+   * `applyOrder` refuses a write during one, so an ungated row would let a drag
+   * run its whole course — ghost, drop indicator, release — and then decline it
+   * silently. The affordances have to agree with the guard.
+   */
   busy: boolean;
   onRemove: (entryId: string) => void;
   /** Asks; it does not do it. The route confirms first — see `WordSetDetail`. */
@@ -78,7 +84,7 @@ export function MemberList({
           <li
             key={entry.id}
             data-drop-index={index}
-            {...drag.rowProps({ list, id: entry.id, index })}
+            {...(busy ? {} : drag.rowProps({ list, id: entry.id, index }))}
             /**
              * `touch-pan-y`, not `touch-none`: a finger on a row scrolls the
              * panel, because a bounded panel whose rows cannot be scrolled from

--- a/src/components/wordsets/MemberPicker.tsx
+++ b/src/components/wordsets/MemberPicker.tsx
@@ -31,6 +31,9 @@ export function MemberPicker({
    * `entryIds` array built from the set in hand, so a second gesture before the
    * first has been read back would send a list that never contained the first
    * word.
+   *
+   * It gates the rows too, not only the buttons: an ungated row would let a
+   * drag run its whole course and then have `applyOrder` decline it silently.
    */
   busy: boolean;
   onAdd: (entryId: string) => void;
@@ -68,7 +71,7 @@ export function MemberPicker({
           <li
             key={entry.id}
             data-drop-index={index}
-            {...drag.rowProps({ list, id: entry.id, index })}
+            {...(busy ? {} : drag.rowProps({ list, id: entry.id, index }))}
             className={`group flex cursor-grab touch-pan-y items-center gap-2 rounded-panel border-y-2 border-transparent py-1.5 select-none hover:bg-bg-alt ${
               drag.dragging?.list === list && drag.dragging.id === entry.id
                 ? 'cursor-grabbing opacity-40'

--- a/src/components/wordsets/MemberPicker.tsx
+++ b/src/components/wordsets/MemberPicker.tsx
@@ -1,71 +1,154 @@
 import { useMemo, useState } from 'react';
+import { FilterPanel } from '@/components/browse/FilterPanel';
 import type { Entry } from '@/domain/entry';
 import type { WordSet } from '@/domain/wordSet';
-import { candidatesFor } from '@/lib/wordSetMembers';
+import { EMPTY_FILTERS, isDefault } from '@/lib/filters';
+import type { Filters } from '@/lib/filters';
+import type { ListDrag } from '@/lib/listDrag';
+import { candidatesFor, CANDIDATE_LIMIT } from '@/lib/wordSetMembers';
+import { DragHandle } from './DragHandle';
 
 /**
- * Add a word already in the notebook to this set.
+ * 単語を探す — the notebook, narrowed the way 一覧 narrows it, minus what the
+ * set already holds.
  *
- * The search is over the entries the provider has in memory, so it answers as
- * fast as it is typed and needs no query. Words already in the set are not
- * offered — see `candidatesFor`.
+ * The same `FilterPanel` and the same `matches`/`sortEntries` as Browse, rather
+ * than a second search box with its own rules: a word that a filter combination
+ * finds on one screen has to be findable by the same combination here, and two
+ * implementations of "find my word" is how that stops being true.
+ *
+ * Nothing is hidden until a query is typed. With no filters set this is the
+ * whole notebook newest-first, because the word most likely to be filed into a
+ * set is the one just added — and because a picker that starts empty gives the
+ * drag gesture nothing to be discovered on.
  */
 export function MemberPicker({
   set,
   entries,
+  allTags,
+  filters,
+  list,
+  drag,
   busy,
+  onFiltersChange,
   onAdd,
 }: {
   set: WordSet;
   entries: readonly Entry[];
+  allTags: string[];
+  filters: Filters;
+  /** This list's name in the drag protocol; see `useListDrag`. */
+  list: string;
+  drag: ListDrag;
   /**
-   * True while a write is in flight. Every ＋追加 is disabled together, not
-   * just the one that was pressed: each write sends the whole `entryIds` array
-   * built from the set in hand, so a second press before the first has been
-   * read back would send a list that never contained the first word.
+   * True while a write is in flight. Every ＋追加 and every grip is disabled
+   * together, not just the one that was pressed: each write sends the whole
+   * `entryIds` array built from the set in hand, so a second gesture before the
+   * first has been read back would send a list that never contained the first
+   * word.
    */
   busy: boolean;
+  onFiltersChange: (next: Filters) => void;
   onAdd: (entryId: string) => void;
 }) {
-  const [query, setQuery] = useState('');
-  const candidates = useMemo(() => candidatesFor(set, entries, query), [set, entries, query]);
-  const searching = query.trim().length > 0;
+  const { shown, total } = useMemo(
+    () => candidatesFor(set, entries, filters),
+    [set, entries, filters],
+  );
+
+  /**
+   * The panel is folded away until it is asked for, which on this screen is a
+   * layout decision rather than a tidiness one: 一覧's filter panel is around
+   * 200px tall, and open by default it pushes every candidate row below the
+   * fold — leaving a drag whose source and target are never on screen together.
+   */
+  const [showFilters, setShowFilters] = useState(false);
+  const narrowed = !isDefault({ ...filters, sort: EMPTY_FILTERS.sort });
 
   return (
     <section className="space-y-3 rounded-card bg-card p-5 shadow-panel">
-      <h2 className="text-sm font-semibold">既存の単語を追加</h2>
+      <h2 className="text-sm font-semibold">単語を探す</h2>
 
       <input
         type="search"
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder="見出し語・読み方で検索"
+        value={filters.q}
+        onChange={(event) => onFiltersChange({ ...filters, q: event.target.value })}
+        placeholder="見出し語・読み方・タグ・意味・例文で検索"
         className="min-h-11 w-full rounded-pill border border-line bg-bg px-4 text-sm text-ink placeholder:text-muted"
       />
 
-      {searching &&
-        (candidates.length > 0 ? (
-          <ul className="divide-y divide-line">
-            {candidates.map((entry) => (
-              <li key={entry.id} className="flex items-center justify-between gap-3 py-2">
-                <span className="min-w-0 truncate text-sm">
-                  <span className="font-display font-bold">{entry.headword}</span>
-                  {entry.reading && <span className="text-muted">（{entry.reading}）</span>}
-                </span>
-                <button
-                  type="button"
-                  onClick={() => onAdd(entry.id)}
-                  disabled={busy}
-                  className="min-h-9 shrink-0 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
-                >
-                  ＋ 追加
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="py-2 text-sm text-muted">追加できる単語が見つかりません</p>
-        ))}
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-xs text-muted tabular-nums">
+          {total} 語{total > CANDIDATE_LIMIT && `（上位 ${CANDIDATE_LIMIT} 件を表示）`}
+        </p>
+        <div className="flex items-center gap-3">
+          {!isDefault(filters) && (
+            <button
+              type="button"
+              onClick={() => onFiltersChange({ ...EMPTY_FILTERS, sort: filters.sort })}
+              className="text-xs text-muted underline hover:text-ink"
+            >
+              すべて解除
+            </button>
+          )}
+          <button
+            type="button"
+            aria-expanded={showFilters}
+            onClick={() => setShowFilters((open) => !open)}
+            className={`rounded-pill px-3 py-1 text-xs font-medium ${
+              narrowed ? 'bg-accent-soft text-accent' : 'bg-bg-alt text-muted hover:text-ink'
+            }`}
+          >
+            絞り込み{showFilters ? ' ▲' : ' ▼'}
+          </button>
+        </div>
+      </div>
+
+      {showFilters && (
+        <FilterPanel filters={filters} allTags={allTags} onChange={onFiltersChange} />
+      )}
+
+      {shown.length ? (
+        <ul data-drop-list={list} data-drop-count={shown.length} className="divide-y divide-line">
+          {shown.map((entry, index) => (
+            <li
+              key={entry.id}
+              data-drop-index={index}
+              className={`flex items-center gap-2 py-1.5 ${
+                drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
+              }`}
+            >
+              <DragHandle
+                label={entry.headword}
+                disabled={busy}
+                onPointerDown={drag.handleProps({ list, id: entry.id, index }).onPointerDown}
+                // This list has no order of its own to change — it is sorted by
+                // the panel above — so the arrows would move a row back to where
+                // the sort puts it. Adding is the keyboard path here.
+                onMoveBy={null}
+              />
+              <span className="min-w-0 flex-1 truncate text-sm">
+                <span className="font-display font-bold">{entry.headword}</span>
+                {entry.reading && <span className="text-muted">（{entry.reading}）</span>}
+              </span>
+              <button
+                type="button"
+                onClick={() => onAdd(entry.id)}
+                disabled={busy}
+                className="min-h-9 shrink-0 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
+              >
+                ＋ 追加
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="py-4 text-sm text-muted">
+          {entries.length === set.entryIds.length
+            ? 'この単語集にすべての単語が入っています'
+            : '条件に合う単語がありません'}
+        </p>
+      )}
     </section>
   );
 }

--- a/src/components/wordsets/MemberPicker.tsx
+++ b/src/components/wordsets/MemberPicker.tsx
@@ -1,0 +1,71 @@
+import { useMemo, useState } from 'react';
+import type { Entry } from '@/domain/entry';
+import type { WordSet } from '@/domain/wordSet';
+import { candidatesFor } from '@/lib/wordSetMembers';
+
+/**
+ * Add a word already in the notebook to this set.
+ *
+ * The search is over the entries the provider has in memory, so it answers as
+ * fast as it is typed and needs no query. Words already in the set are not
+ * offered — see `candidatesFor`.
+ */
+export function MemberPicker({
+  set,
+  entries,
+  busy,
+  onAdd,
+}: {
+  set: WordSet;
+  entries: readonly Entry[];
+  /**
+   * True while a write is in flight. Every ＋追加 is disabled together, not
+   * just the one that was pressed: each write sends the whole `entryIds` array
+   * built from the set in hand, so a second press before the first has been
+   * read back would send a list that never contained the first word.
+   */
+  busy: boolean;
+  onAdd: (entryId: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const candidates = useMemo(() => candidatesFor(set, entries, query), [set, entries, query]);
+  const searching = query.trim().length > 0;
+
+  return (
+    <section className="space-y-3 rounded-card bg-card p-5 shadow-panel">
+      <h2 className="text-sm font-semibold">既存の単語を追加</h2>
+
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="見出し語・読み方で検索"
+        className="min-h-11 w-full rounded-pill border border-line bg-bg px-4 text-sm text-ink placeholder:text-muted"
+      />
+
+      {searching &&
+        (candidates.length > 0 ? (
+          <ul className="divide-y divide-line">
+            {candidates.map((entry) => (
+              <li key={entry.id} className="flex items-center justify-between gap-3 py-2">
+                <span className="min-w-0 truncate text-sm">
+                  <span className="font-display font-bold">{entry.headword}</span>
+                  {entry.reading && <span className="text-muted">（{entry.reading}）</span>}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onAdd(entry.id)}
+                  disabled={busy}
+                  className="min-h-9 shrink-0 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
+                >
+                  ＋ 追加
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="py-2 text-sm text-muted">追加できる単語が見つかりません</p>
+        ))}
+    </section>
+  );
+}

--- a/src/components/wordsets/MemberPicker.tsx
+++ b/src/components/wordsets/MemberPicker.tsx
@@ -60,6 +60,8 @@ export function MemberPicker({
       <ul
         data-drop-list={list}
         data-drop-count={shown.length}
+        // No `data-drop-state`: this list is a source and refuses drops, so it
+        // must not offer the outline that says otherwise. See `MemberList`.
         className="min-h-0 flex-1 overflow-y-auto px-4 py-2"
       >
         {shown.map((entry, index) => (
@@ -67,8 +69,10 @@ export function MemberPicker({
             key={entry.id}
             data-drop-index={index}
             {...drag.rowProps({ list, id: entry.id, index })}
-            className={`flex touch-pan-y items-center gap-2 border-y-2 border-transparent py-1.5 ${
-              drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
+            className={`group flex cursor-grab touch-pan-y items-center gap-2 rounded-panel border-y-2 border-transparent py-1.5 select-none hover:bg-bg-alt ${
+              drag.dragging?.list === list && drag.dragging.id === entry.id
+                ? 'cursor-grabbing opacity-40'
+                : ''
             }`}
           >
             <DragHandle

--- a/src/components/wordsets/MemberPicker.tsx
+++ b/src/components/wordsets/MemberPicker.tsx
@@ -1,42 +1,27 @@
-import { useMemo, useState } from 'react';
-import { FilterPanel } from '@/components/browse/FilterPanel';
 import type { Entry } from '@/domain/entry';
-import type { WordSet } from '@/domain/wordSet';
-import { EMPTY_FILTERS, isDefault } from '@/lib/filters';
-import type { Filters } from '@/lib/filters';
 import type { ListDrag } from '@/lib/listDrag';
-import { candidatesFor, CANDIDATE_LIMIT } from '@/lib/wordSetMembers';
+import { CANDIDATE_LIMIT } from '@/lib/wordSetMembers';
 import { DragHandle } from './DragHandle';
 
 /**
- * 単語を探す — the notebook, narrowed the way 一覧 narrows it, minus what the
- * set already holds.
+ * 単語を探す — the notebook, minus what the set already holds.
  *
- * The same `FilterPanel` and the same `matches`/`sortEntries` as Browse, rather
- * than a second search box with its own rules: a word that a filter combination
- * finds on one screen has to be findable by the same combination here, and two
- * implementations of "find my word" is how that stops being true.
- *
- * Nothing is hidden until a query is typed. With no filters set this is the
- * whole notebook newest-first, because the word most likely to be filed into a
- * set is the one just added — and because a picker that starts empty gives the
- * drag gesture nothing to be discovered on.
+ * The narrowing happens in `PickerToolbar` above and arrives here as a list;
+ * this panel is the drag source and nothing else. Its own scroll is what keeps
+ * it beside 収録語 instead of pushing it off the screen.
  */
 export function MemberPicker({
-  set,
-  entries,
-  allTags,
-  filters,
+  shown,
+  total,
   list,
   drag,
   busy,
-  onFiltersChange,
   onAdd,
+  onAddAll,
 }: {
-  set: WordSet;
-  entries: readonly Entry[];
-  allTags: string[];
-  filters: Filters;
+  shown: readonly Entry[];
+  /** Everything that matched, which is usually more than is rendered. */
+  total: number;
   /** This list's name in the drag protocol; see `useListDrag`. */
   list: string;
   drag: ListDrag;
@@ -48,107 +33,72 @@ export function MemberPicker({
    * word.
    */
   busy: boolean;
-  onFiltersChange: (next: Filters) => void;
   onAdd: (entryId: string) => void;
+  onAddAll: (entryIds: string[]) => void;
 }) {
-  const { shown, total } = useMemo(
-    () => candidatesFor(set, entries, filters),
-    [set, entries, filters],
-  );
-
-  /**
-   * The panel is folded away until it is asked for, which on this screen is a
-   * layout decision rather than a tidiness one: 一覧's filter panel is around
-   * 200px tall, and open by default it pushes every candidate row below the
-   * fold — leaving a drag whose source and target are never on screen together.
-   */
-  const [showFilters, setShowFilters] = useState(false);
-  const narrowed = !isDefault({ ...filters, sort: EMPTY_FILTERS.sort });
-
   return (
-    <section className="space-y-3 rounded-card bg-card p-5 shadow-panel">
-      <h2 className="text-sm font-semibold">単語を探す</h2>
-
-      <input
-        type="search"
-        value={filters.q}
-        onChange={(event) => onFiltersChange({ ...filters, q: event.target.value })}
-        placeholder="見出し語・読み方・タグ・意味・例文で検索"
-        className="min-h-11 w-full rounded-pill border border-line bg-bg px-4 text-sm text-ink placeholder:text-muted"
-      />
-
-      <div className="flex items-baseline justify-between gap-3">
-        <p className="text-xs text-muted tabular-nums">
-          {total} 語{total > CANDIDATE_LIMIT && `（上位 ${CANDIDATE_LIMIT} 件を表示）`}
-        </p>
-        <div className="flex items-center gap-3">
-          {!isDefault(filters) && (
-            <button
-              type="button"
-              onClick={() => onFiltersChange({ ...EMPTY_FILTERS, sort: filters.sort })}
-              className="text-xs text-muted underline hover:text-ink"
-            >
-              すべて解除
-            </button>
-          )}
-          <button
-            type="button"
-            aria-expanded={showFilters}
-            onClick={() => setShowFilters((open) => !open)}
-            className={`rounded-pill px-3 py-1 text-xs font-medium ${
-              narrowed ? 'bg-accent-soft text-accent' : 'bg-bg-alt text-muted hover:text-ink'
-            }`}
-          >
-            絞り込み{showFilters ? ' ▲' : ' ▼'}
-          </button>
-        </div>
+    <section className="flex min-h-0 flex-1 flex-col rounded-card bg-card shadow-panel">
+      <div className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-line p-4">
+        <h2 className="text-sm font-semibold">
+          単語を探す
+          <span className="ml-2 text-xs font-normal text-muted tabular-nums">
+            {total} 語{total > CANDIDATE_LIMIT && `（上位 ${CANDIDATE_LIMIT} 件）`}
+          </span>
+        </h2>
+        {/* Named with its own count, because the rendered rows are capped and
+            "all" would otherwise be read as all of `total`. */}
+        <button
+          type="button"
+          onClick={() => onAddAll(shown.map((entry) => entry.id))}
+          disabled={busy || shown.length === 0}
+          className="min-h-9 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
+        >
+          表示中の {shown.length} 語を追加
+        </button>
       </div>
 
-      {showFilters && (
-        <FilterPanel filters={filters} allTags={allTags} onChange={onFiltersChange} />
-      )}
-
-      {shown.length ? (
-        <ul data-drop-list={list} data-drop-count={shown.length} className="divide-y divide-line">
-          {shown.map((entry, index) => (
-            <li
-              key={entry.id}
-              data-drop-index={index}
-              className={`flex items-center gap-2 py-1.5 ${
-                drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
-              }`}
+      <ul
+        data-drop-list={list}
+        data-drop-count={shown.length}
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-2"
+      >
+        {shown.map((entry, index) => (
+          <li
+            key={entry.id}
+            data-drop-index={index}
+            {...drag.rowProps({ list, id: entry.id, index })}
+            className={`flex touch-pan-y items-center gap-2 border-y-2 border-transparent py-1.5 ${
+              drag.dragging?.list === list && drag.dragging.id === entry.id ? 'opacity-40' : ''
+            }`}
+          >
+            <DragHandle
+              label={entry.headword}
+              disabled={busy}
+              onPointerDown={drag.handleProps({ list, id: entry.id, index }).onPointerDown}
+              // This list has no order of its own to change — it is sorted by
+              // the toolbar above — so the arrows would move a row back to where
+              // the sort puts it. Adding is the keyboard path here.
+              onMoveBy={null}
+            />
+            <span className="min-w-0 flex-1 truncate text-sm">
+              <span className="font-display font-bold">{entry.headword}</span>
+              {entry.reading && <span className="text-muted">（{entry.reading}）</span>}
+            </span>
+            <button
+              type="button"
+              onClick={() => onAdd(entry.id)}
+              disabled={busy}
+              className="min-h-9 shrink-0 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
             >
-              <DragHandle
-                label={entry.headword}
-                disabled={busy}
-                onPointerDown={drag.handleProps({ list, id: entry.id, index }).onPointerDown}
-                // This list has no order of its own to change — it is sorted by
-                // the panel above — so the arrows would move a row back to where
-                // the sort puts it. Adding is the keyboard path here.
-                onMoveBy={null}
-              />
-              <span className="min-w-0 flex-1 truncate text-sm">
-                <span className="font-display font-bold">{entry.headword}</span>
-                {entry.reading && <span className="text-muted">（{entry.reading}）</span>}
-              </span>
-              <button
-                type="button"
-                onClick={() => onAdd(entry.id)}
-                disabled={busy}
-                className="min-h-9 shrink-0 rounded-pill bg-accent-soft px-4 text-xs font-semibold text-accent disabled:opacity-60"
-              >
-                ＋ 追加
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="py-4 text-sm text-muted">
-          {entries.length === set.entryIds.length
-            ? 'この単語集にすべての単語が入っています'
-            : '条件に合う単語がありません'}
-        </p>
-      )}
+              ＋ 追加
+            </button>
+          </li>
+        ))}
+
+        {shown.length === 0 && (
+          <li className="py-6 text-center text-sm text-muted">条件に合う単語がありません</li>
+        )}
+      </ul>
     </section>
   );
 }

--- a/src/components/wordsets/PickerToolbar.tsx
+++ b/src/components/wordsets/PickerToolbar.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { FilterPanel } from '@/components/browse/FilterPanel';
+import { EMPTY_FILTERS, isDefault } from '@/lib/filters';
+import type { Filters } from '@/lib/filters';
+
+/**
+ * The search and filters, above both lists rather than inside the one they
+ * narrow.
+ *
+ * They only affect 単語を探す, but they sit across the top so the two panels
+ * below start at the same height and neither is pushed off screen by a filter
+ * being opened — the point of the whole layout is that the drag's source and
+ * its target are visible at once.
+ */
+export function PickerToolbar({
+  filters,
+  allTags,
+  onChange,
+}: {
+  filters: Filters;
+  allTags: string[];
+  onChange: (next: Filters) => void;
+}) {
+  /**
+   * Folded until asked for. 一覧's panel is around 200px tall; open by default
+   * it takes that much off both lists at once.
+   */
+  const [open, setOpen] = useState(false);
+  const narrowed = !isDefault(filters);
+
+  return (
+    <section className="space-y-3 rounded-card bg-card p-4 shadow-panel">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value={filters.q}
+          onChange={(event) => onChange({ ...filters, q: event.target.value })}
+          placeholder="見出し語・読み方・タグ・意味・例文で検索"
+          className="min-h-11 min-w-0 flex-1 rounded-pill border border-line bg-bg px-4 text-sm text-ink placeholder:text-muted"
+        />
+        {narrowed && (
+          <button
+            type="button"
+            onClick={() => onChange({ ...EMPTY_FILTERS, sort: filters.sort })}
+            className="text-xs text-muted underline hover:text-ink"
+          >
+            すべて解除
+          </button>
+        )}
+        <button
+          type="button"
+          aria-expanded={open}
+          onClick={() => setOpen((shown) => !shown)}
+          className={`min-h-11 shrink-0 rounded-pill px-4 text-xs font-medium ${
+            narrowed ? 'bg-accent-soft text-accent' : 'bg-bg-alt text-muted hover:text-ink'
+          }`}
+        >
+          絞り込み{open ? ' ▲' : ' ▼'}
+        </button>
+      </div>
+
+      {open && <FilterPanel filters={filters} allTags={allTags} onChange={onChange} />}
+    </section>
+  );
+}

--- a/src/components/wordsets/WordSetCard.tsx
+++ b/src/components/wordsets/WordSetCard.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom';
+import type { WordSet } from '@/domain/wordSet';
+
+/**
+ * One 単語集 in the list.
+ *
+ * `count` is passed in rather than read off `set.entryIds.length`, because the
+ * two disagree once a word in the set has been deleted — see `membersOf`. The
+ * caller resolves the members, so the card shows the number the detail page
+ * will actually list.
+ */
+export function WordSetCard({ set, count }: { set: WordSet; count: number }) {
+  return (
+    <Link
+      to={`/wordsets/${set.id}`}
+      className="flex flex-col gap-2 rounded-card bg-card p-4 shadow-panel transition hover:-translate-y-0.5"
+    >
+      <h2 className="font-display text-lg font-bold">{set.name}</h2>
+      {set.description && (
+        <p className="prose-cjk line-clamp-2 text-sm text-muted">{set.description}</p>
+      )}
+      <p className="mt-auto text-xs text-muted tabular-nums">{count} 語</p>
+    </Link>
+  );
+}

--- a/src/components/wordsets/WordSetEditModal.tsx
+++ b/src/components/wordsets/WordSetEditModal.tsx
@@ -30,13 +30,21 @@ export function WordSetEditModal({
   const [description, setDescription] = useState(set.description);
   const [invalid, setInvalid] = useState(false);
 
-  // Reopening after a cancel must show what is stored, not what was abandoned.
+  /**
+   * Reopening after a cancel must show what is stored, not what was abandoned.
+   *
+   * Keyed on the id rather than the object: `refresh()` rebuilds every `WordSet`,
+   * so any refresh landing while this is open would otherwise re-run the reset
+   * and discard what has been typed. Unreachable today — this page is the only
+   * writer and 保存する is `busy`-gated — and the key is what keeps it that way
+   * without depending on that argument holding.
+   */
   useEffect(() => {
     if (!open) return;
     setName(set.name);
     setDescription(set.description);
     setInvalid(false);
-  }, [open, set]);
+  }, [open, set.id, set.name, set.description]);
 
   const save = () => {
     if (!name.trim()) return setInvalid(true);

--- a/src/components/wordsets/WordSetEditModal.tsx
+++ b/src/components/wordsets/WordSetEditModal.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import { Area, Field, Text } from '@/components/entry-form/fields';
+import { Modal } from '@/components/Modal';
+import type { WordSet } from '@/domain/wordSet';
+
+/**
+ * Renaming a 単語集 and giving it a description.
+ *
+ * `level` and `topics` are on `WordSet` and have no field here on purpose:
+ * both exist to describe a set to somebody else once it is published, and
+ * nothing publishes yet. A form that wrote them would be asking the user to
+ * fill in metadata no screen in the app reads back.
+ */
+export function WordSetEditModal({
+  open,
+  set,
+  busy,
+  error,
+  onSave,
+  onClose,
+}: {
+  open: boolean;
+  set: WordSet;
+  busy: boolean;
+  error: string | null;
+  onSave: (fields: { name: string; description: string }) => void;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState(set.name);
+  const [description, setDescription] = useState(set.description);
+  const [invalid, setInvalid] = useState(false);
+
+  // Reopening after a cancel must show what is stored, not what was abandoned.
+  useEffect(() => {
+    if (!open) return;
+    setName(set.name);
+    setDescription(set.description);
+    setInvalid(false);
+  }, [open, set]);
+
+  const save = () => {
+    if (!name.trim()) return setInvalid(true);
+    onSave({ name: name.trim(), description: description.trim() });
+  };
+
+  return (
+    <Modal
+      open={open}
+      title="単語集を編集"
+      onClose={onClose}
+      footer={
+        <div className="flex items-center gap-3">
+          {(invalid || error) && (
+            <p className="flex-1 text-xs text-danger">{invalid ? '名前は必須です。' : error}</p>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="ml-auto min-h-10 rounded-pill bg-bg-alt px-5 text-sm font-semibold text-ink"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={busy}
+            className="min-h-10 rounded-pill bg-accent px-5 text-sm font-semibold text-on-accent disabled:opacity-60"
+          >
+            {busy ? '保存中…' : '保存する'}
+          </button>
+        </div>
+      }
+    >
+      <div className="space-y-3">
+        <Field label="名前" hint="必須">
+          <Text
+            value={name}
+            onChange={(value) => {
+              setName(value);
+              setInvalid(false);
+            }}
+          />
+        </Field>
+        <Field label="説明" hint="任意">
+          <Area value={description} onChange={setDescription} rows={3} />
+        </Field>
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -54,8 +54,17 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
   // into the repository can never outlive the session it belongs to.
   const repository = useMemo(() => entryRepositoryFor(uid), [uid]);
 
+  /**
+   * Re-read the notebook. **Deliberately does not raise `loading`.**
+   *
+   * Saving a word and deleting one both end here, and every route treats
+   * `loading` as "replace the page with 読み込み中…" — so raising it blanked
+   * Browse behind the add sheet on every save, losing the scroll position with
+   * it. The entries in hand are one write out of date, not invalid.
+   *
+   * The gate goes up on mount and on an account change, in the effect below.
+   */
   const refresh = useCallback(async () => {
-    setLoading(true);
     setError(null);
     try {
       const all: Entry[] = [];
@@ -75,6 +84,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
   }, [repository]);
 
   useEffect(() => {
+    setLoading(true);
     void refresh();
   }, [refresh]);
 

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -1,4 +1,12 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 import type { Entry } from '@/domain/entry';
 import type { EntryRepository } from '@/domain/ports';
@@ -55,6 +63,23 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
   const repository = useMemo(() => entryRepositoryFor(uid), [uid]);
 
   /**
+   * Which walk is allowed to publish its result.
+   *
+   * The loop below awaits a page at a time, so a `uid` change part-way through
+   * would otherwise finish by calling `setEntries` with the previous account's
+   * notebook. `WordSetsProvider` has carried this since #15; it matters more
+   * here now that `refresh` is the routine tail of every write and no longer
+   * raises `loading`, which makes overlapping walks ordinary rather than
+   * exceptional and leaves the page interactive throughout one — exactly the
+   * window in which a second write can start.
+   *
+   * Untested: no layer available can reach it. A component test may not import
+   * `@/infra/*`, and this provider resolves its repository through
+   * `@/lib/backend`.
+   */
+  const walk = useRef(0);
+
+  /**
    * Re-read the notebook. **Deliberately does not raise `loading`.**
    *
    * Saving a word and deleting one both end here, and every route treats
@@ -65,6 +90,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    * The gate goes up on mount and on an account change, in the effect below.
    */
   const refresh = useCallback(async () => {
+    const mine = (walk.current += 1);
     setError(null);
     try {
       const all: Entry[] = [];
@@ -74,12 +100,12 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
         all.push(...page.items);
         cursor = page.cursor;
       } while (cursor);
-      setEntries(all);
+      if (walk.current === mine) setEntries(all);
     } catch (cause) {
       console.error(cause);
-      setError('単語を読み込めませんでした。');
+      if (walk.current === mine) setError('単語を読み込めませんでした。');
     } finally {
-      setLoading(false);
+      if (walk.current === mine) setLoading(false);
     }
   }, [repository]);
 

--- a/src/lib/listDrag.ts
+++ b/src/lib/listDrag.ts
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+
+/**
+ * Dragging a row from one list into another, or within one.
+ *
+ * Pointer events rather than HTML5 drag-and-drop, for one reason that decides
+ * it: `dragstart` never fires on a touchscreen. This app is laid out for phones
+ * first, so a gesture that only exists on a mouse would be a feature half the
+ * sessions cannot see. Pointer events are one API over mouse, touch and pen.
+ *
+ * It is deliberately not a general drag-and-drop library. It knows about lists
+ * of rows and insertion points between them, which is the only shape used here,
+ * and it leaves the keyboard path to the caller — a drag handle that is a real
+ * `<button>` with arrow keys is more use to a screen reader than any amount of
+ * `aria-grabbed`.
+ */
+
+export interface DragSource {
+  /** Which list the row came from, so a drop can tell add from reorder. */
+  list: string;
+  id: string;
+  index: number;
+}
+
+export interface DropAt {
+  list: string;
+  /** Insertion point: the gap *before* this row. */
+  index: number;
+}
+
+/**
+ * Which gap a pointer at `clientY` is nearest, given the row it is over.
+ *
+ * The midpoint, not the edge: dropping "on" a row is meaningless for a list
+ * that stores an order, and every row would otherwise have a dead zone in it
+ * where nothing happens at all.
+ */
+export function dropIndexFor(index: number, top: number, height: number, clientY: number): number {
+  return clientY < top + height / 2 ? index : index + 1;
+}
+
+/**
+ * Hit-test a point against the marked-up lists.
+ *
+ * Reads the DOM rather than tracking rectangles in state, because the two lists
+ * resize as rows move between them and a cached layout is wrong from the first
+ * frame of the drag onwards.
+ */
+function targetAt(x: number, y: number): DropAt | null {
+  const element = document.elementFromPoint(x, y);
+  if (!(element instanceof Element)) return null;
+
+  const row = element.closest<HTMLElement>('[data-drop-index]');
+  if (row) {
+    const list = row.closest<HTMLElement>('[data-drop-list]')?.dataset.dropList;
+    const index = Number(row.dataset.dropIndex);
+    if (list === undefined || !Number.isInteger(index)) return null;
+    const rect = row.getBoundingClientRect();
+    return { list, index: dropIndexFor(index, rect.top, rect.height, y) };
+  }
+
+  // The container itself, which is what an empty list — or the padding below
+  // the last row — has to accept, or a set with no words in it could never
+  // receive its first one.
+  const container = element.closest<HTMLElement>('[data-drop-list]');
+  const list = container?.dataset.dropList;
+  if (list === undefined) return null;
+  return { list, index: Number(container?.dataset.dropCount ?? 0) };
+}
+
+export interface ListDrag {
+  dragging: DragSource | null;
+  at: DropAt | null;
+  /** Where to draw the thing following the finger. Null when not dragging. */
+  point: { x: number; y: number } | null;
+  handleProps: (source: DragSource) => {
+    onPointerDown: (event: ReactPointerEvent) => void;
+  };
+}
+
+export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): ListDrag {
+  const [dragging, setDragging] = useState<DragSource | null>(null);
+  const [at, setAt] = useState<DropAt | null>(null);
+  const [point, setPoint] = useState<{ x: number; y: number } | null>(null);
+
+  /**
+   * The last target, read by `pointerup`.
+   *
+   * A ref rather than the state above, because `pointerup` and the final
+   * `pointermove` arrive in the same task on a fast flick: the state setter has
+   * not been applied yet when the release is handled, and the drop would land
+   * on the target from two moves ago.
+   */
+  const target = useRef<DropAt | null>(null);
+
+  /**
+   * The drop handler, held by reference.
+   *
+   * It closes over the current order, so the caller rebuilds it every render —
+   * and the listeners below must not be torn down and re-attached on each of
+   * the sixty renders a second a drag produces. Reading it through a ref keeps
+   * the subscription tied to the gesture rather than to the render.
+   */
+  const handler = useRef(onDrop);
+  useEffect(() => {
+    handler.current = onDrop;
+  });
+
+  const handleProps = useCallback(
+    (source: DragSource) => ({
+      onPointerDown: (event: ReactPointerEvent) => {
+        // Left button only; touch and pen report 0 here as well.
+        if (event.pointerType === 'mouse' && event.button !== 0) return;
+        // Stops the browser starting a text selection that then fights the drag.
+        event.preventDefault();
+        target.current = null;
+        setDragging(source);
+        setAt(null);
+        setPoint({ x: event.clientX, y: event.clientY });
+      },
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    if (!dragging) return;
+
+    const stop = () => {
+      setDragging(null);
+      setAt(null);
+      setPoint(null);
+    };
+
+    const move = (event: PointerEvent) => {
+      setPoint({ x: event.clientX, y: event.clientY });
+      const next = targetAt(event.clientX, event.clientY);
+      target.current = next;
+      setAt(next);
+    };
+
+    const up = () => {
+      const dropped = target.current;
+      target.current = null;
+      stop();
+      if (dropped) handler.current(dragging, dropped);
+    };
+
+    const abandon = () => {
+      target.current = null;
+      stop();
+    };
+
+    // Escape abandons the drag: the only way out once a finger is down, and the
+    // one every other drag on the platform offers.
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') abandon();
+    };
+
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    window.addEventListener('pointercancel', abandon);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+      window.removeEventListener('pointercancel', abandon);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [dragging]);
+
+  return { dragging, at, point, handleProps };
+}

--- a/src/lib/listDrag.ts
+++ b/src/lib/listDrag.ts
@@ -172,6 +172,19 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
   const target = useRef<DropAt | null>(null);
 
   /**
+   * Whether a drag is actually running, for the same reason `target` is a ref.
+   *
+   * The listeners below are captured with the render's value of `dragging`, and
+   * the update that sets it comes from `pointermove` — not a discrete event, so
+   * React is under no obligation to have flushed it before the `pointerup` that
+   * follows on a fast flick. The old listener then reads `null`, discards a drop
+   * whose target the ref had recorded perfectly well, and does not arm the
+   * click-swallow either. Guarding the target and leaving the gate in front of
+   * it stale protects nothing.
+   */
+  const active = useRef<DragSource | null>(null);
+
+  /**
    * The drop handler, held by reference.
    *
    * It closes over the current order, so the caller rebuilds it every render —
@@ -202,6 +215,16 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     (source: DragSource) => ({
       onPointerDown: (event: ReactPointerEvent) => {
         if (event.pointerType === 'touch') return;
+        /**
+         * A press that began on a control is that control's. Without this,
+         * `pointerdown` on 削除 or ＋追加 bubbles here and arms a drag, so a
+         * hand that drifts past the slop turns the press into a drop and the
+         * click that would have removed the word is swallowed as the drag's
+         * own. The failure is not "the button did nothing" — it is "the button
+         * did something else". The grip is unaffected: it arms through
+         * `handleProps`, on the way down, before this ever runs.
+         */
+        if (event.target instanceof Element && event.target.closest('button')) return;
         arm(source, event);
       },
     }),
@@ -213,6 +236,7 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     const stop = () => {
       press.current = null;
       cursor.current = null;
+      active.current = null;
       setDragging(null);
       setAt(null);
       setPoint(null);
@@ -223,10 +247,11 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
       if (!armed) return;
       cursor.current = { x: event.clientX, y: event.clientY };
 
-      if (!dragging) {
+      if (!active.current) {
         if (!beyondSlop(armed, { x: event.clientX, y: event.clientY })) return;
         // Committed: the text the press started selecting is not wanted.
         document.getSelection()?.removeAllRanges();
+        active.current = armed.source;
         setDragging(armed.source);
       }
 
@@ -237,12 +262,12 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     };
 
     const up = () => {
-      const dropped = dragging ? target.current : null;
-      const wasDragging = dragging !== null;
+      const dragged = active.current;
+      const dropped = dragged ? target.current : null;
       target.current = null;
       stop();
 
-      if (wasDragging) {
+      if (dragged) {
         /**
          * The click that would follow this release is not a click on the row —
          * the pointer has moved across the screen since it went down — and a
@@ -266,7 +291,7 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
         window.addEventListener('click', swallow, true);
         setTimeout(() => window.removeEventListener('click', swallow, true), 0);
       }
-      if (dropped) handler.current(dragging!, dropped);
+      if (dragged && dropped) handler.current(dragged, dropped);
     };
 
     const abandon = () => {

--- a/src/lib/listDrag.ts
+++ b/src/lib/listDrag.ts
@@ -30,6 +30,53 @@ export interface DropAt {
 }
 
 /**
+ * How far a pointer must travel before a press becomes a drag.
+ *
+ * A whole row is draggable, and a row also holds a link to the word and a
+ * button that removes it. Without a threshold every click on either would begin
+ * a drag, and a hand that moves two pixels between press and release would stop
+ * being able to open a word at all.
+ */
+const PRESS_SLOP = 5;
+
+/** How near a scroller's edge the pointer has to get, and how fast it then moves. */
+const EDGE_ZONE = 56;
+const EDGE_SPEED = 14;
+
+export function beyondSlop(
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+  slop: number = PRESS_SLOP,
+): boolean {
+  return Math.abs(to.x - from.x) > slop || Math.abs(to.y - from.y) > slop;
+}
+
+/**
+ * How far to scroll a panel this frame, given where the pointer is in it.
+ *
+ * Zero everywhere but the top and bottom bands, and proportional inside them,
+ * so the list creeps when the pointer is near the edge and runs when it is at
+ * it. Without this a bounded, scrolling panel can only receive a drop on the
+ * rows that happen to be showing — the reason it is here is the same reason the
+ * panels are bounded at all.
+ */
+export function edgeScrollFor(
+  top: number,
+  bottom: number,
+  clientY: number,
+  edge: number = EDGE_ZONE,
+  speed: number = EDGE_SPEED,
+): number {
+  if (clientY < top + edge) {
+    return -Math.ceil(speed * Math.min(1, (top + edge - clientY) / edge));
+  }
+  if (clientY > bottom - edge) {
+    return Math.ceil(speed * Math.min(1, (clientY - (bottom - edge)) / edge));
+  }
+  return 0;
+}
+
+/**
  * Which gap a pointer at `clientY` is nearest, given the row it is over.
  *
  * The midpoint, not the edge: dropping "on" a row is meaningless for a list
@@ -69,12 +116,37 @@ function targetAt(x: number, y: number): DropAt | null {
   return { list, index: Number(container?.dataset.dropCount ?? 0) };
 }
 
+/** The nearest ancestor of the point that actually scrolls. */
+function scrollerAt(x: number, y: number): HTMLElement | null {
+  let node = document.elementFromPoint(x, y);
+  while (node instanceof HTMLElement) {
+    const overflow = getComputedStyle(node).overflowY;
+    if ((overflow === 'auto' || overflow === 'scroll') && node.scrollHeight > node.clientHeight) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
 export interface ListDrag {
   dragging: DragSource | null;
   at: DropAt | null;
   /** Where to draw the thing following the finger. Null when not dragging. */
   point: { x: number; y: number } | null;
+  /** For the grip: arms a drag from any pointer, including touch. */
   handleProps: (source: DragSource) => {
+    onPointerDown: (event: ReactPointerEvent) => void;
+  };
+  /**
+   * For the row body: arms a drag from a mouse or a pen, never from a finger.
+   *
+   * A touch drag needs `touch-action: none` on whatever it starts from, and a
+   * whole row marked that way is a row the page can no longer be scrolled by —
+   * inside a bounded panel, that is most of the panel. On touch the grip stays
+   * the way in, and it is a 44px target for exactly that reason.
+   */
+  rowProps: (source: DragSource) => {
     onPointerDown: (event: ReactPointerEvent) => void;
   };
 }
@@ -83,6 +155,11 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
   const [dragging, setDragging] = useState<DragSource | null>(null);
   const [at, setAt] = useState<DropAt | null>(null);
   const [point, setPoint] = useState<{ x: number; y: number } | null>(null);
+
+  /** A press that has not travelled far enough to be a drag yet. */
+  const press = useRef<{ source: DragSource; x: number; y: number } | null>(null);
+  /** The live pointer, read by the scroll loop between moves. */
+  const cursor = useRef<{ x: number; y: number } | null>(null);
 
   /**
    * The last target, read by `pointerup`.
@@ -107,32 +184,52 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     handler.current = onDrop;
   });
 
+  const arm = useCallback((source: DragSource, event: ReactPointerEvent) => {
+    // Left button only; touch and pen report 0 here as well.
+    if (event.pointerType === 'mouse' && event.button !== 0) return;
+    press.current = { source, x: event.clientX, y: event.clientY };
+    cursor.current = { x: event.clientX, y: event.clientY };
+  }, []);
+
   const handleProps = useCallback(
     (source: DragSource) => ({
-      onPointerDown: (event: ReactPointerEvent) => {
-        // Left button only; touch and pen report 0 here as well.
-        if (event.pointerType === 'mouse' && event.button !== 0) return;
-        // Stops the browser starting a text selection that then fights the drag.
-        event.preventDefault();
-        target.current = null;
-        setDragging(source);
-        setAt(null);
-        setPoint({ x: event.clientX, y: event.clientY });
-      },
+      onPointerDown: (event: ReactPointerEvent) => arm(source, event),
     }),
-    [],
+    [arm],
   );
 
-  useEffect(() => {
-    if (!dragging) return;
+  const rowProps = useCallback(
+    (source: DragSource) => ({
+      onPointerDown: (event: ReactPointerEvent) => {
+        if (event.pointerType === 'touch') return;
+        arm(source, event);
+      },
+    }),
+    [arm],
+  );
 
+  // Watching a press, whether or not it has become a drag yet.
+  useEffect(() => {
     const stop = () => {
+      press.current = null;
+      cursor.current = null;
       setDragging(null);
       setAt(null);
       setPoint(null);
     };
 
     const move = (event: PointerEvent) => {
+      const armed = press.current;
+      if (!armed) return;
+      cursor.current = { x: event.clientX, y: event.clientY };
+
+      if (!dragging) {
+        if (!beyondSlop(armed, { x: event.clientX, y: event.clientY })) return;
+        // Committed: the text the press started selecting is not wanted.
+        document.getSelection()?.removeAllRanges();
+        setDragging(armed.source);
+      }
+
       setPoint({ x: event.clientX, y: event.clientY });
       const next = targetAt(event.clientX, event.clientY);
       target.current = next;
@@ -140,10 +237,36 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     };
 
     const up = () => {
-      const dropped = target.current;
+      const dropped = dragging ? target.current : null;
+      const wasDragging = dragging !== null;
       target.current = null;
       stop();
-      if (dropped) handler.current(dragging, dropped);
+
+      if (wasDragging) {
+        /**
+         * The click that would follow this release is not a click on the row —
+         * the pointer has moved across the screen since it went down — and a
+         * row is a link, so left alone it would open the word just dropped.
+         *
+         * **Unproven, and kept anyway.** Chromium fires no click at all after
+         * any drag this suite can produce, including one released on the row it
+         * started from, so nothing here has ever been observed to run. It is
+         * kept because the browsers the suite does not cover are not obliged to
+         * agree, and because a stray navigation mid-arrangement loses the
+         * screen the learner was working on. Do not treat it as tested.
+         *
+         * Removed on the next task rather than with `once`, so a gesture that
+         * produces no click cannot leave a listener waiting to eat an
+         * unrelated one.
+         */
+        const swallow = (click: MouseEvent) => {
+          click.preventDefault();
+          click.stopPropagation();
+        };
+        window.addEventListener('click', swallow, true);
+        setTimeout(() => window.removeEventListener('click', swallow, true), 0);
+      }
+      if (dropped) handler.current(dragging!, dropped);
     };
 
     const abandon = () => {
@@ -169,5 +292,40 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
     };
   }, [dragging]);
 
-  return { dragging, at, point, handleProps };
+  /**
+   * Scrolling the panel under the pointer while a drag is held near its edge.
+   *
+   * A frame loop rather than work done inside `pointermove`, because a pointer
+   * held still at the bottom of a list fires no more moves — and holding still
+   * at the edge is exactly the gesture that means "keep going".
+   */
+  useEffect(() => {
+    if (!dragging) return;
+    let frame = 0;
+
+    const step = () => {
+      frame = requestAnimationFrame(step);
+      const point = cursor.current;
+      if (!point) return;
+
+      const scroller = scrollerAt(point.x, point.y);
+      if (!scroller) return;
+
+      const rect = scroller.getBoundingClientRect();
+      const by = edgeScrollFor(rect.top, rect.bottom, point.y);
+      if (by === 0) return;
+
+      scroller.scrollTop += by;
+      // The rows moved under a pointer that did not, so the target it was over
+      // is stale by exactly this much.
+      const next = targetAt(point.x, point.y);
+      target.current = next;
+      setAt(next);
+    };
+
+    frame = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frame);
+  }, [dragging]);
+
+  return { dragging, at, point, handleProps, rowProps };
 }

--- a/src/lib/listDrag.ts
+++ b/src/lib/listDrag.ts
@@ -293,6 +293,28 @@ export function useListDrag(onDrop: (source: DragSource, at: DropAt) => void): L
   }, [dragging]);
 
   /**
+   * The cursor, and the text under it, for as long as the drag lasts.
+   *
+   * Set on `document.body` rather than on the row, because the pointer spends
+   * the drag over everything *except* the row it started on — over the other
+   * panel, over the gaps, over the page. A grab cursor that reverts to a text
+   * caret the moment the pointer leaves the row reads as the drag having been
+   * dropped. `user-select` goes with it: a pointer held down and moved is a
+   * text selection to the browser, and a half-selected list is the visible
+   * evidence of that fight.
+   */
+  useEffect(() => {
+    if (!dragging) return;
+    const { cursor: hadCursor, userSelect: hadSelect } = document.body.style;
+    document.body.style.cursor = 'grabbing';
+    document.body.style.userSelect = 'none';
+    return () => {
+      document.body.style.cursor = hadCursor;
+      document.body.style.userSelect = hadSelect;
+    };
+  }, [dragging]);
+
+  /**
    * Scrolling the panel under the pointer while a drag is held near its edge.
    *
    * A frame loop rather than work done inside `pointermove`, because a pointer

--- a/src/lib/wordSetMembers.ts
+++ b/src/lib/wordSetMembers.ts
@@ -99,6 +99,36 @@ export function withoutMembers(
 }
 
 /**
+ * Where a row on screen sits in the stored array.
+ *
+ * The two are not the same list. `membersOf` drops an id whose word has been
+ * deleted, so 収録語 can be shorter than `entryIds`, and every position after
+ * the missing one is off by one. Handing a visible index straight to
+ * `reorderMembers` then moves whichever id happens to occupy that slot — often
+ * the stale one, which changes nothing on screen and still costs a write, so
+ * the gesture reads as broken rather than as refused.
+ *
+ * Two edges are deliberate. A visible index past the last row is the trailing
+ * gap and answers `entryIds.length`, which is where an append belongs. A
+ * negative one is passed through rather than clamped, because that is how
+ * ArrowUp on the first row says "before everything", and `reorderMembers` is
+ * what decides that means stay put.
+ */
+export function storedIndexFor(
+  entryIds: readonly string[],
+  visibleIds: readonly string[],
+  visible: number,
+): number {
+  if (visible < 0) return -1;
+
+  const id = visibleIds[visible];
+  if (id === undefined) return entryIds.length;
+
+  const found = entryIds.indexOf(id);
+  return found === -1 ? entryIds.length : found;
+}
+
+/**
  * Move the member at `from` so that it lands at insertion point `to`.
  *
  * `to` is an insertion index in the *original* array's coordinates — the gap

--- a/src/lib/wordSetMembers.ts
+++ b/src/lib/wordSetMembers.ts
@@ -1,0 +1,101 @@
+import type { Entry } from '@/domain/entry';
+import type { WordSet, WordSetDraft } from '@/domain/wordSet';
+
+/**
+ * Turning a 単語集 into the words it holds, and back into something writable.
+ *
+ * Membership is stored as `WordSet.entryIds` and nothing on the entry side
+ * points back, so every screen that shows a set has to resolve the ids against
+ * the notebook it already has in memory. That resolution is the whole of this
+ * module, and it is pure so the pages above it stay about buttons.
+ */
+
+/**
+ * The words in a set, in the order the set stores them.
+ *
+ * **An id with no entry behind it is dropped rather than rendered blank.**
+ * Deleting a word does not visit the sets that named it — that would be one
+ * write per set for a delete that has nothing to do with them — so a set can
+ * outlive its members. Resolving through the notebook is what makes that
+ * harmless: the row disappears, and the count derived from this list agrees
+ * with what is on screen. `entryIds.length` does not, which is why nothing
+ * displays it.
+ *
+ * The stored order is the study order, so it is preserved exactly; sorting
+ * here would quietly discard the one thing this array carries beyond a set.
+ */
+export function membersOf(set: WordSet, entries: readonly Entry[]): Entry[] {
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
+  return set.entryIds.flatMap((id) => {
+    const entry = byId.get(id);
+    return entry ? [entry] : [];
+  });
+}
+
+/** How many suggestions the add-a-word box offers at once. */
+export const CANDIDATE_LIMIT = 8;
+
+/**
+ * Words matching what was typed, minus the ones already in the set.
+ *
+ * Excluding current members is not cosmetic: adding a word twice is a no-op
+ * that looks like a broken button, and the search box is the only place the
+ * two lists are visible at the same time.
+ *
+ * An empty query returns nothing rather than everything — this is a picker for
+ * a set that may hold a handful of words out of hundreds, and an unfiltered
+ * list of the whole notebook is not a suggestion.
+ */
+export function candidatesFor(
+  set: WordSet,
+  entries: readonly Entry[],
+  query: string,
+  limit: number = CANDIDATE_LIMIT,
+): Entry[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [];
+
+  const taken = new Set(set.entryIds);
+  const found: Entry[] = [];
+  for (const entry of entries) {
+    if (found.length === limit) break;
+    if (taken.has(entry.id)) continue;
+    if (
+      entry.headword.toLowerCase().includes(needle) ||
+      entry.reading.toLowerCase().includes(needle)
+    ) {
+      found.push(entry);
+    }
+  }
+  return found;
+}
+
+/**
+ * Appended, not prepended, and never twice.
+ *
+ * New words joining at the end keeps the study order the set was built in.
+ */
+export function withMember(entryIds: readonly string[], entryId: string): string[] {
+  return entryIds.includes(entryId) ? [...entryIds] : [...entryIds, entryId];
+}
+
+export function withoutMember(entryIds: readonly string[], entryId: string): string[] {
+  return entryIds.filter((id) => id !== entryId);
+}
+
+/**
+ * The writable half of a set.
+ *
+ * Written out field by field rather than by destructuring the rest, so that a
+ * new field on `WordSet` fails to compile here instead of silently never being
+ * written back — an edit would then reset it to whatever the form left out.
+ */
+export function toDraft(set: WordSet): WordSetDraft {
+  return {
+    name: set.name,
+    description: set.description,
+    entryIds: set.entryIds,
+    level: set.level,
+    topics: set.topics,
+  };
+}

--- a/src/lib/wordSetMembers.ts
+++ b/src/lib/wordSetMembers.ts
@@ -84,6 +84,21 @@ export function withoutMember(entryIds: readonly string[], entryId: string): str
 }
 
 /**
+ * Drop several at once — the ones a screen was showing, and only those.
+ *
+ * Not "empty the set": an id whose word has been deleted is not on that screen,
+ * so it is not among the ids handed in, and it stays. Clearing it as well would
+ * be this control quietly doing something nobody asked it to.
+ */
+export function withoutMembers(
+  entryIds: readonly string[],
+  entryIdsToDrop: readonly string[],
+): string[] {
+  const dropping = new Set(entryIdsToDrop);
+  return entryIds.filter((id) => !dropping.has(id));
+}
+
+/**
  * Move the member at `from` so that it lands at insertion point `to`.
  *
  * `to` is an insertion index in the *original* array's coordinates — the gap

--- a/src/lib/wordSetMembers.ts
+++ b/src/lib/wordSetMembers.ts
@@ -1,5 +1,7 @@
 import type { Entry } from '@/domain/entry';
 import type { WordSet, WordSetDraft } from '@/domain/wordSet';
+import { matches, sortEntries } from '@/lib/filters';
+import type { Filters } from '@/lib/filters';
 
 /**
  * Turning a 単語集 into the words it holds, and back into something writable.
@@ -32,42 +34,40 @@ export function membersOf(set: WordSet, entries: readonly Entry[]): Entry[] {
   });
 }
 
-/** How many suggestions the add-a-word box offers at once. */
-export const CANDIDATE_LIMIT = 8;
+/**
+ * How many candidates the picker renders at once.
+ *
+ * A cap rather than a page, because the list is a drag source: reaching row
+ * 200 means scrolling the drop target off screen mid-gesture. The count of
+ * everything that matched is shown beside it, so a number larger than this is
+ * a prompt to narrow the filters rather than to scroll.
+ */
+export const CANDIDATE_LIMIT = 50;
 
 /**
- * Words matching what was typed, minus the ones already in the set.
+ * Words that could join the set, narrowed the same way 一覧 narrows the
+ * notebook, minus the ones already in it.
  *
  * Excluding current members is not cosmetic: adding a word twice is a no-op
- * that looks like a broken button, and the search box is the only place the
- * two lists are visible at the same time.
+ * that looks like a broken button, and this is the one screen where both lists
+ * are visible at once.
  *
- * An empty query returns nothing rather than everything — this is a picker for
- * a set that may hold a handful of words out of hundreds, and an unfiltered
- * list of the whole notebook is not a suggestion.
+ * With no filters set this is the whole notebook, newest first — `EMPTY_FILTERS`
+ * sorts by 追加日（新しい順）, so the words most likely to be filed into a set
+ * are the ones already on screen before anything is typed.
  */
 export function candidatesFor(
   set: WordSet,
   entries: readonly Entry[],
-  query: string,
+  filters: Filters,
   limit: number = CANDIDATE_LIMIT,
-): Entry[] {
-  const needle = query.trim().toLowerCase();
-  if (!needle) return [];
-
+): { shown: Entry[]; total: number } {
   const taken = new Set(set.entryIds);
-  const found: Entry[] = [];
-  for (const entry of entries) {
-    if (found.length === limit) break;
-    if (taken.has(entry.id)) continue;
-    if (
-      entry.headword.toLowerCase().includes(needle) ||
-      entry.reading.toLowerCase().includes(needle)
-    ) {
-      found.push(entry);
-    }
-  }
-  return found;
+  const found = sortEntries(
+    entries.filter((entry) => !taken.has(entry.id) && matches(entry, filters)),
+    filters.sort,
+  );
+  return { shown: found.slice(0, limit), total: found.length };
 }
 
 /**
@@ -81,6 +81,52 @@ export function withMember(entryIds: readonly string[], entryId: string): string
 
 export function withoutMember(entryIds: readonly string[], entryId: string): string[] {
   return entryIds.filter((id) => id !== entryId);
+}
+
+/**
+ * Move the member at `from` so that it lands at insertion point `to`.
+ *
+ * `to` is an insertion index in the *original* array's coordinates — the gap
+ * before row `to` — which is what a drop indicator between two rows actually
+ * means. Removing the item first shifts everything after it down by one, so a
+ * downward move has to lose one to land where the indicator was drawn; without
+ * that correction every drag downwards stops one row short of where it was
+ * released, which reads as the feature being broken rather than off by one.
+ */
+export function reorderMembers(entryIds: readonly string[], from: number, to: number): string[] {
+  const next = [...entryIds];
+
+  // An index past the end takes nothing out, which is the answer for a stale
+  // row index arriving after a refresh has shortened the list.
+  const [moved] = next.splice(from, 1);
+  if (moved === undefined) return [...entryIds];
+
+  // Clamped at the bottom only. `splice` already clamps a high index, but a
+  // negative one counts back from the end — and ArrowUp on the first row asks
+  // for gap -1, which would then put it second instead of leaving it alone.
+  const target = Math.max(0, to);
+  next.splice(target > from ? target - 1 : target, 0, moved);
+  return next;
+}
+
+/**
+ * Put a word at a given insertion point, whether or not the set already holds it.
+ *
+ * Dragging a member onto a new position and dragging an outside word in are the
+ * same gesture, and the drop target cannot tell which it was handed — so this
+ * moves an existing member rather than inserting a duplicate.
+ */
+export function insertMemberAt(
+  entryIds: readonly string[],
+  entryId: string,
+  index: number,
+): string[] {
+  const existing = entryIds.indexOf(entryId);
+  if (existing !== -1) return reorderMembers(entryIds, existing, index);
+
+  const next = [...entryIds];
+  next.splice(Math.max(0, Math.min(index, next.length)), 0, entryId);
+  return next;
 }
 
 /**

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from 'react';
 import type { ReactNode } from 'react';
+import type { WordSetRepository } from '@/domain/ports';
 import type { WordSet } from '@/domain/wordSet';
 import { wordSetRepositoryFor } from '@/lib/backend';
 
@@ -16,6 +17,12 @@ interface WordSetsValue {
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
+  /**
+   * Exposed for the same reason `EntriesProvider` exposes its own: `/wordsets`
+   * writes through the instance the list was read from, so a write and the
+   * refresh that follows it can never be talking to two different accounts.
+   */
+  repository: WordSetRepository;
 }
 
 const WordSetsContext = createContext<WordSetsValue | null>(null);
@@ -31,11 +38,9 @@ const PAGE_SIZE = 200;
 /**
  * The user's 単語集, loaded once.
  *
- * Nothing creates a set yet — `/wordsets` is still a placeholder — so in the
- * running app this list is empty and the practice filter that reads it stays
- * hidden. That is the design's own rule for the chips ("only shown if any
- * exist") rather than a stub: the read path is real, and the filter starts
- * working the day the first set is written.
+ * Every screen wants all of them and there are few, so this is one list rather
+ * than a query per page: `/wordsets` renders it, `/wordsets/:id` picks one out
+ * of it, and the practice filter builds its chips from it.
  */
 export function WordSetsProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [sets, setSets] = useState<WordSet[]>([]);
@@ -81,7 +86,10 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
     void refresh();
   }, [refresh]);
 
-  const value = useMemo(() => ({ sets, loading, error, refresh }), [sets, loading, error, refresh]);
+  const value = useMemo(
+    () => ({ sets, loading, error, refresh, repository }),
+    [sets, loading, error, refresh, repository],
+  );
   return <WordSetsContext.Provider value={value}>{children}</WordSetsContext.Provider>;
 }
 

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -61,9 +61,20 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
    */
   const walk = useRef(0);
 
+  /**
+   * Re-read the sets. **Deliberately does not raise `loading`.**
+   *
+   * Every write on `/wordsets` ends here, and the routes treat `loading` as
+   * "replace the page with 読み込み中…" — so raising it took the whole screen
+   * down and put it back on every add, rename and reorder. The list in hand is
+   * not invalid during a refresh, it is one write out of date, and the screen
+   * that has it is the right thing to keep showing.
+   *
+   * The gate still goes up where nothing valid *is* in hand: on mount, and when
+   * `repository` changes because the account did. That is the effect below.
+   */
   const refresh = useCallback(async () => {
     const mine = (walk.current += 1);
-    setLoading(true);
     setError(null);
     try {
       const all: WordSet[] = [];
@@ -83,6 +94,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
   }, [repository]);
 
   useEffect(() => {
+    setLoading(true);
     void refresh();
   }, [refresh]);
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { AppLayout } from './components/AppLayout';
-import { History, WordSets } from './routes/Placeholder';
+import { History } from './routes/Placeholder';
 
 // Routes follow the handoff. AppLayout gates everything below it on auth;
 // /login sits outside so it stays reachable when signed out.
@@ -16,7 +16,8 @@ export const router = createBrowserRouter([
       // One module for both modes; it rejects anything else in :mode. The nav
       // still links the two concrete paths.
       { path: 'practice/:mode', lazy: () => import('./routes/Practice') },
-      { path: 'wordsets', element: <WordSets /> },
+      { path: 'wordsets', lazy: () => import('./routes/WordSets') },
+      { path: 'wordsets/:id', lazy: () => import('./routes/WordSetDetail') },
       { path: 'history', element: <History /> },
     ],
   },

--- a/src/routes/Placeholder.tsx
+++ b/src/routes/Placeholder.tsx
@@ -1,7 +1,7 @@
 /**
- * The two Phase 2 destinations still to be built. They exist so the nav from
- * the handoff is complete and no link dead-ends on a 404. Practice is no longer
- * among them — see `routes/Practice.tsx`.
+ * The one Phase 2 destination still to be built. It exists so the nav from the
+ * handoff is complete and no link dead-ends on a 404. Practice and 単語集 are no
+ * longer among them — see `routes/Practice.tsx` and `routes/WordSets.tsx`.
  */
 function Placeholder({ title, note }: { title: string; note: string }) {
   return (
@@ -10,10 +10,6 @@ function Placeholder({ title, note }: { title: string; note: string }) {
       <p className="mt-2 text-sm text-muted">{note}</p>
     </section>
   );
-}
-
-export function WordSets() {
-  return <Placeholder title="単語集" note="単語集は次のフェーズで実装します。" />;
 }
 
 export function History() {

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/practice';
 import type { Answer, PracticeFilters } from '@/lib/practice';
 import { useProgress } from '@/lib/progress';
+import { membersOf } from '@/lib/wordSetMembers';
 import { useWordSets } from '@/lib/wordSets';
 
 /**
@@ -98,6 +99,17 @@ function Practice({ mode }: { mode: PracticeMode }) {
     [entries, weakIds],
   );
 
+  /** Counted the same way and for the same reason — see `membersOf`. */
+  const setChips = useMemo(
+    () =>
+      sets.map((set) => ({
+        id: set.id,
+        name: set.name,
+        count: membersOf(set, entries).length,
+      })),
+    [sets, entries],
+  );
+
   const matches = useMemo(() => {
     const scope = scopeFor(filters, sets, weakIds);
     return entries.filter((entry) => matchesPractice(entry, filters, scope));
@@ -156,7 +168,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
         mode={mode}
         filters={filters}
         allTags={allTags}
-        allSets={sets}
+        allSets={setChips}
         now={now}
         matchCount={matches.length}
         weakCount={weakCount}

--- a/src/routes/WordSetDetail.tsx
+++ b/src/routes/WordSetDetail.tsx
@@ -19,6 +19,7 @@ import {
   toDraft,
   withMember,
   withoutMember,
+  withoutMembers,
 } from '@/lib/wordSetMembers';
 import { useWordSets } from '@/lib/wordSets';
 
@@ -45,6 +46,16 @@ export function Component() {
   const [writeError, setWriteError] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  /**
+   * The words 表示中の N 語を削除 is asking about, or null when it has not been
+   * pressed.
+   *
+   * It confirms and 削除 on a single row does not, because they are different
+   * sizes of mistake: one row is one press to put back, and the whole list
+   * takes the study order with it — an order that took dragging to build and
+   * that nothing records anywhere else.
+   */
+  const [clearing, setClearing] = useState<string[] | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
 
@@ -223,6 +234,7 @@ export function Component() {
             onRemove={(entryId) =>
               void write({ ...toDraft(set), entryIds: withoutMember(entryIds, entryId) })
             }
+            onRemoveAll={setClearing}
             onMoveBy={(index, delta) =>
               applyOrder(reorderMembers(entryIds, index, delta < 0 ? index - 1 : index + 2))
             }
@@ -248,6 +260,20 @@ export function Component() {
           void write({ ...toDraft(set), ...fields }).then((ok) => {
             if (ok) setEditing(false);
           });
+        }}
+      />
+
+      <ConfirmDialog
+        open={clearing !== null}
+        title="表示中の単語を削除"
+        message={`この単語集から ${clearing?.length ?? 0} 語を外しますか？\n単語そのものは削除されません。`}
+        confirmLabel="外す"
+        busy={busy}
+        error={writeError}
+        onClose={() => setClearing(null)}
+        onConfirm={() => {
+          if (clearing) applyOrder(withoutMembers(entryIds, clearing));
+          setClearing(null);
         }}
       />
 

--- a/src/routes/WordSetDetail.tsx
+++ b/src/routes/WordSetDetail.tsx
@@ -1,13 +1,27 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { Ruby } from '@/components/Ruby';
+import { MemberList } from '@/components/wordsets/MemberList';
 import { MemberPicker } from '@/components/wordsets/MemberPicker';
 import { WordSetEditModal } from '@/components/wordsets/WordSetEditModal';
 import type { WordSetDraft } from '@/domain/wordSet';
 import { useEntries } from '@/lib/entries';
-import { membersOf, toDraft, withMember, withoutMember } from '@/lib/wordSetMembers';
+import { EMPTY_FILTERS } from '@/lib/filters';
+import type { Filters } from '@/lib/filters';
+import { useListDrag } from '@/lib/listDrag';
+import type { DragSource, DropAt } from '@/lib/listDrag';
+import {
+  insertMemberAt,
+  membersOf,
+  reorderMembers,
+  toDraft,
+  withoutMember,
+} from '@/lib/wordSetMembers';
 import { useWordSets } from '@/lib/wordSets';
+
+/** The two drag lists on this page, named once so a typo cannot silently miss. */
+const MEMBERS = 'members';
+const CANDIDATES = 'candidates';
 
 /**
  * One 単語集: what is in it, and everything that changes it.
@@ -29,6 +43,17 @@ export function Component() {
   const [editing, setEditing] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS);
+
+  /**
+   * The order a drop just produced, shown before the write comes back.
+   *
+   * Without it a reorder snaps to the stored order for as long as the round
+   * trip takes and then jumps to the new one, which reads as the drop having
+   * failed and been retried. Tagged with the set it belongs to, so a navigation
+   * mid-write cannot paint one set's order onto another's.
+   */
+  const [pending, setPending] = useState<{ setId: string; entryIds: string[] } | null>(null);
 
   const set = sets.find((item) => item.id === id);
 
@@ -46,6 +71,10 @@ export function Component() {
       return false;
     } finally {
       setBusy(false);
+      // Cleared whether or not it worked: the refresh above has already put the
+      // stored order back in hand, and on a failure that stored order is the
+      // honest thing to show.
+      setPending(null);
     }
   };
 
@@ -70,6 +99,43 @@ export function Component() {
     }
   };
 
+  const allTags = useMemo(
+    () =>
+      [...new Set(entries.flatMap((entry) => entry.tags))].sort((a, b) => a.localeCompare(b, 'ja')),
+    [entries],
+  );
+
+  /** The order on screen: what a drop just produced, or what is stored. */
+  const entryIds =
+    pending && set && pending.setId === set.id ? pending.entryIds : (set?.entryIds ?? []);
+
+  /**
+   * Send an order, unless it is the one already showing.
+   *
+   * The no-change guard is what stops a drop back onto the row it came from
+   * from costing a write, which is most of the drops a hesitant hand makes.
+   */
+  const applyOrder = (next: readonly string[]) => {
+    if (!set || busy) return;
+    if (next.length === entryIds.length && next.every((value, at) => value === entryIds[at]))
+      return;
+    setPending({ setId: set.id, entryIds: [...next] });
+    void write({ ...toDraft(set), entryIds: [...next] });
+  };
+
+  const drag = useListDrag((source: DragSource, at: DropAt) => {
+    // Dropping back into the notebook does nothing. Removing by dragging a word
+    // out would be the symmetric gesture, and is deliberately absent: a slip
+    // would then take a word out of the set silently, where 削除 is a button
+    // that says what it does.
+    if (at.list !== MEMBERS) return;
+    applyOrder(
+      source.list === MEMBERS
+        ? reorderMembers(entryIds, source.index, at.index)
+        : insertMemberAt(entryIds, source.id, at.index),
+    );
+  });
+
   if (loading || entriesLoading)
     return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
   if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
@@ -85,7 +151,7 @@ export function Component() {
     );
   }
 
-  const members = membersOf(set, entries);
+  const members = membersOf({ ...set, entryIds }, entries);
 
   return (
     <div className="space-y-4">
@@ -118,47 +184,34 @@ export function Component() {
 
       {writeError && <p className="text-sm text-danger">{writeError}</p>}
 
-      <MemberPicker
-        set={set}
-        entries={entries}
+      {/* 収録語 above 単語を探す: the set is what this page is about, and the
+          notebook below it is the source you pull from. It also puts the drop
+          target above its drag sources, so a drag is upward and does not fight
+          the page scrolling down. */}
+      <MemberList
+        members={members}
+        list={MEMBERS}
+        drag={drag}
         busy={busy}
-        onAdd={(entryId) =>
-          void write({ ...toDraft(set), entryIds: withMember(set.entryIds, entryId) })
+        onRemove={(entryId) =>
+          void write({ ...toDraft(set), entryIds: withoutMember(entryIds, entryId) })
+        }
+        onMoveBy={(index, delta) =>
+          applyOrder(reorderMembers(entryIds, index, delta < 0 ? index - 1 : index + 2))
         }
       />
 
-      <section className="space-y-2 rounded-card bg-card p-5 shadow-panel">
-        <h2 className="text-sm font-semibold">収録語</h2>
-        {members.length ? (
-          <ul className="divide-y divide-line">
-            {members.map((entry) => (
-              <li key={entry.id} className="flex items-center justify-between gap-3 py-2">
-                <Link to={`/vocabulary/${entry.id}`} className="min-w-0 truncate">
-                  <Ruby
-                    headword={entry.headword}
-                    reading={entry.reading}
-                    className="has-ruby font-display text-base font-bold"
-                  />
-                </Link>
-                <button
-                  type="button"
-                  onClick={() =>
-                    void write({ ...toDraft(set), entryIds: withoutMember(set.entryIds, entry.id) })
-                  }
-                  disabled={busy}
-                  className="min-h-9 shrink-0 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger disabled:opacity-60"
-                >
-                  削除
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="py-4 text-sm text-muted">
-            まだ単語がありません。上の検索から追加してください。
-          </p>
-        )}
-      </section>
+      <MemberPicker
+        set={set}
+        entries={entries}
+        allTags={allTags}
+        filters={filters}
+        list={CANDIDATES}
+        drag={drag}
+        busy={busy}
+        onFiltersChange={setFilters}
+        onAdd={(entryId) => applyOrder(insertMemberAt(entryIds, entryId, entryIds.length))}
+      />
 
       <button
         type="button"
@@ -194,6 +247,19 @@ export function Component() {
         }}
         onConfirm={() => void confirmDelete()}
       />
+
+      {/* What follows the finger. `pointer-events-none` is not styling: the
+          drop target is found with elementFromPoint, and a ghost under the
+          cursor would be the only thing it ever finds. */}
+      {drag.dragging && drag.point && (
+        <div
+          aria-hidden
+          style={{ left: drag.point.x, top: drag.point.y }}
+          className="pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-1/2 rounded-pill bg-accent px-3 py-1 font-display text-xs font-bold text-on-accent shadow-panel"
+        >
+          {entries.find((entry) => entry.id === drag.dragging?.id)?.headword}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/routes/WordSetDetail.tsx
+++ b/src/routes/WordSetDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { MemberList } from '@/components/wordsets/MemberList';
 import { MemberPicker } from '@/components/wordsets/MemberPicker';
+import { PickerToolbar } from '@/components/wordsets/PickerToolbar';
 import { WordSetEditModal } from '@/components/wordsets/WordSetEditModal';
 import type { WordSetDraft } from '@/domain/wordSet';
 import { useEntries } from '@/lib/entries';
@@ -11,10 +12,12 @@ import type { Filters } from '@/lib/filters';
 import { useListDrag } from '@/lib/listDrag';
 import type { DragSource, DropAt } from '@/lib/listDrag';
 import {
+  candidatesFor,
   insertMemberAt,
   membersOf,
   reorderMembers,
   toDraft,
+  withMember,
   withoutMember,
 } from '@/lib/wordSetMembers';
 import { useWordSets } from '@/lib/wordSets';
@@ -152,6 +155,9 @@ export function Component() {
   }
 
   const members = membersOf({ ...set, entryIds }, entries);
+  // Against the order on screen, not the stored one, so a word just dropped in
+  // leaves the list it was dragged from in the same render.
+  const candidates = candidatesFor({ ...set, entryIds }, entries, filters);
 
   return (
     <div className="space-y-4">
@@ -184,34 +190,45 @@ export function Component() {
 
       {writeError && <p className="text-sm text-danger">{writeError}</p>}
 
-      {/* 収録語 above 単語を探す: the set is what this page is about, and the
-          notebook below it is the source you pull from. It also puts the drop
-          target above its drag sources, so a drag is upward and does not fight
-          the page scrolling down. */}
-      <MemberList
-        members={members}
-        list={MEMBERS}
-        drag={drag}
-        busy={busy}
-        onRemove={(entryId) =>
-          void write({ ...toDraft(set), entryIds: withoutMember(entryIds, entryId) })
-        }
-        onMoveBy={(index, delta) =>
-          applyOrder(reorderMembers(entryIds, index, delta < 0 ? index - 1 : index + 2))
-        }
-      />
+      <PickerToolbar filters={filters} allTags={allTags} onChange={setFilters} />
 
-      <MemberPicker
-        set={set}
-        entries={entries}
-        allTags={allTags}
-        filters={filters}
-        list={CANDIDATES}
-        drag={drag}
-        busy={busy}
-        onFiltersChange={setFilters}
-        onAdd={(entryId) => applyOrder(insertMemberAt(entryIds, entryId, entryIds.length))}
-      />
+      {/*
+        Source on the left, destination on the right, and both bounded so they
+        scroll inside themselves. Stacked one above the other they drifted
+        apart as soon as either had a few rows in it, and a drag whose start and
+        end are never on screen together cannot be performed. Below the nav
+        breakpoint they stack, which is why the cap is a fraction of the
+        viewport rather than a fixed height: two of them still fit.
+      */}
+      <div className="grid gap-4 nav:grid-cols-2">
+        <div className="flex max-h-[46vh] min-h-64 nav:max-h-[62vh]">
+          <MemberPicker
+            shown={candidates.shown}
+            total={candidates.total}
+            list={CANDIDATES}
+            drag={drag}
+            busy={busy}
+            onAdd={(entryId) => applyOrder(insertMemberAt(entryIds, entryId, entryIds.length))}
+            onAddAll={(ids) =>
+              applyOrder(ids.reduce<readonly string[]>((so, id) => withMember(so, id), entryIds))
+            }
+          />
+        </div>
+        <div className="flex max-h-[46vh] min-h-64 nav:max-h-[62vh]">
+          <MemberList
+            members={members}
+            list={MEMBERS}
+            drag={drag}
+            busy={busy}
+            onRemove={(entryId) =>
+              void write({ ...toDraft(set), entryIds: withoutMember(entryIds, entryId) })
+            }
+            onMoveBy={(index, delta) =>
+              applyOrder(reorderMembers(entryIds, index, delta < 0 ? index - 1 : index + 2))
+            }
+          />
+        </div>
+      </div>
 
       <button
         type="button"

--- a/src/routes/WordSetDetail.tsx
+++ b/src/routes/WordSetDetail.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { Ruby } from '@/components/Ruby';
+import { MemberPicker } from '@/components/wordsets/MemberPicker';
+import { WordSetEditModal } from '@/components/wordsets/WordSetEditModal';
+import type { WordSetDraft } from '@/domain/wordSet';
+import { useEntries } from '@/lib/entries';
+import { membersOf, toDraft, withMember, withoutMember } from '@/lib/wordSetMembers';
+import { useWordSets } from '@/lib/wordSets';
+
+/**
+ * One 単語集: what is in it, and everything that changes it.
+ *
+ * Every edit here is a whole-document write of `entryIds`, because that is
+ * what the port offers and what the order in it is worth — Firestore's array
+ * union would add a member without saying where. The cost is that two writes
+ * in flight at once would have the second overwrite the first, which is what
+ * `busy` exists to prevent.
+ */
+export function Component() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { sets, loading, error, refresh, repository } = useWordSets();
+  const { entries, loading: entriesLoading } = useEntries();
+
+  const [busy, setBusy] = useState(false);
+  const [writeError, setWriteError] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const set = sets.find((item) => item.id === id);
+
+  const write = async (draft: WordSetDraft): Promise<boolean> => {
+    if (!set || busy) return false;
+    setBusy(true);
+    setWriteError(null);
+    try {
+      await repository.update(set.id, draft);
+      await refresh();
+      return true;
+    } catch (cause) {
+      console.error(cause);
+      setWriteError('保存できませんでした。もう一度お試しください。');
+      return false;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  /**
+   * Leave only once the delete and the refresh have both landed. A failed
+   * refresh means the set is gone from Firestore but still in the cached list,
+   * and a list that still shows it is worse than staying here with an error.
+   */
+  const confirmDelete = async () => {
+    if (!set) return;
+    setBusy(true);
+    setDeleteError(null);
+    try {
+      await repository.remove(set.id);
+      await refresh();
+      void navigate('/wordsets', { replace: true });
+    } catch (cause) {
+      console.error(cause);
+      setDeleteError('削除できませんでした。もう一度お試しください。');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading || entriesLoading)
+    return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
+  if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
+
+  if (!set) {
+    return (
+      <div className="py-16 text-center">
+        <p className="text-sm text-muted">単語集が見つかりません</p>
+        <Link to="/wordsets" className="mt-2 inline-block text-sm text-accent underline">
+          単語集一覧へ戻る
+        </Link>
+      </div>
+    );
+  }
+
+  const members = membersOf(set, entries);
+
+  return (
+    <div className="space-y-4">
+      <Link to="/wordsets" className="inline-block text-sm text-muted hover:text-ink">
+        ← 単語集一覧へ戻る
+      </Link>
+
+      <header className="rounded-card bg-card p-5 shadow-panel">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="font-display text-2xl font-bold">
+              {set.name}
+              <span className="ml-2 text-sm font-normal text-muted tabular-nums">
+                {members.length} 語
+              </span>
+            </h1>
+            {set.description && (
+              <p className="prose-cjk mt-2 text-sm text-muted">{set.description}</p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="min-h-9 shrink-0 rounded-pill bg-bg-alt px-4 text-xs font-semibold text-ink"
+          >
+            編集
+          </button>
+        </div>
+      </header>
+
+      {writeError && <p className="text-sm text-danger">{writeError}</p>}
+
+      <MemberPicker
+        set={set}
+        entries={entries}
+        busy={busy}
+        onAdd={(entryId) =>
+          void write({ ...toDraft(set), entryIds: withMember(set.entryIds, entryId) })
+        }
+      />
+
+      <section className="space-y-2 rounded-card bg-card p-5 shadow-panel">
+        <h2 className="text-sm font-semibold">収録語</h2>
+        {members.length ? (
+          <ul className="divide-y divide-line">
+            {members.map((entry) => (
+              <li key={entry.id} className="flex items-center justify-between gap-3 py-2">
+                <Link to={`/vocabulary/${entry.id}`} className="min-w-0 truncate">
+                  <Ruby
+                    headword={entry.headword}
+                    reading={entry.reading}
+                    className="has-ruby font-display text-base font-bold"
+                  />
+                </Link>
+                <button
+                  type="button"
+                  onClick={() =>
+                    void write({ ...toDraft(set), entryIds: withoutMember(set.entryIds, entry.id) })
+                  }
+                  disabled={busy}
+                  className="min-h-9 shrink-0 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger disabled:opacity-60"
+                >
+                  削除
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="py-4 text-sm text-muted">
+            まだ単語がありません。上の検索から追加してください。
+          </p>
+        )}
+      </section>
+
+      <button
+        type="button"
+        onClick={() => setConfirmingDelete(true)}
+        className="min-h-10 w-full rounded-pill bg-danger-soft text-sm font-semibold text-danger"
+      >
+        この単語集を削除
+      </button>
+
+      <WordSetEditModal
+        open={editing}
+        set={set}
+        busy={busy}
+        error={writeError}
+        onClose={() => setEditing(false)}
+        onSave={(fields) => {
+          void write({ ...toDraft(set), ...fields }).then((ok) => {
+            if (ok) setEditing(false);
+          });
+        }}
+      />
+
+      <ConfirmDialog
+        open={confirmingDelete}
+        title="単語集を削除"
+        message={`「${set.name}」を削除しますか？\n収録されている単語そのものは削除されません。`}
+        confirmLabel="削除する"
+        busy={busy}
+        error={deleteError}
+        onClose={() => {
+          setConfirmingDelete(false);
+          setDeleteError(null);
+        }}
+        onConfirm={() => void confirmDelete()}
+      />
+    </div>
+  );
+}

--- a/src/routes/WordSetDetail.tsx
+++ b/src/routes/WordSetDetail.tsx
@@ -16,6 +16,7 @@ import {
   insertMemberAt,
   membersOf,
   reorderMembers,
+  storedIndexFor,
   toDraft,
   withMember,
   withoutMember,
@@ -40,7 +41,7 @@ export function Component() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { sets, loading, error, refresh, repository } = useWordSets();
-  const { entries, loading: entriesLoading } = useEntries();
+  const { entries, loading: entriesLoading, error: entriesError } = useEntries();
 
   const [busy, setBusy] = useState(false);
   const [writeError, setWriteError] = useState<string | null>(null);
@@ -85,9 +86,11 @@ export function Component() {
       return false;
     } finally {
       setBusy(false);
-      // Cleared whether or not it worked: the refresh above has already put the
-      // stored order back in hand, and on a failure that stored order is the
-      // honest thing to show.
+      // Cleared whether or not it worked, and correct either way for the same
+      // reason: `set.entryIds` was never mutated locally, so dropping `pending`
+      // falls back to what is stored. On the failing path the refresh above did
+      // not run at all -- it is the absence of a local mutation that saves this,
+      // not the refresh.
       setPending(null);
     }
   };
@@ -123,6 +126,18 @@ export function Component() {
   const entryIds =
     pending && set && pending.setId === set.id ? pending.entryIds : (set?.entryIds ?? []);
 
+  const members = set ? membersOf({ ...set, entryIds }, entries) : [];
+
+  /**
+   * A row index from either list, in the coordinates the stored array uses.
+   *
+   * Every index arriving from the DOM counts rendered rows, and `members` is
+   * shorter than `entryIds` whenever the set holds a word that has since been
+   * deleted. See `storedIndexFor` — untranslated, a drag moves the wrong id.
+   */
+  const visibleIds = members.map((entry) => entry.id);
+  const stored = (visible: number) => storedIndexFor(entryIds, visibleIds, visible);
+
   /**
    * Send an order, unless it is the one already showing.
    *
@@ -145,14 +160,21 @@ export function Component() {
     if (at.list !== MEMBERS) return;
     applyOrder(
       source.list === MEMBERS
-        ? reorderMembers(entryIds, source.index, at.index)
-        : insertMemberAt(entryIds, source.id, at.index),
+        ? reorderMembers(entryIds, stored(source.index), stored(at.index))
+        : insertMemberAt(entryIds, source.id, stored(at.index)),
     );
   });
 
   if (loading || entriesLoading)
     return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
-  if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
+  /**
+   * The notebook's error counts as much as the set's. Every count and every row
+   * on this page is derived from `entries` rather than from the set, so a failed
+   * notebook load with only `error` surfaced renders a set that looks empty
+   * instead of a page that says it could not load.
+   */
+  if (error || entriesError)
+    return <p className="py-16 text-center text-sm text-danger">{error ?? entriesError}</p>;
 
   if (!set) {
     return (
@@ -165,7 +187,6 @@ export function Component() {
     );
   }
 
-  const members = membersOf({ ...set, entryIds }, entries);
   // Against the order on screen, not the stored one, so a word just dropped in
   // leaves the list it was dragged from in the same render.
   const candidates = candidatesFor({ ...set, entryIds }, entries, filters);
@@ -236,7 +257,9 @@ export function Component() {
             }
             onRemoveAll={setClearing}
             onMoveBy={(index, delta) =>
-              applyOrder(reorderMembers(entryIds, index, delta < 0 ? index - 1 : index + 2))
+              applyOrder(
+                reorderMembers(entryIds, stored(index), stored(delta < 0 ? index - 1 : index + 2)),
+              )
             }
           />
         </div>

--- a/src/routes/WordSets.tsx
+++ b/src/routes/WordSets.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { WordSetCard } from '@/components/wordsets/WordSetCard';
+import { useEntries } from '@/lib/entries';
+import { membersOf } from '@/lib/wordSetMembers';
+import { useWordSets } from '@/lib/wordSets';
+
+/**
+ * 単語集 — the list, and the one field it takes to start one.
+ *
+ * Creating asks for a name and nothing else, then opens the new set: a 単語集
+ * is only worth anything once it has words in it, and the screen that adds
+ * them is the one after this. Description and the rest are edited there.
+ */
+export function Component() {
+  const { sets, loading, error, refresh, repository } = useWordSets();
+  const { entries, loading: entriesLoading } = useEntries();
+  const navigate = useNavigate();
+
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  // Memoised because the name box above re-renders this list on every
+  // keystroke, and resolving members walks the whole notebook once per set.
+  const counts = useMemo(
+    () => new Map(sets.map((set) => [set.id, membersOf(set, entries).length])),
+    [sets, entries],
+  );
+
+  const create = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || creating) return;
+
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const id = await repository.create({
+        name: trimmed,
+        description: '',
+        entryIds: [],
+        level: '',
+        topics: [],
+      });
+      setName('');
+      // The detail page reads the set out of this same list and has no fetch of
+      // its own, so a create that does not refresh lands on 見つかりません for a
+      // set that was written perfectly well.
+      await refresh();
+      void navigate(`/wordsets/${id}`);
+    } catch (cause) {
+      console.error(cause);
+      setCreateError('単語集を作成できませんでした。');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (loading || entriesLoading)
+    return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
+  if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="font-display text-2xl font-bold">単語集</h1>
+
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void create();
+        }}
+        className="flex flex-wrap items-center gap-2 rounded-card bg-card p-4 shadow-panel"
+      >
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="新しい単語集の名前"
+          aria-label="新しい単語集の名前"
+          className="min-h-11 min-w-0 flex-1 rounded-pill border border-line bg-bg px-4 text-sm text-ink placeholder:text-muted"
+        />
+        <button
+          type="submit"
+          disabled={creating || !name.trim()}
+          className="min-h-11 rounded-pill bg-accent px-6 text-sm font-semibold text-on-accent disabled:opacity-60"
+        >
+          {creating ? '作成中…' : '作成'}
+        </button>
+        {createError && <p className="w-full text-xs text-danger">{createError}</p>}
+      </form>
+
+      {sets.length ? (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-3">
+          {sets.map((set) => (
+            <WordSetCard key={set.id} set={set} count={counts.get(set.id) ?? 0} />
+          ))}
+        </div>
+      ) : (
+        <p className="py-16 text-center text-sm text-muted">
+          まだ単語集がありません。名前を入れて作成してください。
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/routes/WordSets.tsx
+++ b/src/routes/WordSets.tsx
@@ -14,7 +14,7 @@ import { useWordSets } from '@/lib/wordSets';
  */
 export function Component() {
   const { sets, loading, error, refresh, repository } = useWordSets();
-  const { entries, loading: entriesLoading } = useEntries();
+  const { entries, loading: entriesLoading, error: entriesError } = useEntries();
   const navigate = useNavigate();
 
   const [name, setName] = useState('');
@@ -58,7 +58,11 @@ export function Component() {
 
   if (loading || entriesLoading)
     return <p className="py-16 text-center text-sm text-muted">読み込み中…</p>;
-  if (error) return <p className="py-16 text-center text-sm text-danger">{error}</p>;
+  // The notebook's error counts as much as the list's: every card's count is
+  // resolved against `entries`, so a failed load with only `error` surfaced
+  // renders each set as 0 語 rather than saying it could not be read.
+  if (error || entriesError)
+    return <p className="py-16 text-center text-sm text-danger">{error ?? entriesError}</p>;
 
   return (
     <div className="space-y-4">

--- a/tests/component/MemberList.test.tsx
+++ b/tests/component/MemberList.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { MemberList } from '@/components/wordsets/MemberList';
+import type { ListDrag } from '@/lib/listDrag';
+import { makeEntry } from '../fixtures/entry';
+
+const MEMBERS = [
+  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' }),
+  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
+];
+
+const idle: ListDrag = {
+  dragging: null,
+  at: null,
+  point: null,
+  handleProps: () => ({ onPointerDown: () => {} }),
+};
+
+const setup = (busy = false) => {
+  const onMoveBy = vi.fn();
+  // Each row links to its word, and a Link needs a router. React Router's own
+  // in-memory one, not a stand-in for anything of ours.
+  render(
+    <MemoryRouter>
+      <MemberList
+        members={MEMBERS}
+        list="members"
+        drag={idle}
+        busy={busy}
+        onRemove={vi.fn()}
+        onMoveBy={onMoveBy}
+      />
+    </MemoryRouter>,
+  );
+  return { onMoveBy, grip: screen.getByRole('button', { name: '兆候を並び替え' }) };
+};
+
+/**
+ * The keyboard half of reordering, which is the only half that exists without a
+ * pointer. A grip that can only be dragged puts the study order — the one thing
+ * `entryIds` carries beyond a set — out of reach of anyone not using a mouse.
+ */
+describe('MemberList — reordering from the keyboard', () => {
+  it('moves the row up and down with the arrow keys', () => {
+    const { onMoveBy, grip } = setup();
+
+    fireEvent.keyDown(grip, { key: 'ArrowUp' });
+    fireEvent.keyDown(grip, { key: 'ArrowDown' });
+
+    expect(onMoveBy.mock.calls).toEqual([
+      [1, -1],
+      [1, 1],
+    ]);
+  });
+
+  /**
+   * `aria-disabled`, not `disabled`, and this is what that distinction buys: a
+   * real `disabled` drops focus the instant the write starts, so every single
+   * arrow press would throw the keyboard out of the list and the row would have
+   * to be found again to move it twice.
+   */
+  it('keeps focus on the grip while a write is in flight, and refuses the key', () => {
+    const { onMoveBy, grip } = setup(true);
+    grip.focus();
+
+    fireEvent.keyDown(grip, { key: 'ArrowUp' });
+
+    expect(onMoveBy).not.toHaveBeenCalled();
+    expect(grip).toHaveFocus();
+  });
+});

--- a/tests/component/MemberList.test.tsx
+++ b/tests/component/MemberList.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { MemberList } from '@/components/wordsets/MemberList';
+import type { ListDrag } from '@/lib/listDrag';
 import { idleDrag } from '../fixtures/drag';
 import { makeEntry } from '../fixtures/entry';
 
@@ -10,24 +11,33 @@ const MEMBERS = [
   makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
 ];
 
-const setup = (busy = false) => {
+const setup = (busy = false, drag: ListDrag = idleDrag) => {
   const onMoveBy = vi.fn();
+  const onRemoveAll = vi.fn();
   // Each row links to its word, and a Link needs a router. React Router's own
   // in-memory one, not a stand-in for anything of ours.
-  render(
+  const { container } = render(
     <MemoryRouter>
       <MemberList
         members={MEMBERS}
         list="members"
-        drag={idleDrag}
+        drag={drag}
         busy={busy}
         onRemove={vi.fn()}
+        onRemoveAll={onRemoveAll}
         onMoveBy={onMoveBy}
       />
     </MemoryRouter>,
   );
-  return { onMoveBy, grip: screen.getByRole('button', { name: '兆候を並び替え' }) };
+  return {
+    onMoveBy,
+    onRemoveAll,
+    grip: screen.getByRole('button', { name: '兆候を並び替え' }),
+    list: container.querySelector('[data-drop-list="members"]'),
+  };
 };
+
+const FROM_PICKER = { list: 'candidates', id: 'w9', index: 0 };
 
 /**
  * The keyboard half of reordering, which is the only half that exists without a
@@ -61,5 +71,59 @@ describe('MemberList — reordering from the keyboard', () => {
 
     expect(onMoveBy).not.toHaveBeenCalled();
     expect(grip).toHaveFocus();
+  });
+});
+
+/**
+ * Which list will accept the word being dragged.
+ *
+ * This reads like a styling assertion and is not one. 単語を探す is a drag
+ * source that refuses drops, so 収録語 is the only panel a release does
+ * anything over — and with nothing marking it, a drop on the wrong half of the
+ * screen is silently ignored and the whole gesture looks broken. `idle` is the
+ * third state on purpose: an outline that is always on says nothing at the
+ * moment it is needed.
+ */
+describe('MemberList — saying where a word can be dropped', () => {
+  it('offers nothing while no drag is happening', () => {
+    expect(setup().list).toHaveAttribute('data-drop-state', 'idle');
+  });
+
+  it('marks itself as available once a word is picked up elsewhere', () => {
+    const dragging = { ...idleDrag, dragging: FROM_PICKER };
+    expect(setup(false, dragging).list).toHaveAttribute('data-drop-state', 'ready');
+  });
+
+  it('marks itself as the target once the pointer is over it', () => {
+    const over = { ...idleDrag, dragging: FROM_PICKER, at: { list: 'members', index: 1 } };
+    expect(setup(false, over).list).toHaveAttribute('data-drop-state', 'over');
+  });
+});
+
+/**
+ * The mirror of 表示中の N 語を追加, and the more dangerous of the pair.
+ *
+ * It hands the ids up rather than acting: emptying a set destroys the study
+ * order, which took dragging to build and is recorded nowhere else, so the
+ * route puts a confirmation in front of it.
+ */
+describe('MemberList — removing everything on screen', () => {
+  const removeAll = () => screen.getByRole('button', { name: /語を削除$/ });
+
+  it('asks about exactly the words it is showing', () => {
+    const { onRemoveAll } = setup();
+    expect(removeAll()).toHaveTextContent('表示中の 2 語を削除');
+
+    fireEvent.click(removeAll());
+
+    expect(onRemoveAll).toHaveBeenCalledWith(['w1', 'w2']);
+  });
+
+  it('asks nothing while a write is still in flight', () => {
+    const { onRemoveAll } = setup(true);
+
+    fireEvent.click(removeAll());
+
+    expect(onRemoveAll).not.toHaveBeenCalled();
   });
 });

--- a/tests/component/MemberList.test.tsx
+++ b/tests/component/MemberList.test.tsx
@@ -2,20 +2,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { MemberList } from '@/components/wordsets/MemberList';
-import type { ListDrag } from '@/lib/listDrag';
+import { idleDrag } from '../fixtures/drag';
 import { makeEntry } from '../fixtures/entry';
 
 const MEMBERS = [
   makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' }),
   makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
 ];
-
-const idle: ListDrag = {
-  dragging: null,
-  at: null,
-  point: null,
-  handleProps: () => ({ onPointerDown: () => {} }),
-};
 
 const setup = (busy = false) => {
   const onMoveBy = vi.fn();
@@ -26,7 +19,7 @@ const setup = (busy = false) => {
       <MemberList
         members={MEMBERS}
         list="members"
-        drag={idle}
+        drag={idleDrag}
         busy={busy}
         onRemove={vi.fn()}
         onMoveBy={onMoveBy}

--- a/tests/component/MemberPicker.test.tsx
+++ b/tests/component/MemberPicker.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { MemberPicker } from '@/components/wordsets/MemberPicker';
+import { makeEntry } from '../fixtures/entry';
+import { makeWordSet } from '../fixtures/wordSet';
+
+const NOTEBOOK = [
+  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' }),
+  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
+];
+
+const setup = (busy = false) => {
+  const onAdd = vi.fn();
+  render(<MemberPicker set={makeWordSet()} entries={NOTEBOOK} busy={busy} onAdd={onAdd} />);
+  return { onAdd, search: screen.getByPlaceholderText('見出し語・読み方で検索') };
+};
+
+describe('MemberPicker', () => {
+  it('reports the word behind the ＋追加 that was pressed', () => {
+    const { onAdd, search } = setup();
+    fireEvent.change(search, { target: { value: 'ちょうこう' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '＋ 追加' }));
+
+    expect(onAdd).toHaveBeenCalledWith('w2');
+  });
+
+  /**
+   * Looks like styling and is not. Every add sends the set's *whole* `entryIds`
+   * array, built from the copy this render was given, so a second ＋追加 pressed
+   * before the first write has been read back sends a list that never contained
+   * the first word — the learner adds two words, sees one, and nothing reports
+   * an error. The route refuses the second write regardless; without this the
+   * button still looks like it worked.
+   */
+  it('takes no further additions while a write is still in flight', () => {
+    const { onAdd, search } = setup(true);
+    fireEvent.change(search, { target: { value: 'ちょうこう' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '＋ 追加' }));
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+});

--- a/tests/component/MemberPicker.test.tsx
+++ b/tests/component/MemberPicker.test.tsx
@@ -1,80 +1,74 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { MemberPicker } from '@/components/wordsets/MemberPicker';
-import { EMPTY_FILTERS } from '@/lib/filters';
-import type { ListDrag } from '@/lib/listDrag';
+import { idleDrag } from '../fixtures/drag';
 import { makeEntry } from '../fixtures/entry';
-import { makeWordSet } from '../fixtures/wordSet';
 
-const NOTEBOOK = [
-  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ', learnedOn: '2026-06-24' }),
-  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう', learnedOn: '2026-06-22' }),
+const SHOWN = [
+  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' }),
+  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
 ];
-
-/** A drag that is not happening: this file is about the buttons, not the gesture. */
-const idle: ListDrag = {
-  dragging: null,
-  at: null,
-  point: null,
-  handleProps: () => ({ onPointerDown: () => {} }),
-};
 
 const setup = (busy = false) => {
   const onAdd = vi.fn();
+  const onAddAll = vi.fn();
   render(
     <MemberPicker
-      set={makeWordSet()}
-      entries={NOTEBOOK}
-      allTags={[]}
-      filters={EMPTY_FILTERS}
+      shown={SHOWN}
+      // More matched than is rendered, which is the case the button's label has
+      // to survive.
+      total={137}
       list="candidates"
-      drag={idle}
+      drag={idleDrag}
       busy={busy}
-      onFiltersChange={vi.fn()}
       onAdd={onAdd}
+      onAddAll={onAddAll}
     />,
   );
-  return { onAdd };
+  return { onAdd, onAddAll };
 };
+
+const addAll = () => screen.getByRole('button', { name: /語を追加$/ });
 
 describe('MemberPicker', () => {
   it('reports the word behind the ＋追加 that was pressed', () => {
     const { onAdd } = setup();
 
-    // Newest first with no filters set, so 切り分け leads and 兆候 follows.
     fireEvent.click(screen.getAllByRole('button', { name: '＋ 追加' })[1]!);
 
     expect(onAdd).toHaveBeenCalledWith('w2');
   });
 
   /**
-   * Looks like styling and is not. Every add sends the set's *whole* `entryIds`
-   * array, built from the copy this render was given, so a second ＋追加 pressed
-   * before the first write has been read back sends a list that never contained
-   * the first word — the learner adds two words, sees one, and nothing reports
-   * an error. The route refuses the second write regardless; without this the
-   * button still looks like it worked.
+   * The rendered rows are capped and the match count is not, so "add all" has
+   * to mean the rows on screen and say so. A button reading 「すべて追加」 next
+   * to 「137 語」 is a promise to add 137 words; pressing it adds 50, and which
+   * 87 were left out is not visible anywhere.
    */
-  /**
-   * Layout, not tidiness, and the reason belongs on the assertion: 一覧's filter
-   * panel is around 200px tall. Rendered open it pushes every candidate row
-   * past the bottom of a 720px viewport, and a drag whose source and target are
-   * never on screen together cannot be performed at all.
-   */
-  it('keeps the filter panel folded away until it is asked for', () => {
-    setup();
-    expect(screen.queryByText('追加日（新しい順）')).not.toBeInTheDocument();
+  it('adds the words on screen, and names how many that is', () => {
+    const { onAddAll } = setup();
+    expect(addAll()).toHaveTextContent('表示中の 2 語を追加');
 
-    fireEvent.click(screen.getByRole('button', { name: /絞り込み/ }));
+    fireEvent.click(addAll());
 
-    expect(screen.getByText('追加日（新しい順）')).toBeInTheDocument();
+    expect(onAddAll).toHaveBeenCalledWith(['w1', 'w2']);
   });
 
+  /**
+   * Looks like styling and is not. Every add sends the set's *whole* `entryIds`
+   * array, built from the copy this render was given, so a second press before
+   * the first write has been read back sends a list that never contained the
+   * first word — the learner adds two words, sees one, and nothing reports an
+   * error. The route refuses the second write regardless; without this the
+   * button still looks like it worked.
+   */
   it('takes no further additions while a write is still in flight', () => {
-    const { onAdd } = setup(true);
+    const { onAdd, onAddAll } = setup(true);
 
     fireEvent.click(screen.getAllByRole('button', { name: '＋ 追加' })[0]!);
+    fireEvent.click(addAll());
 
     expect(onAdd).not.toHaveBeenCalled();
+    expect(onAddAll).not.toHaveBeenCalled();
   });
 });

--- a/tests/component/MemberPicker.test.tsx
+++ b/tests/component/MemberPicker.test.tsx
@@ -1,26 +1,48 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { MemberPicker } from '@/components/wordsets/MemberPicker';
+import { EMPTY_FILTERS } from '@/lib/filters';
+import type { ListDrag } from '@/lib/listDrag';
 import { makeEntry } from '../fixtures/entry';
 import { makeWordSet } from '../fixtures/wordSet';
 
 const NOTEBOOK = [
-  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' }),
-  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' }),
+  makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ', learnedOn: '2026-06-24' }),
+  makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう', learnedOn: '2026-06-22' }),
 ];
+
+/** A drag that is not happening: this file is about the buttons, not the gesture. */
+const idle: ListDrag = {
+  dragging: null,
+  at: null,
+  point: null,
+  handleProps: () => ({ onPointerDown: () => {} }),
+};
 
 const setup = (busy = false) => {
   const onAdd = vi.fn();
-  render(<MemberPicker set={makeWordSet()} entries={NOTEBOOK} busy={busy} onAdd={onAdd} />);
-  return { onAdd, search: screen.getByPlaceholderText('見出し語・読み方で検索') };
+  render(
+    <MemberPicker
+      set={makeWordSet()}
+      entries={NOTEBOOK}
+      allTags={[]}
+      filters={EMPTY_FILTERS}
+      list="candidates"
+      drag={idle}
+      busy={busy}
+      onFiltersChange={vi.fn()}
+      onAdd={onAdd}
+    />,
+  );
+  return { onAdd };
 };
 
 describe('MemberPicker', () => {
   it('reports the word behind the ＋追加 that was pressed', () => {
-    const { onAdd, search } = setup();
-    fireEvent.change(search, { target: { value: 'ちょうこう' } });
+    const { onAdd } = setup();
 
-    fireEvent.click(screen.getByRole('button', { name: '＋ 追加' }));
+    // Newest first with no filters set, so 切り分け leads and 兆候 follows.
+    fireEvent.click(screen.getAllByRole('button', { name: '＋ 追加' })[1]!);
 
     expect(onAdd).toHaveBeenCalledWith('w2');
   });
@@ -33,11 +55,25 @@ describe('MemberPicker', () => {
    * an error. The route refuses the second write regardless; without this the
    * button still looks like it worked.
    */
-  it('takes no further additions while a write is still in flight', () => {
-    const { onAdd, search } = setup(true);
-    fireEvent.change(search, { target: { value: 'ちょうこう' } });
+  /**
+   * Layout, not tidiness, and the reason belongs on the assertion: 一覧's filter
+   * panel is around 200px tall. Rendered open it pushes every candidate row
+   * past the bottom of a 720px viewport, and a drag whose source and target are
+   * never on screen together cannot be performed at all.
+   */
+  it('keeps the filter panel folded away until it is asked for', () => {
+    setup();
+    expect(screen.queryByText('追加日（新しい順）')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: '＋ 追加' }));
+    fireEvent.click(screen.getByRole('button', { name: /絞り込み/ }));
+
+    expect(screen.getByText('追加日（新しい順）')).toBeInTheDocument();
+  });
+
+  it('takes no further additions while a write is still in flight', () => {
+    const { onAdd } = setup(true);
+
+    fireEvent.click(screen.getAllByRole('button', { name: '＋ 追加' })[0]!);
 
     expect(onAdd).not.toHaveBeenCalled();
   });

--- a/tests/component/PickerToolbar.test.tsx
+++ b/tests/component/PickerToolbar.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PickerToolbar } from '@/components/wordsets/PickerToolbar';
+import { EMPTY_FILTERS } from '@/lib/filters';
+
+describe('PickerToolbar', () => {
+  /**
+   * Layout, not tidiness, and the reason belongs on the assertion: 一覧's filter
+   * panel is around 200px tall, and it sits above both of the bounded lists it
+   * shares the screen with. Rendered open it takes that height off each of
+   * them, and a drag whose source and target are both scrolled away cannot be
+   * performed at all.
+   */
+  it('keeps the filter panel folded away until it is asked for', () => {
+    render(<PickerToolbar filters={EMPTY_FILTERS} allTags={[]} onChange={vi.fn()} />);
+    expect(screen.queryByText('追加日（新しい順）')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /絞り込み/ }));
+
+    expect(screen.getByText('追加日（新しい順）')).toBeInTheDocument();
+  });
+
+  it('types into the same search the notebook is filtered by', () => {
+    const onChange = vi.fn();
+    render(<PickerToolbar filters={EMPTY_FILTERS} allTags={[]} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText('見出し語・読み方・タグ・意味・例文で検索'), {
+      target: { value: '兆' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ ...EMPTY_FILTERS, q: '兆' });
+  });
+});

--- a/tests/component/WordSetEditModal.test.tsx
+++ b/tests/component/WordSetEditModal.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WordSetEditModal } from '@/components/wordsets/WordSetEditModal';
+import { makeWordSet } from '../fixtures/wordSet';
+
+const set = makeWordSet({ name: '仕事の語', description: '会議で出てきた語' });
+
+const setup = () => {
+  const onSave = vi.fn();
+  const view = render(
+    <WordSetEditModal open set={set} busy={false} error={null} onSave={onSave} onClose={vi.fn()} />,
+  );
+  return { onSave, view, name: screen.getByLabelText(/名前/) };
+};
+
+describe('WordSetEditModal', () => {
+  /**
+   * The form holds its own copy of the fields, so without the reset the text a
+   * cancelled edit left behind is still there on reopen — and the next 保存する
+   * writes the name the user had already decided against.
+   */
+  it('shows the stored name again after an edit was cancelled', () => {
+    const { view, name } = setup();
+    fireEvent.change(name, { target: { value: '捨てる名前' } });
+
+    view.rerender(
+      <WordSetEditModal
+        open={false}
+        set={set}
+        busy={false}
+        error={null}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    view.rerender(
+      <WordSetEditModal
+        open
+        set={set}
+        busy={false}
+        error={null}
+        onSave={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/名前/)).toHaveValue('仕事の語');
+  });
+
+  /**
+   * A set with no name is unidentifiable in the list and in the practice chips,
+   * and `sanitizeWordSet` would coerce it to `''` rather than refuse it.
+   */
+  it('refuses to save a name that is only whitespace', () => {
+    const { onSave, name } = setup();
+    fireEvent.change(name, { target: { value: '   ' } });
+
+    fireEvent.click(screen.getByRole('button', { name: '保存する' }));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText('名前は必須です。')).toBeInTheDocument();
+  });
+});

--- a/tests/component/listDrag.test.tsx
+++ b/tests/component/listDrag.test.tsx
@@ -1,0 +1,73 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useListDrag } from '@/lib/listDrag';
+import type { DragSource, DropAt } from '@/lib/listDrag';
+
+/**
+ * The drag hook's one behaviour that a browser cannot show: what happens when a
+ * release is handled before React has flushed the state the move set.
+ *
+ * `pointermove` is not a discrete event, so the update it schedules may still be
+ * pending when the `pointerup` after it arrives — and the window listener in
+ * flight was captured with the *previous* value. Reproducing that needs both
+ * events inside one `act`, which is the one place a test has an advantage over
+ * a real pointer: Playwright cannot hold React's scheduler still.
+ */
+
+/** A minimal consumer of the hook: one list, one row. */
+function Harness({ onDrop }: { onDrop: (source: DragSource, at: DropAt) => void }) {
+  const drag = useListDrag(onDrop);
+  return (
+    <ul data-drop-list="rows" data-drop-count={1}>
+      <li data-drop-index={0} {...drag.rowProps({ list: 'rows', id: 'x', index: 0 })}>
+        row
+      </li>
+    </ul>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useListDrag — a release that beats the render', () => {
+  it('commits the drop instead of discarding it', () => {
+    const onDrop = vi.fn();
+    render(<Harness onDrop={onDrop} />);
+    const row = screen.getByText('row');
+
+    // jsdom has no layout and does not implement elementFromPoint at all, so
+    // the hit test has nothing to find. Standing in for the browser's own API,
+    // not for anything of ours.
+    Object.defineProperty(document, 'elementFromPoint', {
+      configurable: true,
+      value: () => row,
+    });
+    vi.spyOn(row, 'getBoundingClientRect').mockReturnValue({
+      top: 0,
+      height: 40,
+      bottom: 40,
+      left: 0,
+      right: 100,
+      width: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    // Arming writes refs only, so no render happens here.
+    fireEvent.pointerDown(row, { clientX: 10, clientY: 10 });
+
+    // Both in one act: the move schedules `dragging`, and the release is
+    // handled before that update can reach the listener.
+    act(() => {
+      window.dispatchEvent(new MouseEvent('pointermove', { clientX: 60, clientY: 30 }));
+      window.dispatchEvent(new MouseEvent('pointerup'));
+    });
+
+    expect(onDrop).toHaveBeenCalledWith(
+      { list: 'rows', id: 'x', index: 0 },
+      { list: 'rows', index: 1 },
+    );
+  });
+});

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -134,6 +134,21 @@ export const WORD_SETS: Record<string, unknown>[] = [
 ];
 
 /**
+ * One 単語集 holding all three words.
+ *
+ * Deleting one of them leaves a set whose stored `entryIds` is longer than the
+ * rows it renders — the state in which a visible row index and a stored index
+ * stop agreeing, and the only shape that can see it.
+ */
+export const FULL_SET: Record<string, unknown>[] = [
+  {
+    id: 'set-all',
+    name: '全部セット',
+    entryIds: ['w-kiriwake', 'w-choukou', 'w-chotto'],
+  },
+];
+
+/**
  * Two 単語集 that both claim 兆候.
  *
  * A word belongs to as many sets as it is put in — membership is a list on each

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -100,10 +100,22 @@ export const seedSignedIn = (page: Page) => seed(page, { signedIn: true, entries
 /**
  * One 単語集 over two of the three words.
  *
- * Seeded rather than created through the app, because nothing creates one yet:
- * `/wordsets` is still a placeholder. The read path is real, so this is what
- * the practice filter will see the day the first set is written for real.
+ * Seeded rather than built through `/wordsets` in every spec that needs one:
+ * the specs about what a set *does* should not each pay for the four clicks
+ * that make it. `wordsets.spec.ts` covers those clicks once.
  */
 export const WORD_SETS: Record<string, unknown>[] = [
   { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
+];
+
+/**
+ * Two 単語集 that both claim 兆候.
+ *
+ * A word belongs to as many sets as it is put in — membership is a list on each
+ * set, and nothing on the entry records which of them claimed it. That is what
+ * makes deleting the word a question about several documents at once.
+ */
+export const OVERLAPPING_SETS: Record<string, unknown>[] = [
+  { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
+  { id: 'set-news', name: 'ニュースセット', entryIds: ['w-choukou'] },
 ];

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -98,6 +98,31 @@ export async function seed(page: Page, data: E2ESeed = {}): Promise<void> {
 export const seedSignedIn = (page: Page) => seed(page, { signedIn: true, entries: WORDS });
 
 /**
+ * Start recording whether the full-page 読み込み中… placeholder ever replaces the
+ * screen, and return a way to ask afterwards.
+ *
+ * A flash cannot be caught by looking for it: by the time an assertion runs, the
+ * render that caused it has already been undone. It has to be recorded as it
+ * happens, which is what the observer is for.
+ *
+ * The thing it exists to catch: every write ends in its provider's `refresh()`,
+ * and every route treats `loading` as "replace the page with 読み込み中…". A
+ * refresh that raises that flag therefore takes the whole screen down and puts
+ * it back on every single save.
+ */
+export async function watchForBlanking(page: Page): Promise<() => Promise<boolean>> {
+  await page.evaluate(() => {
+    const seen = { it: false };
+    (window as unknown as { __blanked: { it: boolean } }).__blanked = seen;
+    new MutationObserver(() => {
+      if (document.body.textContent?.includes('読み込み中')) seen.it = true;
+    }).observe(document.body, { childList: true, subtree: true, characterData: true });
+  });
+  return () =>
+    page.evaluate(() => (window as unknown as { __blanked: { it: boolean } }).__blanked.it);
+}
+
+/**
  * One 単語集 over two of the three words.
  *
  * Seeded rather than built through `/wordsets` in every spec that needs one:

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -213,8 +213,8 @@ test.describe('the practice setup screen', () => {
 
   /**
    * The 単語集 row is absent whenever there are none, which is the design's
-   * rule and — until `/wordsets` exists — the state of the running app. The
-   * pair of cases is what stops the row being quietly dropped altogether.
+   * rule for a notebook that has not organised anything yet. The pair of cases
+   * is what stops the row being quietly dropped altogether.
    */
   test('hides the 単語集 row when the learner has no sets', async ({ page }) => {
     await seedSignedIn(page);

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
-import { seedSignedIn } from './fixtures';
+import { seedSignedIn, watchForBlanking } from './fixtures';
 
 /**
  * The notebook's whole reason to exist: find a word, read it, add one, change
@@ -138,6 +138,27 @@ test.describe('editing and deleting', () => {
    * documents in tests/unit/migrationOutput.test.ts, and it stays in the form
    * because a stored document is not obliged to have come from this field.
    */
+  /**
+   * The same defect as on `/wordsets`, and the reason the fix went into both
+   * providers rather than one: saving ends in `refresh()`, and a refresh that
+   * reports itself as loading replaces the whole page with 読み込み中…. Editing
+   * is where it shows on this side, because adding navigates to the new word
+   * and leaves the blanked page behind.
+   */
+  test('editing a word does not blank the page it was edited on', async ({ page }) => {
+    await page.goto('/vocabulary/w-choukou');
+    await page.getByRole('button', { name: '編集' }).click();
+
+    const dialog = editDialog(page);
+    await dialog.getByLabel('意味・説明').fill('起こる前のしるし。');
+
+    const blanked = await watchForBlanking(page);
+    await dialog.getByRole('button', { name: '保存する' }).click();
+    await expect(page.getByText('起こる前のしるし。')).toBeVisible();
+
+    expect(await blanked()).toBe(false);
+  });
+
   test('refuses to save with the learning date cleared', async ({ page }) => {
     await page.goto('/vocabulary/w-choukou');
     await page.getByRole('button', { name: '編集' }).click();

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -125,20 +125,6 @@ test.describe('editing and deleting', () => {
   });
 
   /**
-   * The date guard, tested for what it can actually be given.
-   *
-   * An impossible day like 2026-02-31 cannot be typed at all: the field is
-   * <input type="date">, and the browser refuses the value before any of our
-   * code runs. Nor can it arrive through JSON import, where sanitizeDraft has
-   * already coerced it. So in the running app this guard exists for exactly one
-   * input — a cleared field — and that is what is asserted here.
-   *
-   * The impossible-date rule itself is covered where it is reachable, over
-   * isValidIsoDate in tests/unit/sanitize.test.ts, against the Firestore
-   * documents in tests/unit/migrationOutput.test.ts, and it stays in the form
-   * because a stored document is not obliged to have come from this field.
-   */
-  /**
    * The same defect as on `/wordsets`, and the reason the fix went into both
    * providers rather than one: saving ends in `refresh()`, and a refresh that
    * reports itself as loading replaces the whole page with 読み込み中…. Editing
@@ -159,6 +145,20 @@ test.describe('editing and deleting', () => {
     expect(await blanked()).toBe(false);
   });
 
+  /**
+   * The date guard, tested for what it can actually be given.
+   *
+   * An impossible day like 2026-02-31 cannot be typed at all: the field is
+   * <input type="date">, and the browser refuses the value before any of our
+   * code runs. Nor can it arrive through JSON import, where sanitizeDraft has
+   * already coerced it. So in the running app this guard exists for exactly one
+   * input — a cleared field — and that is what is asserted here.
+   *
+   * The impossible-date rule itself is covered where it is reachable, over
+   * isValidIsoDate in tests/unit/sanitize.test.ts, against the Firestore
+   * documents in tests/unit/migrationOutput.test.ts, and it stays in the form
+   * because a stored document is not obliged to have come from this field.
+   */
   test('refuses to save with the learning date cleared', async ({ page }) => {
     await page.goto('/vocabulary/w-choukou');
     await page.getByRole('button', { name: '編集' }).click();

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -74,7 +74,7 @@ test.describe('word sets', () => {
     // Creating opens the new set: a 単語集 is worth nothing until it has words.
     await expect(page.getByRole('heading', { name: /会議の語/ })).toBeVisible();
     await expect(
-      page.getByText('下の一覧からドラッグ、または「＋ 追加」で入れてください'),
+      page.getByText('ここに単語をドラッグ、または「＋ 追加」で入れてください'),
     ).toBeVisible();
 
     await page.getByPlaceholder('見出し語・読み方・タグ・意味・例文で検索').fill('ちょうこう');
@@ -178,6 +178,71 @@ test.describe('word sets', () => {
     await expect
       .poll(() => memberHrefs(page))
       .toEqual(['/vocabulary/w-chotto', '/vocabulary/w-kiriwake', '/vocabulary/w-choukou']);
+  });
+
+  /**
+   * The grip is a 44px target, and a whole row is a much larger one. Dragging
+   * only ever from the grip was the first thing that turned out to be hard to
+   * do with a mouse.
+   */
+  test('drags a word by its body, not only by its grip', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+
+    await dragOnto(
+      page,
+      // The headword itself, which is row body rather than grip. `exact`
+      // because this word reads as itself, so 「ちょっと（ちょっと）」 would
+      // otherwise match the reading too.
+      page.locator('[data-drop-list="candidates"] li').first().getByText('ちょっと', {
+        exact: true,
+      }),
+      memberOrder(page).first(),
+    );
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-chotto', '/vocabulary/w-kiriwake', '/vocabulary/w-choukou']);
+  });
+
+  /**
+   * What the movement threshold is for, and it has to be a press that *moves* —
+   * `locator.click()` releases on the pixel it pressed, so it would open the
+   * word with the threshold removed and prove nothing. A hand pressing a row
+   * drifts a pixel or two; without the slop that is a drag, and the click it
+   * ends with is swallowed as the drag's own.
+   */
+  test('still opens the word when a press on a row drifts slightly', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+
+    const row = await memberOrder(page).first().boundingBox();
+    if (!row) throw new Error('the first member is not laid out');
+    const x = row.x + row.width / 2;
+    const y = row.y + row.height / 2;
+
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 3, y - 2);
+    await page.mouse.up();
+
+    await expect(page).toHaveURL(/\/vocabulary\/w-kiriwake$/);
+  });
+
+  /** Adding a filtered list one row at a time is the thing this replaces. */
+  test('adds every word on screen at once', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/wordsets');
+    await page.getByLabel('新しい単語集の名前').fill('全部');
+    await page.getByRole('button', { name: '作成' }).click();
+
+    await page.getByRole('button', { name: '表示中の 3 語を追加' }).click();
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-kiriwake', '/vocabulary/w-choukou', '/vocabulary/w-chotto']);
+    // And the picker is empty afterwards, because it excludes what the set holds.
+    await expect(page.getByText('条件に合う単語がありません')).toBeVisible();
   });
 
   /**

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
-import { OVERLAPPING_SETS, seed, seedSignedIn, WORD_SETS, WORDS } from './fixtures';
+import {
+  OVERLAPPING_SETS,
+  seed,
+  seedSignedIn,
+  watchForBlanking,
+  WORD_SETS,
+  WORDS,
+} from './fixtures';
 
 /** The words in 収録語, in the order the set stores them. */
 const memberOrder = (page: Page) =>
@@ -198,6 +205,25 @@ test.describe('word sets', () => {
     await expect
       .poll(() => memberHrefs(page))
       .toEqual(['/vocabulary/w-choukou', '/vocabulary/w-kiriwake']);
+  });
+
+  /**
+   * Every write here ends in `refresh()`, and a provider that reports itself as
+   * loading during that refresh takes the whole page down with it: the route
+   * renders 読み込み中… in place of everything, then puts it back. On a fast
+   * connection that is a flash; on a slow one the set disappears while a word
+   * is being added to it, and the scroll position goes with it.
+   */
+  test('adding a word does not blank the page it was added from', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+    await expect(memberOrder(page)).toHaveCount(2);
+
+    const blanked = await watchForBlanking(page);
+    await page.getByRole('button', { name: '＋ 追加' }).click();
+    await expect(memberOrder(page)).toHaveCount(3);
+
+    expect(await blanked()).toBe(false);
   });
 
   test('deleting a set keeps every word it held', async ({ page }) => {

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page } from '@playwright/test';
 import {
+  FULL_SET,
   OVERLAPPING_SETS,
   seed,
   seedSignedIn,
@@ -243,6 +244,82 @@ test.describe('word sets', () => {
       .toEqual(['/vocabulary/w-kiriwake', '/vocabulary/w-choukou', '/vocabulary/w-chotto']);
     // And the picker is empty afterwards, because it excludes what the set holds.
     await expect(page.getByText('条件に合う単語がありません')).toBeVisible();
+  });
+
+  /**
+   * A set holding a word that has since been deleted renders fewer rows than it
+   * stores, and every index arriving from the DOM counts rendered rows. Passing
+   * one straight to `reorderMembers` moved whichever id occupied that slot —
+   * here the stale one, so the write went out and nothing on screen changed.
+   *
+   * Both entry points are covered because they are separate code paths, and the
+   * keyboard one is the only way to reorder without a pointer.
+   */
+  test('reorders by drag around a member whose word was deleted', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: FULL_SET });
+    await page.goto('/vocabulary/w-kiriwake');
+    await page.getByRole('button', { name: '削除' }).click();
+    await page.getByRole('button', { name: '削除する' }).click();
+
+    await page.goto('/wordsets/set-all');
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-choukou', '/vocabulary/w-chotto']);
+
+    await dragOnto(
+      page,
+      page.getByRole('button', { name: 'ちょっとを並び替え' }),
+      memberOrder(page).first(),
+    );
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-chotto', '/vocabulary/w-choukou']);
+  });
+
+  test('reorders by keyboard around a member whose word was deleted', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: FULL_SET });
+    await page.goto('/vocabulary/w-kiriwake');
+    await page.getByRole('button', { name: '削除' }).click();
+    await page.getByRole('button', { name: '削除する' }).click();
+
+    await page.goto('/wordsets/set-all');
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-choukou', '/vocabulary/w-chotto']);
+
+    await page.getByRole('button', { name: 'ちょっとを並び替え' }).press('ArrowUp');
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-chotto', '/vocabulary/w-choukou']);
+  });
+
+  /**
+   * A press that begins on a control belongs to that control. `pointerdown` on
+   * 削除 bubbles to the row, so without a bail-out a hand that drifts past the
+   * threshold turns it into a drag — and the click that would have removed the
+   * word is swallowed as the drag's own. The failure is not "the button did
+   * nothing", it is "the button did something else".
+   */
+  test('removes the word when the press on 削除 drifts', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+
+    const remove = page
+      .locator('li', { has: page.locator('a[href="/vocabulary/w-choukou"]') })
+      .getByRole('button', { name: '削除' });
+    const box = await remove.boundingBox();
+    if (!box) throw new Error('the 削除 button is not laid out');
+
+    const x = box.x + box.width / 2;
+    const y = box.y + box.height / 2;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    await page.mouse.move(x + 6, y + 3, { steps: 3 });
+    await page.mouse.up();
+
+    await expect.poll(() => memberHrefs(page)).toEqual(['/vocabulary/w-kiriwake']);
   });
 
   /**

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -80,7 +80,7 @@ test.describe('word sets', () => {
     await page.getByPlaceholder('見出し語・読み方・タグ・意味・例文で検索').fill('ちょうこう');
     await page.getByRole('button', { name: '＋ 追加' }).click();
 
-    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /1 語/ })).toBeVisible();
     // Matched on href rather than on the name: furigana splits a headword into
     // separate <ruby> elements, so its accessible name interleaves the readings.
     await expect(page.locator('a[href="/vocabulary/w-choukou"]')).toBeVisible();
@@ -96,14 +96,14 @@ test.describe('word sets', () => {
     await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
     await page.goto('/wordsets');
     await page.getByRole('link', { name: /仕事セット/ }).click();
-    await expect(page.getByRole('heading', { name: /2 語/ })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /2 語/ })).toBeVisible();
 
     await page
       .locator('li', { has: page.locator('a[href="/vocabulary/w-choukou"]') })
       .getByRole('button', { name: '削除' })
       .click();
 
-    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /1 語/ })).toBeVisible();
     await page.goto('/vocabulary');
     await expect(page.getByText('3 語')).toBeVisible();
   });
@@ -122,7 +122,7 @@ test.describe('word sets', () => {
     await page.getByRole('button', { name: '作成' }).click();
     await page.getByPlaceholder('見出し語・読み方・タグ・意味・例文で検索').fill('ちょうこう');
     await page.getByRole('button', { name: '＋ 追加' }).click();
-    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: /1 語/ })).toBeVisible();
 
     await page.goto('/wordsets');
     await expect(page.getByRole('link', { name: /仕事セット/ })).toContainText('2 語');
@@ -243,6 +243,27 @@ test.describe('word sets', () => {
       .toEqual(['/vocabulary/w-kiriwake', '/vocabulary/w-choukou', '/vocabulary/w-chotto']);
     // And the picker is empty afterwards, because it excludes what the set holds.
     await expect(page.getByText('条件に合う単語がありません')).toBeVisible();
+  });
+
+  /**
+   * Emptying a set confirms first, unlike removing one row. What it destroys is
+   * the study order, which took dragging to build and is recorded nowhere else,
+   * so a mis-press costs the arrangement rather than one word.
+   */
+  test('empties the set only after confirming, and keeps the words', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+
+    await page.getByRole('button', { name: '表示中の 2 語を削除' }).click();
+    await page.getByRole('button', { name: 'キャンセル' }).click();
+    await expect(memberOrder(page)).toHaveCount(2);
+
+    await page.getByRole('button', { name: '表示中の 2 語を削除' }).click();
+    await page.getByRole('button', { name: '外す' }).click();
+
+    await expect.poll(() => memberHrefs(page)).toEqual([]);
+    await page.goto('/vocabulary');
+    await expect(page.getByText('3 語')).toBeVisible();
   });
 
   /**

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test';
+import { OVERLAPPING_SETS, seed, seedSignedIn, WORD_SETS, WORDS } from './fixtures';
+
+/**
+ * 単語集, from an empty list to a drill scoped to one.
+ *
+ * What is only observable here: that a set written on one screen is read back
+ * by another — the practice setup builds its chips from the same provider, and
+ * that hand-off across two routes is the whole point of the feature. Also that
+ * removing a word from a set, and deleting the set, leave the notebook alone,
+ * which is the promise both buttons make and the one a user cannot undo.
+ *
+ * What is deliberately not here: which words the search box offers and the
+ * order members are stored in. Those are pure and covered in
+ * tests/unit/wordSetMembers.test.ts. Resolving a deleted member is covered
+ * there too — what the case below adds is that every screen that counts a set
+ * goes through that resolution, which no unit test can see.
+ */
+
+test.describe('word sets', () => {
+  test('creates a set, fills it, and drills it', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/wordsets');
+    await expect(
+      page.getByText('まだ単語集がありません。名前を入れて作成してください。'),
+    ).toBeVisible();
+
+    await page.getByLabel('新しい単語集の名前').fill('会議の語');
+    await page.getByRole('button', { name: '作成' }).click();
+
+    // Creating opens the new set: a 単語集 is worth nothing until it has words.
+    await expect(page.getByRole('heading', { name: /会議の語/ })).toBeVisible();
+    await expect(
+      page.getByText('まだ単語がありません。上の検索から追加してください。'),
+    ).toBeVisible();
+
+    await page.getByPlaceholder('見出し語・読み方で検索').fill('ちょうこう');
+    await page.getByRole('button', { name: '＋ 追加' }).click();
+
+    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+    // Matched on href rather than on the name: furigana splits a headword into
+    // separate <ruby> elements, so its accessible name interleaves the readings.
+    await expect(page.locator('a[href="/vocabulary/w-choukou"]')).toBeVisible();
+
+    // The set exists for the practice filter, which reads it from the provider
+    // rather than from this page — and counted, so the chip and the queue agree.
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: /会議の語/ }).click();
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+  });
+
+  test('removing a word from a set keeps it in the notebook', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets');
+    await page.getByRole('link', { name: /仕事セット/ }).click();
+    await expect(page.getByRole('heading', { name: /2 語/ })).toBeVisible();
+
+    await page
+      .locator('li', { has: page.locator('a[href="/vocabulary/w-choukou"]') })
+      .getByRole('button', { name: '削除' })
+      .click();
+
+    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+    await page.goto('/vocabulary');
+    await expect(page.getByText('3 語')).toBeVisible();
+  });
+
+  /**
+   * A word is not owned by the first set that took it. Membership is a list on
+   * each set precisely so that 兆候 can sit in 仕事セット and in a new set at
+   * once — a picker that hid words already held *somewhere* would look like a
+   * tidier version of the same feature and quietly make sets exclusive.
+   */
+  test('adds a word to a second set without taking it out of the first', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets');
+
+    await page.getByLabel('新しい単語集の名前').fill('ニュースの語');
+    await page.getByRole('button', { name: '作成' }).click();
+    await page.getByPlaceholder('見出し語・読み方で検索').fill('ちょうこう');
+    await page.getByRole('button', { name: '＋ 追加' }).click();
+    await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
+
+    await page.goto('/wordsets');
+    await expect(page.getByRole('link', { name: /仕事セット/ })).toContainText('2 語');
+    await expect(page.getByRole('link', { name: /ニュースの語/ })).toContainText('1 語');
+  });
+
+  /**
+   * Deleting a word takes it out of every set that held it — on screen. The id
+   * itself stays in `entryIds`: nothing walks the sets on a delete, and
+   * `membersOf` resolves the list against the notebook, so a set that outlives
+   * a member simply stops listing it. This case is what says the resolution is
+   * applied everywhere a set is counted, rather than only where it is listed.
+   */
+  test('a deleted word leaves every set that held it, and every count of them', async ({
+    page,
+  }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: OVERLAPPING_SETS });
+    await page.goto('/vocabulary/w-choukou');
+    await page.getByRole('button', { name: '削除' }).click();
+    await page.getByRole('button', { name: '削除する' }).click();
+    await expect(page).toHaveURL(/\/vocabulary$/);
+
+    await page.goto('/wordsets');
+    await expect(page.getByRole('link', { name: /仕事セット/ })).toContainText('1 語');
+    await expect(page.getByRole('link', { name: /ニュースセット/ })).toContainText('0 語');
+
+    await page.getByRole('link', { name: /ニュースセット/ }).click();
+    await expect(page.locator('a[href="/vocabulary/w-choukou"]')).toBeHidden();
+  });
+
+  test('deleting a set keeps every word it held', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets');
+    await page.getByRole('link', { name: /仕事セット/ }).click();
+
+    await page.getByRole('button', { name: 'この単語集を削除' }).click();
+    await page.getByRole('button', { name: '削除する' }).click();
+
+    await expect(page).toHaveURL('/wordsets');
+    await expect(
+      page.getByText('まだ単語集がありません。名前を入れて作成してください。'),
+    ).toBeVisible();
+
+    await page.goto('/vocabulary');
+    await expect(page.getByText('3 語')).toBeVisible();
+  });
+});

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -1,5 +1,41 @@
 import { expect, test } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { OVERLAPPING_SETS, seed, seedSignedIn, WORD_SETS, WORDS } from './fixtures';
+
+/** The words in 収録語, in the order the set stores them. */
+const memberOrder = (page: Page) =>
+  page.locator('[data-drop-list="members"] li a[href^="/vocabulary/"]');
+
+/**
+ * Those words as a list of hrefs, for `expect.poll`.
+ *
+ * Matched on href rather than on text: furigana splits a headword into separate
+ * `<ruby>` elements, so the accessible name of a row interleaves its readings.
+ */
+const memberHrefs = (page: Page) =>
+  memberOrder(page).evaluateAll((rows) => rows.map((row) => row.getAttribute('href')));
+
+/**
+ * Press on `grip`, move to the top of `row`, release.
+ *
+ * Hand-driven rather than `locator.dragTo`, for the reason the implementation
+ * is hand-rolled: this is a pointer-events gesture, not HTML5 drag-and-drop,
+ * and it needs intermediate moves — a single jump from press to release never
+ * produces the `pointermove` the drop target is chosen on.
+ */
+async function dragOnto(page: Page, grip: Locator, row: Locator): Promise<void> {
+  const from = await grip.boundingBox();
+  const to = await row.boundingBox();
+  if (!from || !to) throw new Error('nothing to drag: one of the two rows is not laid out');
+
+  await page.mouse.move(from.x + from.width / 2, from.y + from.height / 2);
+  await page.mouse.down();
+  // Two moves: the first starts the drag, the second lands in the target's top
+  // half, which is the half that means "insert before this row".
+  await page.mouse.move(to.x + to.width / 2, to.y + to.height, { steps: 5 });
+  await page.mouse.move(to.x + to.width / 2, to.y + 2, { steps: 5 });
+  await page.mouse.up();
+}
 
 /**
  * 単語集, from an empty list to a drill scoped to one.
@@ -31,10 +67,10 @@ test.describe('word sets', () => {
     // Creating opens the new set: a 単語集 is worth nothing until it has words.
     await expect(page.getByRole('heading', { name: /会議の語/ })).toBeVisible();
     await expect(
-      page.getByText('まだ単語がありません。上の検索から追加してください。'),
+      page.getByText('下の一覧からドラッグ、または「＋ 追加」で入れてください'),
     ).toBeVisible();
 
-    await page.getByPlaceholder('見出し語・読み方で検索').fill('ちょうこう');
+    await page.getByPlaceholder('見出し語・読み方・タグ・意味・例文で検索').fill('ちょうこう');
     await page.getByRole('button', { name: '＋ 追加' }).click();
 
     await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
@@ -77,7 +113,7 @@ test.describe('word sets', () => {
 
     await page.getByLabel('新しい単語集の名前').fill('ニュースの語');
     await page.getByRole('button', { name: '作成' }).click();
-    await page.getByPlaceholder('見出し語・読み方で検索').fill('ちょうこう');
+    await page.getByPlaceholder('見出し語・読み方・タグ・意味・例文で検索').fill('ちょうこう');
     await page.getByRole('button', { name: '＋ 追加' }).click();
     await expect(page.getByRole('heading', { name: /1 語/ })).toBeVisible();
 
@@ -113,6 +149,55 @@ test.describe('word sets', () => {
     await page.goto('/practice/flashcards');
     await expect(page.getByRole('button', { name: /ニュースセット/ })).toContainText('0');
     await expect(page.getByRole('button', { name: /仕事セット/ })).toContainText('1');
+  });
+
+  /**
+   * The gesture, end to end, and the only place it can be seen: it is a pointer
+   * driving a hit test over a live layout, and neither half exists in jsdom.
+   * The arithmetic underneath it is unit-tested; what this proves is that a
+   * press, a move and a release over the real page reach it at all.
+   */
+  test('drags a word from the notebook into the top of the set', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+    await expect(memberOrder(page)).toHaveCount(2);
+
+    await dragOnto(
+      page,
+      page.getByRole('button', { name: 'ちょっとを並び替え' }),
+      memberOrder(page).first(),
+    );
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-chotto', '/vocabulary/w-kiriwake', '/vocabulary/w-choukou']);
+  });
+
+  /**
+   * Reordering is the half with no alternative: words join at the end, and
+   * until the rows could be dragged the study order was fixed by the order they
+   * happened to be filed in.
+   */
+  test('drags a member above another to change the study order', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: WORDS, wordSets: WORD_SETS });
+    await page.goto('/wordsets/set-work');
+
+    await dragOnto(
+      page,
+      page.getByRole('button', { name: '兆候を並び替え' }),
+      memberOrder(page).first(),
+    );
+
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-choukou', '/vocabulary/w-kiriwake']);
+
+    // And it survives a reload, so what moved was the stored order and not the
+    // rows on screen.
+    await page.reload();
+    await expect
+      .poll(() => memberHrefs(page))
+      .toEqual(['/vocabulary/w-choukou', '/vocabulary/w-kiriwake']);
   });
 
   test('deleting a set keeps every word it held', async ({ page }) => {

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -91,7 +91,8 @@ test.describe('word sets', () => {
    * itself stays in `entryIds`: nothing walks the sets on a delete, and
    * `membersOf` resolves the list against the notebook, so a set that outlives
    * a member simply stops listing it. This case is what says the resolution is
-   * applied everywhere a set is counted, rather than only where it is listed.
+   * applied *everywhere* a set is counted; the practice chip was reading
+   * `entryIds.length` and promising cards its own queue could not deal.
    */
   test('a deleted word leaves every set that held it, and every count of them', async ({
     page,
@@ -108,6 +109,10 @@ test.describe('word sets', () => {
 
     await page.getByRole('link', { name: /ニュースセット/ }).click();
     await expect(page.locator('a[href="/vocabulary/w-choukou"]')).toBeHidden();
+
+    await page.goto('/practice/flashcards');
+    await expect(page.getByRole('button', { name: /ニュースセット/ })).toContainText('0');
+    await expect(page.getByRole('button', { name: /仕事セット/ })).toContainText('1');
   });
 
   test('deleting a set keeps every word it held', async ({ page }) => {

--- a/tests/fixtures/drag.ts
+++ b/tests/fixtures/drag.ts
@@ -1,0 +1,17 @@
+import type { ListDrag } from '@/lib/listDrag';
+
+/**
+ * A drag that is not happening.
+ *
+ * The gesture itself is only observable in a browser — it is a pointer driving
+ * a hit test over a live layout — so the component tests take this and assert
+ * on the buttons and the keyboard instead. See `tests/e2e/wordsets.spec.ts`
+ * for the drag.
+ */
+export const idleDrag: ListDrag = {
+  dragging: null,
+  at: null,
+  point: null,
+  handleProps: () => ({ onPointerDown: () => {} }),
+  rowProps: () => ({ onPointerDown: () => {} }),
+};

--- a/tests/fixtures/wordSet.ts
+++ b/tests/fixtures/wordSet.ts
@@ -1,0 +1,24 @@
+import type { WordSet } from '@/domain/wordSet';
+
+/**
+ * A complete, valid `WordSet`, so a test that cares about `entryIds` can
+ * override it and trust the rest — the same bargain as `makeEntry`, and built
+ * by hand for the same reason.
+ */
+export function makeWordSet(overrides: Partial<WordSet> = {}): WordSet {
+  return {
+    id: 'set-1',
+    ownerUid: 'uid-alice',
+    name: '仕事の語',
+    description: '会議で出てきた語',
+    entryIds: [],
+    level: 'N2',
+    topics: ['仕事'],
+    publishedId: null,
+    publishedVersion: 0,
+    copiedFrom: null,
+    createdAt: '2026-06-24T09:00:00.000Z',
+    updatedAt: '2026-06-24T09:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/tests/unit/listDrag.test.ts
+++ b/tests/unit/listDrag.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dropIndexFor } from '@/lib/listDrag';
+import { beyondSlop, dropIndexFor, edgeScrollFor } from '@/lib/listDrag';
 
 /**
  * Where a pointer sitting over a row means the word should land.
@@ -30,5 +30,75 @@ describe('dropIndexFor', () => {
    */
   it('has no dead zone: the midpoint itself already means after', () => {
     expect(at(120)).toBe(3);
+  });
+});
+
+/**
+ * The threshold that separates a click on a row from a drag of it.
+ *
+ * A whole row is draggable, and a row also holds a link to the word and a
+ * button that removes it. Without this every press on either would begin a
+ * drag, and the click that follows would be swallowed as the drag's own — so
+ * opening a word from the set would stop working entirely.
+ */
+describe('beyondSlop', () => {
+  const from = { x: 100, y: 100 };
+
+  it.each([
+    ['exactly at the threshold', { x: 105, y: 100 }],
+    ['a hand that shook', { x: 102, y: 97 }],
+    ['not at all', { x: 100, y: 100 }],
+  ])('is still a click: %s', (_case, to) => {
+    expect(beyondSlop(from, to, 5)).toBe(false);
+  });
+
+  it.each([
+    ['sideways', { x: 106, y: 100 }],
+    ['upward', { x: 100, y: 93 }],
+  ])('has become a drag: %s', (_case, to) => {
+    expect(beyondSlop(from, to, 5)).toBe(true);
+  });
+});
+
+/**
+ * Scrolling a bounded panel while a drag is held near its edge.
+ *
+ * Both lists scroll inside themselves so they can sit side by side, which means
+ * the row a word is being dragged to is often not rendered when the drag
+ * starts. Without this, those rows are unreachable.
+ */
+describe('edgeScrollFor', () => {
+  // A panel occupying 200…600, with a 50px band at each end.
+  const at = (clientY: number) => edgeScrollFor(200, 600, clientY, 50, 10);
+
+  it('does not scroll while the pointer is in the middle', () => {
+    expect(at(400)).toBe(0);
+    expect(at(251)).toBe(0);
+    expect(at(549)).toBe(0);
+  });
+
+  it('scrolls up near the top and down near the bottom', () => {
+    expect(at(210)).toBeLessThan(0);
+    expect(at(590)).toBeGreaterThan(0);
+  });
+
+  /**
+   * Proportional, so the list creeps at the edge of the band and runs at the
+   * edge of the panel. A single speed makes the only usable gesture a
+   * fully-committed one, and overshoots every short move.
+   */
+  it('speeds up the closer the pointer gets to the edge', () => {
+    // Both bands, because they are two branches: 205 is nearer the top than
+    // 245 and so must scroll harder, which for an upward scroll means lower.
+    expect(at(205)).toBeLessThan(at(245));
+    expect(at(560)).toBeLessThan(at(595));
+    expect(at(600)).toBe(10);
+    expect(at(200)).toBe(-10);
+  });
+
+  /** Past the edge entirely — a pointer dragged off the panel — stays capped. */
+  it('does not accelerate without limit past the edge', () => {
+    expect(at(900)).toBe(10);
+    expect(at(-100)).toBe(-10);
   });
 });

--- a/tests/unit/listDrag.test.ts
+++ b/tests/unit/listDrag.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { dropIndexFor } from '@/lib/listDrag';
+
+/**
+ * Where a pointer sitting over a row means the word should land.
+ *
+ * The whole gesture is judged by this one number, and it is the only part of it
+ * a test can hold still: everything above it is a browser delivering pointer
+ * events over a layout that changes as rows move.
+ */
+describe('dropIndexFor', () => {
+  // Row 2 of a list, 40px tall, starting 100px down the viewport.
+  const row = { index: 2, top: 100, height: 40 };
+  const at = (clientY: number) => dropIndexFor(row.index, row.top, row.height, clientY);
+
+  it('drops before the row while the pointer is in its top half', () => {
+    expect(at(101)).toBe(2);
+    expect(at(119)).toBe(2);
+  });
+
+  it('drops after the row once the pointer passes the middle', () => {
+    expect(at(121)).toBe(3);
+    expect(at(139)).toBe(3);
+  });
+
+  /**
+   * The midpoint and not the edge. Judging by edges leaves the centre of every
+   * row meaning nothing, so a careful drop aimed at a word — which is where a
+   * hand naturally aims — would be the one place the gesture does nothing.
+   */
+  it('has no dead zone: the midpoint itself already means after', () => {
+    expect(at(120)).toBe(3);
+  });
+});

--- a/tests/unit/wordSetMembers.test.ts
+++ b/tests/unit/wordSetMembers.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { candidatesFor, membersOf, toDraft, withMember, withoutMember } from '@/lib/wordSetMembers';
+import { makeEntry } from '../fixtures/entry';
+import { makeWordSet } from '../fixtures/wordSet';
+
+/**
+ * Resolving a 単語集 against the notebook, which is every screen's first step:
+ * membership is a list of ids and nothing on the entry side points back.
+ */
+
+const KIRIWAKE = makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' });
+const CHOUKOU = makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' });
+const HAKKIRI = makeEntry({ id: 'w3', headword: 'はっきり', reading: 'はっきり' });
+const NOTEBOOK = [KIRIWAKE, CHOUKOU, HAKKIRI];
+
+describe('membersOf', () => {
+  /**
+   * The stored order *is* the study order — it is the reason membership lives
+   * on the set rather than on the entry. Resolving through the notebook's own
+   * order would silently sort the set by when each word was added instead.
+   */
+  it('returns the words in the set’s order, not the notebook’s', () => {
+    const set = makeWordSet({ entryIds: ['w3', 'w1', 'w2'] });
+    expect(membersOf(set, NOTEBOOK).map((entry) => entry.headword)).toEqual([
+      'はっきり',
+      '切り分け',
+      '兆候',
+    ]);
+  });
+
+  /**
+   * Deleting a word does not visit the sets that named it, so a set outlives
+   * its members. Counting the id anyway is what makes 「3 語」 sit above a list
+   * of two, and makes a practice chip promise cards the queue cannot deal.
+   */
+  it('drops an id whose word has been deleted instead of counting it', () => {
+    const set = makeWordSet({ entryIds: ['w1', 'gone', 'w2'] });
+    expect(membersOf(set, NOTEBOOK).map((entry) => entry.id)).toEqual(['w1', 'w2']);
+  });
+});
+
+describe('candidatesFor', () => {
+  const empty = makeWordSet();
+
+  it('matches on the reading, not only on the headword', () => {
+    expect(candidatesFor(empty, NOTEBOOK, 'ちょうこう').map((entry) => entry.id)).toEqual(['w2']);
+  });
+
+  /**
+   * Offering a word that is already in the set gives a ＋追加 button that
+   * writes nothing — indistinguishable, from the other side of the screen,
+   * from a save that failed.
+   */
+  it('does not offer a word the set already holds', () => {
+    const set = makeWordSet({ entryIds: ['w2'] });
+    expect(candidatesFor(set, NOTEBOOK, 'ちょう')).toEqual([]);
+  });
+
+  /** A picker that answers an empty box with the whole notebook is a list. */
+  it('suggests nothing until something is typed', () => {
+    expect(candidatesFor(empty, NOTEBOOK, '   ')).toEqual([]);
+  });
+
+  it('stops at the limit rather than rendering every match', () => {
+    // 「り」 is in 切り分け and はっきり both, so a limit of 1 has something to cut.
+    expect(candidatesFor(empty, NOTEBOOK, 'り')).toHaveLength(2);
+    expect(candidatesFor(empty, NOTEBOOK, 'り', 1).map((entry) => entry.id)).toEqual(['w1']);
+  });
+});
+
+describe('withMember', () => {
+  /** Prepending would reorder a set every time a word joined it. */
+  it('appends, leaving the existing study order alone', () => {
+    expect(withMember(['w1', 'w2'], 'w3')).toEqual(['w1', 'w2', 'w3']);
+  });
+
+  /** A repeated id deals the same card twice in one session. */
+  it('ignores a word the set already holds', () => {
+    expect(withMember(['w1', 'w2'], 'w1')).toEqual(['w1', 'w2']);
+  });
+});
+
+describe('withoutMember', () => {
+  it('removes only the word asked for, in place', () => {
+    expect(withoutMember(['w1', 'w2', 'w3'], 'w2')).toEqual(['w1', 'w3']);
+  });
+});
+
+/**
+ * Every write sends a whole draft, so anything `toDraft` forgets is a field the
+ * next rename silently clears. `level` and `topics` have no form yet, which is
+ * exactly why they are the ones that can disappear without anybody noticing.
+ */
+describe('toDraft', () => {
+  it('carries through the fields no form on screen can restore', () => {
+    const set = makeWordSet({ level: 'N1', topics: ['旅行'], entryIds: ['w1'] });
+    expect(toDraft(set)).toEqual({
+      name: set.name,
+      description: set.description,
+      entryIds: ['w1'],
+      level: 'N1',
+      topics: ['旅行'],
+    });
+  });
+});

--- a/tests/unit/wordSetMembers.test.ts
+++ b/tests/unit/wordSetMembers.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import { candidatesFor, membersOf, toDraft, withMember, withoutMember } from '@/lib/wordSetMembers';
+import { EMPTY_FILTERS } from '@/lib/filters';
+import {
+  candidatesFor,
+  insertMemberAt,
+  membersOf,
+  reorderMembers,
+  toDraft,
+  withMember,
+  withoutMember,
+} from '@/lib/wordSetMembers';
 import { makeEntry } from '../fixtures/entry';
 import { makeWordSet } from '../fixtures/wordSet';
 
@@ -8,10 +17,28 @@ import { makeWordSet } from '../fixtures/wordSet';
  * membership is a list of ids and nothing on the entry side points back.
  */
 
-const KIRIWAKE = makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ' });
-const CHOUKOU = makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう' });
-const HAKKIRI = makeEntry({ id: 'w3', headword: 'はっきり', reading: 'はっきり' });
-const NOTEBOOK = [KIRIWAKE, CHOUKOU, HAKKIRI];
+/** Distinct learning dates, because the picker's default order is by them. */
+const KIRIWAKE = makeEntry({
+  id: 'w1',
+  headword: '切り分け',
+  reading: 'きりわけ',
+  learnedOn: '2026-06-24',
+});
+const CHOUKOU = makeEntry({
+  id: 'w2',
+  headword: '兆候',
+  reading: 'ちょうこう',
+  learnedOn: '2026-06-22',
+  jlpt: 'N1',
+});
+const HAKKIRI = makeEntry({
+  id: 'w3',
+  headword: 'はっきり',
+  reading: 'はっきり',
+  learnedOn: '2026-01-15',
+});
+/** Deliberately not in date order, so a test that expects one proves it. */
+const NOTEBOOK = [CHOUKOU, HAKKIRI, KIRIWAKE];
 
 describe('membersOf', () => {
   /**
@@ -41,9 +68,31 @@ describe('membersOf', () => {
 
 describe('candidatesFor', () => {
   const empty = makeWordSet();
+  const ids = (result: { shown: { id: string }[] }) => result.shown.map((entry) => entry.id);
 
-  it('matches on the reading, not only on the headword', () => {
-    expect(candidatesFor(empty, NOTEBOOK, 'ちょうこう').map((entry) => entry.id)).toEqual(['w2']);
+  /**
+   * The picker opens on the notebook, newest first, before a filter is touched.
+   * A word is usually filed into a set soon after it is written down, so the
+   * ones worth offering unprompted are the recent ones — and a list that starts
+   * empty leaves the drag gesture with nothing to be discovered on.
+   */
+  it('starts on the whole notebook, most recently learned first', () => {
+    expect(ids(candidatesFor(empty, NOTEBOOK, EMPTY_FILTERS))).toEqual(['w1', 'w2', 'w3']);
+  });
+
+  it('narrows on the search term, over readings as well as headwords', () => {
+    expect(ids(candidatesFor(empty, NOTEBOOK, { ...EMPTY_FILTERS, q: 'ちょうこう' }))).toEqual([
+      'w2',
+    ]);
+  });
+
+  /**
+   * The same 一覧 filters over the same predicate, so a word that a filter
+   * combination finds on 一覧 is findable by that combination here. A second
+   * search implementation is how that stops being true.
+   */
+  it('narrows on a filter the search box cannot express', () => {
+    expect(ids(candidatesFor(empty, NOTEBOOK, { ...EMPTY_FILTERS, jlpt: ['N1'] }))).toEqual(['w2']);
   });
 
   /**
@@ -53,18 +102,20 @@ describe('candidatesFor', () => {
    */
   it('does not offer a word the set already holds', () => {
     const set = makeWordSet({ entryIds: ['w2'] });
-    expect(candidatesFor(set, NOTEBOOK, 'ちょう')).toEqual([]);
+    expect(ids(candidatesFor(set, NOTEBOOK, EMPTY_FILTERS))).toEqual(['w1', 'w3']);
   });
 
-  /** A picker that answers an empty box with the whole notebook is a list. */
-  it('suggests nothing until something is typed', () => {
-    expect(candidatesFor(empty, NOTEBOOK, '   ')).toEqual([]);
-  });
-
-  it('stops at the limit rather than rendering every match', () => {
-    // 「り」 is in 切り分け and はっきり both, so a limit of 1 has something to cut.
-    expect(candidatesFor(empty, NOTEBOOK, 'り')).toHaveLength(2);
-    expect(candidatesFor(empty, NOTEBOOK, 'り', 1).map((entry) => entry.id)).toEqual(['w1']);
+  /**
+   * The cap is a drag constraint, not a paging one: reaching row 200 means
+   * scrolling the drop target off screen mid-gesture. `total` is what tells the
+   * learner to narrow rather than scroll, so it counts the matches and not the
+   * rows.
+   */
+  it('caps the rows but still reports how many matched', () => {
+    expect(candidatesFor(empty, NOTEBOOK, EMPTY_FILTERS, 2)).toEqual({
+      shown: [KIRIWAKE, CHOUKOU],
+      total: 3,
+    });
   });
 });
 
@@ -83,6 +134,65 @@ describe('withMember', () => {
 describe('withoutMember', () => {
   it('removes only the word asked for, in place', () => {
     expect(withoutMember(['w1', 'w2', 'w3'], 'w2')).toEqual(['w1', 'w3']);
+  });
+});
+
+/**
+ * `to` is an insertion point in the *original* array's coordinates — the gap
+ * the drop indicator was drawn in. Removing the moved item first shifts
+ * everything after it down by one, and forgetting that is the classic off-by-one
+ * that makes every downward drag land one row short of where it was released.
+ */
+describe('reorderMembers', () => {
+  /**
+   * Dropped into the gap between w2 and w3 — index 2 while w1 is still in the
+   * list. Landing at index 2 *after* w1 has been lifted out puts it after w3
+   * instead, one row further than the indicator promised.
+   */
+  it('lands where the indicator was drawn when moving down', () => {
+    expect(reorderMembers(['w1', 'w2', 'w3'], 0, 2)).toEqual(['w2', 'w1', 'w3']);
+  });
+
+  it('lands where the indicator was drawn when moving up', () => {
+    expect(reorderMembers(['w1', 'w2', 'w3'], 2, 0)).toEqual(['w3', 'w1', 'w2']);
+  });
+
+  /** Both gaps touching a row mean "leave it alone", or a nudge costs a write. */
+  it.each([1, 2])('does nothing dropping row 1 into gap %i', (to) => {
+    expect(reorderMembers(['w1', 'w2', 'w3'], 1, to)).toEqual(['w1', 'w2', 'w3']);
+  });
+
+  /**
+   * What ArrowUp on the first row asks for. A negative index counts back from
+   * the end in `splice`, so without the clamp the top row would jump to second
+   * place — the opposite of the key that was pressed.
+   */
+  it('leaves the first row alone when it is moved up', () => {
+    expect(reorderMembers(['w1', 'w2', 'w3'], 0, -1)).toEqual(['w1', 'w2', 'w3']);
+  });
+
+  /** A row index left over from a list that has since been refreshed shorter. */
+  it('leaves the list alone when asked to move a row that is not there', () => {
+    expect(reorderMembers(['w1', 'w2'], 7, 0)).toEqual(['w1', 'w2']);
+  });
+});
+
+/**
+ * A drop target cannot tell whether what landed on it came from the notebook or
+ * from three rows further up its own list, so one function has to answer both.
+ */
+describe('insertMemberAt', () => {
+  it('inserts a word from outside at the gap it was dropped in', () => {
+    expect(insertMemberAt(['w1', 'w2'], 'w3', 1)).toEqual(['w1', 'w3', 'w2']);
+  });
+
+  /** Otherwise dragging a member onto a new position duplicates it. */
+  it('moves a word the set already holds rather than adding it twice', () => {
+    expect(insertMemberAt(['w1', 'w2', 'w3'], 'w3', 0)).toEqual(['w3', 'w1', 'w2']);
+  });
+
+  it('appends when the gap is past the end', () => {
+    expect(insertMemberAt(['w1'], 'w2', 99)).toEqual(['w1', 'w2']);
   });
 });
 

--- a/tests/unit/wordSetMembers.test.ts
+++ b/tests/unit/wordSetMembers.test.ts
@@ -8,6 +8,7 @@ import {
   toDraft,
   withMember,
   withoutMember,
+  withoutMembers,
 } from '@/lib/wordSetMembers';
 import { makeEntry } from '../fixtures/entry';
 import { makeWordSet } from '../fixtures/wordSet';
@@ -134,6 +135,22 @@ describe('withMember', () => {
 describe('withoutMember', () => {
   it('removes only the word asked for, in place', () => {
     expect(withoutMember(['w1', 'w2', 'w3'], 'w2')).toEqual(['w1', 'w3']);
+  });
+});
+
+describe('withoutMembers', () => {
+  it('removes several at once and keeps the rest in order', () => {
+    expect(withoutMembers(['w1', 'w2', 'w3', 'w4'], ['w3', 'w1'])).toEqual(['w2', 'w4']);
+  });
+
+  /**
+   * 表示中の N 語を削除 hands over the rows it was showing, and an id whose word
+   * has been deleted is not one of them. Emptying the array instead would be
+   * that button doing more than it says — and there is nothing on screen for
+   * the extra removal to have come from.
+   */
+  it('leaves behind an id that was not on screen to be removed', () => {
+    expect(withoutMembers(['w1', 'gone', 'w2'], ['w1', 'w2'])).toEqual(['gone']);
   });
 });
 

--- a/tests/unit/wordSetMembers.test.ts
+++ b/tests/unit/wordSetMembers.test.ts
@@ -5,6 +5,7 @@ import {
   insertMemberAt,
   membersOf,
   reorderMembers,
+  storedIndexFor,
   toDraft,
   withMember,
   withoutMember,
@@ -151,6 +152,66 @@ describe('withoutMembers', () => {
    */
   it('leaves behind an id that was not on screen to be removed', () => {
     expect(withoutMembers(['w1', 'gone', 'w2'], ['w1', 'w2'])).toEqual(['gone']);
+  });
+});
+
+/**
+ * Translating a row on screen into a position in the stored array.
+ *
+ * The bug this exists for: every index reaching `reorderMembers` and
+ * `insertMemberAt` counted *rendered* rows, and `membersOf` drops an id whose
+ * word has been deleted — so as soon as a set held one, the two lists were
+ * different lengths and every index after the gap pointed at the wrong id.
+ *
+ * Nothing caught it because every other case in this file resolves cleanly.
+ * `['w1', 'gone', 'w2']` is the shape that separates them.
+ */
+describe('storedIndexFor', () => {
+  const STORED = ['w1', 'gone', 'w2'];
+  const VISIBLE = ['w1', 'w2'];
+
+  it('finds the row that a visible index actually names', () => {
+    expect(storedIndexFor(STORED, VISIBLE, 0)).toBe(0);
+    // The one that mattered: visible row 1 is w2, stored at 2, not at 1.
+    expect(storedIndexFor(STORED, VISIBLE, 1)).toBe(2);
+  });
+
+  /** The gap after the last row, which is where an append belongs. */
+  it('answers the end of the stored array for a gap past the last row', () => {
+    expect(storedIndexFor(STORED, VISIBLE, 2)).toBe(3);
+  });
+
+  /**
+   * ArrowUp on the first row asks for the gap before everything. Clamping it to
+   * 0 here would be indistinguishable from "move to the front", and
+   * `reorderMembers` is what decides a negative gap means stay put.
+   */
+  it('passes a negative index through rather than clamping it', () => {
+    expect(storedIndexFor(STORED, VISIBLE, -1)).toBe(-1);
+  });
+});
+
+/**
+ * The two defects the translation fixes, stated as the gestures that produce
+ * them. Both are reachable through the UI: a set that holds a word which has
+ * since been deleted is a supported state.
+ */
+describe('reordering a set that holds a deleted word', () => {
+  const STORED = ['w1', 'gone', 'w2'];
+  const VISIBLE = ['w1', 'w2'];
+  const at = (visible: number) => storedIndexFor(STORED, VISIBLE, visible);
+
+  /** Untranslated this moved `gone` instead, so nothing on screen changed. */
+  it('moves the word the learner dragged, not the stale id beside it', () => {
+    expect(reorderMembers(STORED, at(1), at(0))).toEqual(['w2', 'w1', 'gone']);
+  });
+
+  /** Untranslated this landed the word above the row it was dropped below. */
+  it('lands a new word in the gap it was released in', () => {
+    const stored = ['gone', 'w1'];
+    const visible = ['w1'];
+    const after = storedIndexFor(stored, visible, 1);
+    expect(insertMemberAt(stored, 'w2', after)).toEqual(['gone', 'w1', 'w2']);
   });
 });
 


### PR DESCRIPTION
### Summary

Phase 2, item 4: the write side of 単語集. `/wordsets` lists sets and starts one
from a name; `/wordsets/:id` fills it, arranges it, renames it and deletes it.

The read side already existed — a Firestore `WordSetRepository`, `sanitizeWordSet`,
`WordSetsProvider`, and practice filter chips that hid themselves while there were
no sets. Nothing could write one, so those chips had never appeared in the running
app. They do now.

Two fixes ride along, both reachable only because sets became writable.

### What changed

**Screens**

- `/wordsets` — the list, plus a name field that creates a set and opens it. A
  set is worth nothing until it has words in it, and the screen that adds them is
  the next one.
- `/wordsets/:id` — two bounded, scrolling panels side by side: 単語を探す on the
  left, 収録語 on the right, with search and filters across the top. Add a word by
  dragging it across or pressing ＋追加; arrange the study order by dragging within
  収録語 or with the arrow keys; rename, empty or delete the set.

**Finding words**

The picker narrows through 一覧's own `FilterPanel` over the same
`matches`/`sortEntries`, not a second search with its own rules: a combination
that finds a word on 一覧 has to find it here, and two implementations is how that
stops being true. With nothing set it shows the whole notebook newest-first —
a word is usually filed into a set soon after it is written down.

**Bulk**

`表示中の N 語を追加` and `表示中の N 語を削除`, both named after the rows on
screen rather than after the match count, which is capped at 50 and usually
larger. Removing confirms first and adding does not: emptying the list takes the
study order with it, and that order took dragging to build and is recorded
nowhere else.

**Data**

`membersOf`, `candidatesFor`, `withMember(s)`, `withoutMember(s)`,
`reorderMembers`, `insertMemberAt`, `toDraft` in `src/lib/wordSetMembers.ts`;
`useListDrag` and its geometry in `src/lib/listDrag.ts`. `WordSetsProvider` now
exposes its repository, the way `EntriesProvider` does.

No rules change: `users/{uid}/{document=**}` already covers `wordSets`, and the
adapter was merged and tested in #15.

### Decisions a reviewer should not have to re-derive

**Membership resolves through the notebook rather than being trusted as stored.**
Deleting a word does not visit the sets that named it — that would be a write per
set for a delete that has nothing to do with them — so `entryIds` can outlive its
members. `membersOf` drops an id with no entry behind it, which is what keeps a
set's count agreeing with the list under it. Everything that counts a set goes
through it. The one place that will not be enough is publishing, where the
snapshot must resolve the list rather than copy the array.

**`level` and `topics` have no field in the edit form.** Both exist to describe a
set to somebody else once it is published, and nothing publishes yet, so a form
for them would ask for metadata no screen reads back. `toDraft` still carries them
through every write, or the first rename would clear them.

**Pointer events, not HTML5 drag-and-drop.** `dragstart` never fires on a
touchscreen. No dependency was added; the hit test reads `data-drop-list` /
`data-drop-index` from the DOM rather than caching rectangles, because both lists
resize as rows move between them.

**A press becomes a drag only after 5px.** A row is also a link to its word, so a
hand that drifts two pixels between press and release has to still be able to open
it.

**Touch drags start from the grip, not the row.** A touch drag needs
`touch-action: none` on whatever it starts from, and a whole row marked that way
is a row the panel can no longer be scrolled by. The grip is a 44px target for
exactly that reason.

**Dragging a member *out* is a no-op.** The symmetric gesture would remove it, and
a slip would then take a word out of a set silently, where 削除 is a button that
says what it does.

**Both panels are bounded and scroll inside themselves.** Stacked one above the
other they drifted apart as soon as either had a few rows, and a drag whose start
and end are never on screen together cannot be performed. Below the nav breakpoint
they stack again, so the cap is a fraction of the viewport rather than a fixed
height. Bounded panels then need edge auto-scroll, on a frame loop rather than
inside `pointermove`, because a pointer held at the bottom of a list fires no more
moves — and holding still at the edge is exactly the gesture that means keep going.

**収録語 says whether it can take a drop.** 単語を探す is a source and refuses
them, so without something marking the list that accepts them, releasing over the
wrong half does nothing and looks broken. This is the one part of the styling that
carries meaning, so it is the one part with a test.

### The two fixes

**The practice chip counted ids, not words** (`4f3b387`). `entryIds.length` over a
set whose second word had been deleted advertised 3 and dealt 2 — the queue was
already right, because `matchesPractice` intersects with the entries in hand.
Unreachable until a set could be written. `PracticeSetup` now takes
`{ id, name, count }` so it cannot recompute the number a different way from its
caller.

**A post-write refresh blanked the page** (`a6b7c08`). Every write ends in its
provider's `refresh()`, and `refresh()` raised the same `loading` flag the initial
load uses — which every route reads as "replace the page with 読み込み中…". Adding
a word to a set took the whole screen down and put it back. The data in hand during
a refresh is one write out of date, not invalid. The gate now goes up only on
mount and on an account change. `EntriesProvider` carried the same defect and is
fixed with it; it shows on the edit path rather than the add path, because adding
navigates to the new word and leaves the blanked page behind. Found by hand on
another device.

### Tests

Chosen by the cheapest layer that can see the defect, per `CLAUDE.md`:

| Layer | Added | Why there |
| --- | --- | --- |
| `tests/unit` | membership, candidate filtering, reorder arithmetic, drop-index and edge-scroll geometry | all value-in, value-out |
| `tests/component` | the in-flight write guard on every bulk control, the edit form resetting on reopen, keyboard reordering, the drop-state affordance, the folded filter panel | document-level handlers and rendered structure; nothing about them is visible from a return value |
| `tests/e2e` | a set created on one screen reaching the practice filter on another, one word in two sets, a deleted word leaving both, dragging by grip and by row body, reordering, add-all, empty-with-confirmation, and two cases pinning that a write does not blank its page | routing, providers, and a real pointer over a real layout |

No new integration tests: `tests/integration/wordSetRepo.test.ts` already covers
create, update, the `entryIds` round trip, dedupe and delete. No new screenshot
baselines.

**Every fix was proved red first**, by reverting what it guards and confirming
only the expected cases failed. That process changed the change three times:

- The "moving down" reorder case did not discriminate the index correction it was
  written for — `splice` clamps a high index either way. It now drops into an
  interior gap, where the two answers differ.
- The upper `Math.min` clamp was dead for the same reason and is gone. The lower
  one is not: ArrowUp on the first row asks for gap `-1`, which `splice` counts
  back from the end, so without it the top row moved to *second*.
- The `from`-out-of-range guard was already covered by the missing-row check and
  is gone too.

And it found two defects no reading of the code had:

- **An `<a>` is natively draggable.** With the row body as a drag source, a press
  that drifted a few pixels started the browser's own link drag, which cancels the
  click — so a word could no longer be opened at all. The case that found it
  presses and moves 3px, because `locator.click()` releases on the pixel it
  pressed and would have proved nothing.
- **The click-swallow after a drag has never run.** Chromium fires no click at all
  following any drag this suite can produce, including one released on the row it
  started from — measured with a throwaway probe rather than guessed at. The code
  is kept for the browsers the suite does not cover and its comment now says
  plainly that it is unverified; the end-to-end case written to cover it was
  deleted, because a test that cannot go red says nothing.

One expected-red case stayed green and was rewritten rather than trusted: a
blanking case written against ＋追加 on `/vocabulary` passed twice in four runs,
because that flow navigates away and the count it asserted was only ever visible
mid-navigation. It now edits from the detail page, which stays put.

`yarn test:unit` 427 · `yarn test:emulator` 53 · `yarn test:e2e` 46 · typecheck,
lint and format clean. The full end-to-end suite was run three times consecutively
after each of the last three commits, for flake.

### Verified by hand

On a second device, which is where the page-blanking bug was reported from and
where drag-and-drop was found to be awkward enough to need the whole-row grab and
the side-by-side layout.

Not verified by hand: touch drag on a real phone or tablet. It is written for
pointer events and exercised in Chromium with synthesised ones, but no physical
touchscreen has been near it.

### Review round

`kowinauyeung` reviewed it and found two blockers, both one root cause: every row
index arriving from the DOM counts *rendered* rows, and `membersOf` drops an id
whose word has been deleted — so a set holding one renders fewer rows than it
stores. A visible index handed to `reorderMembers` moved whichever id occupied
that slot, usually the stale one: nothing changed on screen and the write still
went out. The keyboard path had the same fault and mattered more, since the arrow
keys are the only way to reorder without a pointer. `storedIndexFor` translates
between the two, unit-tested over `['w1','gone','w2']` and reached end to end by
deleting a word a set holds.

Five suggestions were taken as well: `up` read `dragging` from state while the
target beside it was a ref for exactly the reason that is unsafe — flagged as
reasoning without a reproduction, and it does reproduce, in
`tests/component/listDrag.test.tsx`, by holding React from flushing between the
move and the release; a press beginning on 削除 or ＋追加 armed a drag, so a
drifted press removed nothing and dropped something instead; rows were not gated
on `busy` the way the grip was, so a drag during a write ran its whole course and
was then declined silently; `useEntries().error` was read on neither word-set
screen, so a failed notebook load rendered a set that looked empty; and
`EntriesProvider.refresh` gained the generation counter `WordSetsProvider` has
carried since #15.

One suggestion was declined with reasoning: `membersOf` rebuilding a map per set
is O(N × entries), which the review itself judged not worth changing at this size.

### Not in this

Phase 2 items 5 and 6 remain: `/history` over `ProgressRepository.listSessions`,
and the dashboard's 最新の練習 panel.

Known and deliberate: no long-press to drag on touch (the grip is the way in
there), no screenshot baseline for the new page, and nothing prunes an id from a
set when its word is deleted — the resolution above makes that invisible
everywhere except a future publish.
