### PR TITLE
feat(security): bound writes, gate on a claim, and add App Check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,9 +12,15 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 
-# reCAPTCHA Enterprise site key for App Check. Optional: with it unset the app
-# runs without App Check rather than failing attestation on every request, which
-# is what a build enforcing App Check with no key would do. Create the key in
-# the Firebase console under App Check, and register a debug token there for
-# each machine running `yarn dev`.
+# reCAPTCHA v3 site key for App Check — v3, not Enterprise. The two are created
+# in different consoles and Enterprise needs a billing account, which these
+# projects do not have; the client constructs a ReCaptchaV3Provider.
+#
+# Optional: with it unset the app runs without App Check rather than failing
+# attestation on every request, which is what a build enforcing App Check with
+# no key would do. Register the key under App Check in the Firebase console,
+# and register a debug token there for each machine running `yarn dev`.
+#
+# One key covers both projects: a v3 "site" is a list of domains and belongs to
+# no Firebase project, so this value is deliberately not split dev/prod.
 VITE_RECAPTCHA_SITE_KEY=

--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ VITE_FIREBASE_PROJECT_ID=
 VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
+
+# reCAPTCHA Enterprise site key for App Check. Optional: with it unset the app
+# runs without App Check rather than failing attestation on every request, which
+# is what a build enforcing App Check with no key would do. Create the key in
+# the Firebase console under App Check, and register a debug token there for
+# each machine running `yarn dev`.
+VITE_RECAPTCHA_SITE_KEY=

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -44,9 +44,23 @@ jobs:
       # the runner has none. Scoped to this step rather than the job so that
       # install-time scripts never see them.
       #
-      # These six ship inside the bundle and can be read from the deployed site
-      # by anyone; rules, not secrecy, protect the data. They are secrets only
+      # These ship inside the bundle and can be read from the deployed site by
+      # anyone; rules, not secrecy, protect the data. They are secrets only
       # because the repo is public and a scraped key invites quota abuse.
+      #
+      # The reCAPTCHA key differs from the six above in one way that matters:
+      # the others are required and the build throws without them, while this
+      # one is optional and its absence means App Check is simply off. The
+      # client says so in the browser console, where a CI run has nobody
+      # looking — hence the annotation below, which puts it on the run summary.
+      - name: Warn when App Check is unconfigured
+        env:
+          KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "::warning title=App Check::VITE_RECAPTCHA_SITE_KEY is not set. This build ships without App Check: the Firebase config in it is public, and nothing attests that a request came from this app."
+          fi
+
       - name: Build
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
@@ -55,6 +69,7 @@ jobs:
           VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
         run: yarn build
 
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -69,6 +69,11 @@ jobs:
             exit 1
           fi
 
+      # VITE_RECAPTCHA_SITE_KEY is deliberately not PROD_-prefixed: one
+      # reCAPTCHA v3 site key covers both projects, because a v3 "site" is a
+      # list of domains and is not owned by a Firebase project. The App Check
+      # *registration* is per project and there are two of them, each holding
+      # the same secret. Enterprise keys would need splitting; v3 does not.
       - name: Build
         env:
           VITE_FIREBASE_API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
@@ -80,9 +85,41 @@ jobs:
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
         run: yarn build
 
+      # Every PROD_ secret must exist before anything is checked against it.
+      #
+      # This job has no `environment:`, so it reads repository-level secrets
+      # only — putting the production values in the `production` environment,
+      # which is the natural reading of "production secrets", hands this job
+      # empty strings instead. Nothing downstream would catch that: `client.ts`
+      # validates the config at runtime, and `vite build` never evaluates the
+      # module, so the build stays green and the bundle throws on first paint.
+      - name: Require every production value
+        env:
+          API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
+          AUTH_DOMAIN: ${{ secrets.PROD_VITE_FIREBASE_AUTH_DOMAIN }}
+          PROJECT_ID: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}
+          STORAGE_BUCKET: ${{ secrets.PROD_VITE_FIREBASE_STORAGE_BUCKET }}
+          SENDER_ID: ${{ secrets.PROD_VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          APP_ID: ${{ secrets.PROD_VITE_FIREBASE_APP_ID }}
+        run: |
+          missing=''
+          for name in API_KEY AUTH_DOMAIN PROJECT_ID STORAGE_BUCKET SENDER_ID APP_ID; do
+            eval "value=\$$name"
+            if [ -z "$value" ]; then missing="$missing PROD_VITE_FIREBASE_$name"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error title=Missing secrets::Not set at repository level:$missing. Environment-scoped secrets are not visible to this job."
+            exit 1
+          fi
+
       # Proves the bundle is the one this run built, and that it points where
       # it is about to be deployed. A dist/ built against the dev project would
       # otherwise deploy happily and talk to the wrong database.
+      #
+      # `grep -q ""` matches every line and exits 0, so this check was a no-op
+      # whenever EXPECTED was empty — it failed open in exactly the case it
+      # existed for. The step above is what stops that, and this one no longer
+      # has to trust its input.
       - name: Check the bundle points at production
         env:
           EXPECTED: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,156 @@
+name: Deploy (production)
+
+# Manual only. Production has no branch that deploys itself: a push to `main`
+# is a merge, and a merge is not a decision to release. The decision is this
+# button, and it names the commit it is releasing.
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Full commit SHA on main to deploy (40 characters)'
+        required: true
+
+permissions:
+  contents: read
+
+# Never two at once, and never cancelled halfway: a cancelled deploy between
+# the rules step and the hosting step leaves the two out of step with each
+# other, which is the one state this workflow orders itself to avoid.
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  # Same split as the dev workflow and for the same reason: this job runs
+  # install scripts, so it holds no credential. Unlike dev it also has to
+  # establish that the commit is one that may be released at all.
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The whole history, because the ancestry check below needs main.
+          fetch-depth: 0
+          ref: ${{ inputs.sha }}
+
+      # The check that makes the input safe. Without it this workflow deploys
+      # any commit in the repository — including one that only ever existed on
+      # a branch, or in a pull request that was closed unmerged.
+      - name: Refuse a commit that is not on main
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error title=Not on main::$SHA is not an ancestor of origin/main. Production deploys only from main."
+            exit 1
+          fi
+          echo "::notice::Deploying $SHA ($(git log -1 --format='%s' "$SHA"))"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # Dev warns and carries on when this is unset. Production does not: a
+      # build with no App Check ships a public Firebase config that nothing
+      # attests, and the console message saying so is seen by nobody.
+      - name: Require App Check
+        env:
+          KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "::error title=App Check::VITE_RECAPTCHA_SITE_KEY is not set. Refusing to build production without App Check."
+            exit 1
+          fi
+
+      - name: Build
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.PROD_VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.PROD_VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.PROD_VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.PROD_VITE_FIREBASE_APP_ID }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.VITE_RECAPTCHA_SITE_KEY }}
+        run: yarn build
+
+      # Proves the bundle is the one this run built, and that it points where
+      # it is about to be deployed. A dist/ built against the dev project would
+      # otherwise deploy happily and talk to the wrong database.
+      - name: Check the bundle points at production
+        env:
+          EXPECTED: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}
+        run: |
+          if ! grep -rq "$EXPECTED" dist/assets/*.js; then
+            echo "::error title=Wrong project::The built bundle does not contain $EXPECTED."
+            exit 1
+          fi
+          if grep -rq 'goitei-dev' dist/assets/*.js; then
+            echo "::error title=Wrong project::The built bundle mentions goitei-dev."
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-prod
+          path: dist
+          retention-days: 1
+
+  # Holds the credentials, runs no install script from the build, and is gated
+  # on the `production` environment — which is where a required reviewer or a
+  # wait timer is configured. The gate is in GitHub rather than in this file so
+  # that changing it does not need a commit.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.sha }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      # Before authenticating, so no postinstall script sees a credential.
+      - run: yarn install --frozen-lockfile
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist-prod
+          path: dist
+
+      - uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_PROD_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_PROD_DEPLOY_SERVICE_ACCOUNT }}
+
+      # Rules first, hosting second, and never in one command.
+      #
+      # The window between them is the whole reason for the order. Rules ahead
+      # of the client means the client is briefly older than the rules it runs
+      # under, which fails closed — a request the new rules refuse. Hosting
+      # first means a client is briefly newer than its rules, which fails open:
+      # it writes a shape the old rules still permit.
+      - name: Deploy Firestore rules
+        run: yarn firebase deploy --only firestore:rules --project prod --non-interactive
+
+      - name: Deploy Hosting
+        run: yarn firebase deploy --only hosting --project prod --non-interactive
+
+      - name: Record what was released
+        env:
+          SHA: ${{ inputs.sha }}
+        run: echo "::notice title=Released::$SHA to goitei"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -97,19 +97,32 @@ jobs:
       # empty strings instead. Nothing downstream would catch that: `client.ts`
       # validates the config at runtime, and `vite build` never evaluates the
       # module, so the build stays green and the bundle throws on first paint.
+      #
+      # The names are listed in full rather than rebuilt from a short loop
+      # variable. Five of the six matched; `SENDER_ID` printed
+      # `PROD_VITE_FIREBASE_SENDER_ID` while the secret read is
+      # `PROD_VITE_FIREBASE_MESSAGING_SENDER_ID` — so the one run this step
+      # exists for sent the reader off to create a secret nothing reads.
       - name: Require every production value
         env:
-          API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
-          AUTH_DOMAIN: ${{ secrets.PROD_VITE_FIREBASE_AUTH_DOMAIN }}
-          PROJECT_ID: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}
-          STORAGE_BUCKET: ${{ secrets.PROD_VITE_FIREBASE_STORAGE_BUCKET }}
-          SENDER_ID: ${{ secrets.PROD_VITE_FIREBASE_MESSAGING_SENDER_ID }}
-          APP_ID: ${{ secrets.PROD_VITE_FIREBASE_APP_ID }}
+          PROD_VITE_FIREBASE_API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
+          PROD_VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.PROD_VITE_FIREBASE_AUTH_DOMAIN }}
+          PROD_VITE_FIREBASE_PROJECT_ID: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}
+          PROD_VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.PROD_VITE_FIREBASE_STORAGE_BUCKET }}
+          PROD_VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.PROD_VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          PROD_VITE_FIREBASE_APP_ID: ${{ secrets.PROD_VITE_FIREBASE_APP_ID }}
         run: |
           missing=''
-          for name in API_KEY AUTH_DOMAIN PROJECT_ID STORAGE_BUCKET SENDER_ID APP_ID; do
+          for name in \
+            PROD_VITE_FIREBASE_API_KEY \
+            PROD_VITE_FIREBASE_AUTH_DOMAIN \
+            PROD_VITE_FIREBASE_PROJECT_ID \
+            PROD_VITE_FIREBASE_STORAGE_BUCKET \
+            PROD_VITE_FIREBASE_MESSAGING_SENDER_ID \
+            PROD_VITE_FIREBASE_APP_ID
+          do
             eval "value=\$$name"
-            if [ -z "$value" ]; then missing="$missing PROD_VITE_FIREBASE_$name"; fi
+            if [ -z "$value" ]; then missing="$missing $name"; fi
           done
           if [ -n "$missing" ]; then
             echo "::error title=Missing secrets::Not set at repository level:$missing. Environment-scoped secrets are not visible to this job."
@@ -185,6 +198,13 @@ jobs:
       # under, which fails closed — a request the new rules refuse. Hosting
       # first means a client is briefly newer than its rules, which fails open:
       # it writes a shape the old rules still permit.
+      #
+      # **Two steps come before this workflow runs, and it cannot check them.**
+      # These rules gate on a custom claim, which reaches a client only in a
+      # freshly minted ID token — so every account must be granted with
+      # `yarn allow` and must sign in again first, or it is locked out for up to
+      # an hour. See "Operator runbook" in README.md, which is in the working
+      # tree after merge in a way a pull request description is not.
       - name: Deploy Firestore rules
         run: yarn firebase deploy --only firestore:rules --project prod --non-interactive
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -76,6 +76,10 @@ jobs:
       # the same secret. Enterprise keys would need splitting; v3 does not.
       - name: Build
         env:
+          # The released commit, not the workflow's. On a workflow_dispatch run
+          # GITHUB_SHA is the default branch's head, so a rollback would ship a
+          # footer naming source that was never running — see build-info.ts.
+          DEPLOY_SHA: ${{ inputs.sha }}
           VITE_FIREBASE_API_KEY: ${{ secrets.PROD_VITE_FIREBASE_API_KEY }}
           VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.PROD_VITE_FIREBASE_AUTH_DOMAIN }}
           VITE_FIREBASE_PROJECT_ID: ${{ secrets.PROD_VITE_FIREBASE_PROJECT_ID }}

--- a/README.md
+++ b/README.md
@@ -169,31 +169,64 @@ days. Preview channels are hosting-only: rules are project-wide, so deploying
 them from a pull request would change the rules every other preview runs under.
 A preview reads the real `goitei-dev` data, not a copy.
 
-**Production is not automated.** Nothing in `.github/workflows/` can reach
-`goitei`; deploy it by hand with the commands below.
+**Production is a button, not a branch.** Run _Deploy (production)_ from the
+Actions tab and give it the full 40-character SHA; the workflow refuses any
+commit that is not an ancestor of `origin/main`, and the `production`
+environment is where a required reviewer or a wait timer is configured. A push
+to `main` is a merge, and a merge is not a decision to release.
 
 Which project a build talks to comes from the env file Vite picks, not from the
-`--project` flag, so the two must be set together:
+`--project` flag, so a by-hand deploy must set the two together:
 
 ```bash
 # dev
 yarn vite build --mode development
 yarn firebase deploy --only hosting,firestore:rules --project dev
-
-# production
-yarn build
-yarn firebase deploy --only hosting,firestore:rules --project prod
 ```
 
 `firestore.rules` gives an account read and write over everything beneath its
 own `users/{uid}`, and nothing else; every unlisted path is denied. Access is
-gated on `allowedUsers/{uid}` existing — an allowlist collection no client can
-write, so signups are closed until a document is added for that account. Nothing
-in front of the site can substitute for this: Hosting serves the config that
-reaches Firestore, so a password on the HTML protects the page, not the data.
+gated on the custom claim `allowed`, which nothing but `yarn allow` sets, so
+signups are closed until an operator grants it. Nothing in front of the site can
+substitute for this: Hosting serves the config that reaches Firestore, so a
+password on the HTML protects the page, not the data.
 
 For the first production import, follow the rules-first order in
 [`migration/README.md`](migration/README.md).
+
+### Operator runbook
+
+Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth
+application-default login` against the right project.
+
+**Granting access.** `yarn allow you@example.com prod`. The account must have
+signed in once first — the claim is set on the uid Google issued, so there is
+nothing to set it on before that. Anything other than `prod` or `--revoke` is
+rejected rather than ignored.
+
+**Revoking it.** `yarn allow you@example.com prod --revoke`. **This lands within
+the hour, not on the keystroke.** The claim lives inside the ID token the client
+already holds and Firestore rules have no revocation check, so it keeps working
+until that token expires. Revoking the refresh tokens ends the session at the
+next refresh but does not shorten that window. When responding to abuse, delete
+the data — that part takes effect now.
+
+**Releasing.** Three steps, in this order:
+
+1. `yarn allow <email> prod` for every account that must keep working.
+2. Ask each of them to sign out and sign back in. A claim reaches the client
+   only in a freshly minted ID token; an open session picks it up at its next
+   refresh, which is up to an hour away.
+3. Run _Deploy (production)_.
+
+The order is not a preference. The workflow deploys rules before hosting on
+purpose — a client briefly older than its rules fails closed, the other way
+round fails open — and the rules being deployed require a claim that no token
+issued before step 1 carries. Reversing steps 1 and 3 locks out everyone who was
+already signed in, for up to an hour, including whoever is doing the deploy.
+
+This matters most exactly once: the first production run of that workflow _is_
+the migration onto the claim.
 
 ### Deploy credentials
 

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,0 +1,65 @@
+import { cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+import { applicationDefault } from 'firebase-admin/app';
+
+/**
+ * Grant or revoke access, by custom claim.
+ *
+ *   yarn allow you@example.com          # grant on goitei-dev
+ *   yarn allow you@example.com --revoke
+ *   yarn allow you@example.com prod
+ *
+ * The security rules read `request.auth.token.allowed`, so this is the only
+ * thing that opens the door. It replaced an `allowedUsers` document that rules
+ * checked with `exists()` on every request — one billed read per request, to
+ * answer a question whose answer changes twice in an account's lifetime.
+ *
+ * **Revoking is two operations, and doing only the first is the mistake.** A
+ * claim lives inside the ID token the client already holds, so clearing it
+ * changes nothing until that token expires — up to an hour of continued access
+ * after a ban. `revokeRefreshTokens` forces the client to re-authenticate, and
+ * the new token is the one without the claim. Both run here, in that order.
+ */
+
+const [email, ...rest] = process.argv.slice(2);
+const revoke = rest.includes('--revoke');
+const env = rest.includes('prod') ? 'prod' : 'dev';
+
+if (!email) {
+  console.error('usage: allow-user.ts <email> [prod] [--revoke]');
+  process.exit(1);
+}
+
+const projectId = env === 'prod' ? 'goitei' : 'goitei-dev';
+
+if (getApps().length === 0) {
+  const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  initializeApp({
+    credential: key ? cert(key) : applicationDefault(),
+    projectId,
+  });
+}
+
+const auth = getAuth();
+
+const user = await auth.getUserByEmail(email).catch(() => null);
+if (!user) {
+  // Deliberately not created here: the uid has to be the one Google issued, so
+  // the account must have signed in once before it can be allowed.
+  console.error(`${email} has never signed in to ${projectId}; ask them to try once first.`);
+  process.exit(1);
+}
+
+const claims = { ...user.customClaims, allowed: revoke ? undefined : true };
+await auth.setCustomUserClaims(user.uid, claims);
+
+if (revoke) {
+  // Without this the client keeps its existing token, claim and all, until it
+  // expires. This is what makes a ban take effect now rather than within an hour.
+  await auth.revokeRefreshTokens(user.uid);
+}
+
+console.log(
+  `${revoke ? 'revoked' : 'allowed'}: ${email} (${user.uid}) on ${projectId}` +
+    (revoke ? ' — refresh tokens revoked, the client must sign in again' : ''),
+);

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -14,11 +14,16 @@ import { applicationDefault } from 'firebase-admin/app';
  * checked with `exists()` on every request — one billed read per request, to
  * answer a question whose answer changes twice in an account's lifetime.
  *
- * **Revoking is two operations, and doing only the first is the mistake.** A
- * claim lives inside the ID token the client already holds, so clearing it
- * changes nothing until that token expires — up to an hour of continued access
- * after a ban. `revokeRefreshTokens` forces the client to re-authenticate, and
- * the new token is the one without the claim. Both run here, in that order.
+ * **A ban lands within the hour, not on the keystroke.** A claim lives inside
+ * the ID token the client already holds, and Firestore rules have no revocation
+ * check, so clearing the claim changes nothing until that token expires — up to
+ * an hour. Revoking the refresh tokens does not shorten that: it stops the next
+ * refresh from succeeding, which ends the session, but the token already in
+ * hand keeps its claims until it runs out.
+ *
+ * It is done anyway, because ending the session is worth doing on its own. What
+ * it is not is immediate, and an operator responding to abuse has to know that
+ * — deleting the offending data is the part that takes effect now.
  */
 
 const [email, ...rest] = process.argv.slice(2);
@@ -54,12 +59,14 @@ const claims = { ...user.customClaims, allowed: revoke ? undefined : true };
 await auth.setCustomUserClaims(user.uid, claims);
 
 if (revoke) {
-  // Without this the client keeps its existing token, claim and all, until it
-  // expires. This is what makes a ban take effect now rather than within an hour.
+  // Ends the session at the next refresh. It does not invalidate the token the
+  // client is holding right now — see the note above.
   await auth.revokeRefreshTokens(user.uid);
 }
 
 console.log(
   `${revoke ? 'revoked' : 'allowed'}: ${email} (${user.uid}) on ${projectId}` +
-    (revoke ? ' — refresh tokens revoked, the client must sign in again' : ''),
+    (revoke
+      ? ' — refresh tokens revoked. The ID token already issued stays valid until it expires, so access ends within the hour rather than immediately.'
+      : ''),
 );

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,6 +1,5 @@
-import { cert, getApps, initializeApp } from 'firebase-admin/app';
+import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
-import { applicationDefault } from 'firebase-admin/app';
 
 /**
  * Grant or revoke access, by custom claim.
@@ -27,13 +26,21 @@ import { applicationDefault } from 'firebase-admin/app';
  */
 
 const [email, ...rest] = process.argv.slice(2);
-const revoke = rest.includes('--revoke');
-const env = rest.includes('prod') ? 'prod' : 'dev';
 
-if (!email) {
+// Rejected rather than ignored, because the mistake this catches is silent and
+// natural: `--revoke` is spelled with dashes, so `--prod` is how one reaches
+// for the other — and `rest.includes('prod')` is false for it, so the run would
+// grant access on **dev** and say so only in its last line.
+const unknown = rest.filter((arg) => arg !== 'prod' && arg !== '--revoke');
+
+if (!email || unknown.length > 0) {
+  if (unknown.length > 0) console.error(`unknown argument: ${unknown.join(' ')}`);
   console.error('usage: allow-user.ts <email> [prod] [--revoke]');
   process.exit(1);
 }
+
+const revoke = rest.includes('--revoke');
+const env = rest.includes('prod') ? 'prod' : 'dev';
 
 const projectId = env === 'prod' ? 'goitei' : 'goitei-dev';
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -202,6 +202,31 @@ export default tseslint.config(
     },
   },
 
+  // Operator and migration scripts written in TypeScript.
+  //
+  // These were linted by nothing until now. `eslint .` matches no `.ts` file
+  // outside the blocks above, and it does not fail on a directory it skips —
+  // `npx eslint admin` says "all of the files matching the glob pattern are
+  // ignored" and exits 2, but `eslint .` stays green. So `yarn lint` passed
+  // over a duplicate import in the script that grants production access.
+  //
+  // Scoped to the same two folders `tsconfig.scripts.json` includes, so the
+  // lint pass and the typecheck pass cannot disagree about what a script is.
+  // Typed through `project` rather than `projectService`: the service resolves
+  // the nearest `tsconfig.json`, and this repository's root one is a solution
+  // file listing no files of its own.
+  {
+    files: ['admin/**/*.ts', 'migration/**/*.ts'],
+    extends: [js.configs.recommended, tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      globals: globals.node,
+      parserOptions: {
+        project: './tsconfig.scripts.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+
   // One-shot migration scripts and this config file. Plain ESM outside any
   // tsconfig, so they get the untyped ruleset.
   {

--- a/firestore.rules
+++ b/firestore.rules
@@ -68,17 +68,144 @@ service cloud.firestore {
     //
     // To open signups: delete this function and its call sites. Do that
     // together with App Check and a budget-alert kill switch, not before.
+    //
+    // **A custom claim, not a document read.** exists() here is billed as a
+    // document read on *every request to every path*, which on a public service
+    // doubles the read cost of the whole application to answer a question whose
+    // answer changes perhaps twice in an account's lifetime.
+    //
+    // What that trades away is immediacy, and it is worth stating: a claim
+    // lives in the ID token, so removing it takes effect when the token next
+    // refreshes — up to an hour. Revocation is therefore two steps, not one:
+    // clear the claim *and* revoke the refresh tokens, which forces the client
+    // to re-authenticate immediately. `admin/allow-user.ts` does both.
     function isAllowed() {
-      return signedIn()
-        && exists(/databases/$(database)/documents/allowedUsers/$(request.auth.uid));
+      return signedIn() && request.auth.token.allowed == true;
     }
 
-    // Everything private, in one rule. No field-level conditions, no visibility
-    // flags, nothing to get subtly wrong.
+    // ---- shape and size ----
+    //
+    // These exist for one threat and it is not shape: an account that is
+    // legitimately signed in can write **as many documents as it likes, as
+    // large as it likes**, and on a metered project that is somebody else's
+    // bill. Firestore caps a document at 1 MiB, which is 1 MiB per document and
+    // no limit at all on how many.
+    //
+    // **What rules cannot check is worth knowing before trusting this.** There
+    // is no way to iterate a list, so the length of `senses[3].description` is
+    // invisible here — only the number of senses and the size of the top-level
+    // strings can be bounded. Anything relying on per-element limits has to
+    // enforce them somewhere that can see them.
+    //
+    // Deliberately not a full schema. Requiring every field to exist and match
+    // a type turns every schema change into a rules deploy, and a rules deploy
+    // that lags a client release denies writes from a version already shipped.
+    function str(value, max) {
+      return value is string && value.size() <= max;
+    }
+
+    function list(value, max) {
+      return value is list && value.size() <= max;
+    }
+
+    function ownedBy(uid) {
+      return request.resource.data.ownerUid == uid;
+    }
+
+    // Bookkeeping a client may never rewrite. On an update `request.resource`
+    // is the merged result, so an untouched field compares equal to itself.
+    //
+    // `resource == null` first, and not for tidiness: on a create there is no
+    // existing document, and reaching into `resource.data` there is a null
+    // dereference — which rules report as an evaluation error and treat as a
+    // denial, so every create was refused with a message about null rather than
+    // about ownership.
+    function keepsCreatedAt() {
+      return resource == null
+        || !('createdAt' in resource.data)
+        || request.resource.data.createdAt == resource.data.createdAt;
+    }
+
+    function validEntry(uid) {
+      let d = request.resource.data;
+      return ownedBy(uid)
+        && d.keys().size() <= 40
+        && str(d.headword, 200) && d.headword.size() > 0
+        && str(d.reading, 200)
+        && str(d.definition, 20000)
+        && str(d.definitionSub, 20000)
+        && str(d.source, 500)
+        && str(d.citationForm, 200)
+        && list(d.pos, 20)
+        && list(d.tags, 50)
+        && list(d.senses, 100)
+        && list(d.examples, 100)
+        && list(d.related, 100)
+        && (d.pitchAccent == null || d.pitchAccent is int);
+    }
+
+    function validWordSet(uid) {
+      let d = request.resource.data;
+      return ownedBy(uid)
+        && d.keys().size() <= 20
+        && str(d.name, 200) && d.name.size() > 0
+        && str(d.description, 5000)
+        // The one unbounded list in the schema, and the one a set is made of.
+        && list(d.entryIds, 2000)
+        && list(d.topics, 50);
+    }
+
+    function validSession(uid) {
+      let d = request.resource.data;
+      return ownedBy(uid)
+        && d.keys().size() <= 20
+        && str(d.filterLabel, 500)
+        && d.total is int && d.total >= 0 && d.total <= 2000
+        && d.correct is int && d.correct >= 0 && d.correct <= d.total
+        && list(d.missed, 2000);
+    }
+
+    // Private data, one collection at a time.
+    //
+    // **There is deliberately no `match /{document=**}` here any more.** Rules
+    // are a union: a recursive wildcard granting write is an unconditional
+    // allow that every validation below would be evaluated *beside* rather than
+    // *after*, so leaving it in place while adding shape checks would have
+    // looked like hardening and enforced nothing.
+    //
+    // The cost of enumerating is that a collection nobody listed is denied
+    // rather than allowed. That is the right way round, and it is why adding a
+    // path to the app now means adding it here too.
     match /users/{uid} {
-      allow read, write: if isOwner(uid) && isAllowed();
-      match /{document=**} {
-        allow read, write: if isOwner(uid) && isAllowed();
+      function mine() {
+        return isOwner(uid) && isAllowed();
+      }
+
+      allow read: if mine();
+      allow write: if mine() && request.resource.data.keys().size() <= 20;
+
+      match /entries/{entryId} {
+        allow read, delete: if mine();
+        allow create, update: if mine() && validEntry(uid) && keepsCreatedAt();
+      }
+
+      match /wordSets/{setId} {
+        allow read, delete: if mine();
+        allow create, update: if mine() && validWordSet(uid) && keepsCreatedAt();
+      }
+
+      match /practiceSessions/{sessionId} {
+        allow read, delete: if mine();
+        allow create, update: if mine() && validSession(uid) && keepsCreatedAt();
+      }
+
+      // One document holding every entry's progress — see ProgressRepository
+      // for why it is a map rather than a collection. Its size is bounded by
+      // the 1 MiB document cap and by the notebook it mirrors, so the only
+      // thing worth asserting is that it belongs to the owner.
+      match /progress/{documentId} {
+        allow read, delete: if mine();
+        allow create, update: if mine();
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -74,11 +74,23 @@ service cloud.firestore {
     // doubles the read cost of the whole application to answer a question whose
     // answer changes perhaps twice in an account's lifetime.
     //
-    // What that trades away is immediacy, and it is worth stating: a claim
-    // lives in the ID token, so removing it takes effect when the token next
-    // refreshes — up to an hour. Revocation is therefore two steps, not one:
-    // clear the claim *and* revoke the refresh tokens, which forces the client
-    // to re-authenticate immediately. `admin/allow-user.ts` does both.
+    // **What it trades away is immediacy, and the trade is real.** The gate
+    // this replaces was re-evaluated on every request, so removing a document
+    // took effect on the next one. A claim lives inside the ID token the client
+    // is already holding, and Firestore rules have no revocation check — there
+    // is no rules equivalent of `verifyIdToken(..., checkRevoked: true)`. So a
+    // removed claim changes nothing until that token expires: **up to an hour.**
+    //
+    // Revoking the refresh tokens does not shorten it. It stops the *next*
+    // refresh from succeeding, which ends the session — but the ID token
+    // already in hand keeps its claims and keeps being accepted until it runs
+    // out. `admin/allow-user.ts` revokes them anyway, because ending the
+    // session is worth doing; it is not what makes a ban land.
+    //
+    // Closing the window properly means storing a revocation time and comparing
+    // `request.auth.token.auth_time` against it here, which reintroduces the
+    // per-request read this change removed. That is a decision worth making
+    // deliberately if abuse ever becomes a live problem, and not before.
     function isAllowed() {
       return signedIn() && request.auth.token.allowed == true;
     }
@@ -97,9 +109,24 @@ service cloud.firestore {
     // strings can be bounded. Anything relying on per-element limits has to
     // enforce them somewhere that can see them.
     //
-    // Deliberately not a full schema. Requiring every field to exist and match
-    // a type turns every schema change into a rules deploy, and a rules deploy
-    // that lags a client release denies writes from a version already shipped.
+    // Read "bounded" as cardinality, not size. 100 senses of 3,000 characters
+    // each is accepted, measured against the emulator. **The only size bound on
+    // a document here is Firestore's own 1 MiB**, which is a ceiling rather
+    // than a budget: it stops one document being enormous and says nothing
+    // about how many documents there are.
+    //
+    // Deliberately not a full schema, and `get` with a default is what makes
+    // that true rather than merely claimed. `d.field` on an absent key is an
+    // evaluation error, which rules treat as a denial — so naming a field is
+    // requiring it, and an earlier version of this file required every field it
+    // mentioned while the paragraph above said it did not.
+    //
+    // That matters in one direction in particular: `deploy-prod.yml` deploys
+    // rules before hosting, so rules rejecting a newly optional field would be
+    // live before the client that fills it.
+    //
+    // `headword` is the exception and is read directly: an entry without one is
+    // not an entry, and the form refuses it too.
     function str(value, max) {
       return value is string && value.size() <= max;
     }
@@ -131,17 +158,17 @@ service cloud.firestore {
       return ownedBy(uid)
         && d.keys().size() <= 40
         && str(d.headword, 200) && d.headword.size() > 0
-        && str(d.reading, 200)
-        && str(d.definition, 20000)
-        && str(d.definitionSub, 20000)
-        && str(d.source, 500)
-        && str(d.citationForm, 200)
-        && list(d.pos, 20)
-        && list(d.tags, 50)
-        && list(d.senses, 100)
-        && list(d.examples, 100)
-        && list(d.related, 100)
-        && (d.pitchAccent == null || d.pitchAccent is int);
+        && str(d.get('reading', ''), 200)
+        && str(d.get('definition', ''), 20000)
+        && str(d.get('definitionSub', ''), 20000)
+        && str(d.get('source', ''), 500)
+        && str(d.get('citationForm', ''), 200)
+        && list(d.get('pos', []), 20)
+        && list(d.get('tags', []), 50)
+        && list(d.get('senses', []), 100)
+        && list(d.get('examples', []), 100)
+        && list(d.get('related', []), 100)
+        && (d.get('pitchAccent', null) == null || d.get('pitchAccent', 0) is int);
     }
 
     function validWordSet(uid) {
@@ -149,20 +176,21 @@ service cloud.firestore {
       return ownedBy(uid)
         && d.keys().size() <= 20
         && str(d.name, 200) && d.name.size() > 0
-        && str(d.description, 5000)
+        && str(d.get('description', ''), 5000)
         // The one unbounded list in the schema, and the one a set is made of.
-        && list(d.entryIds, 2000)
-        && list(d.topics, 50);
+        && list(d.get('entryIds', []), 2000)
+        && list(d.get('topics', []), 50);
     }
 
     function validSession(uid) {
       let d = request.resource.data;
       return ownedBy(uid)
         && d.keys().size() <= 20
-        && str(d.filterLabel, 500)
-        && d.total is int && d.total >= 0 && d.total <= 2000
-        && d.correct is int && d.correct >= 0 && d.correct <= d.total
-        && list(d.missed, 2000);
+        && str(d.get('filterLabel', ''), 500)
+        && d.get('total', 0) is int && d.get('total', 0) >= 0 && d.get('total', 0) <= 2000
+        && d.get('correct', 0) is int && d.get('correct', 0) >= 0
+        && d.get('correct', 0) <= d.get('total', 0)
+        && list(d.get('missed', []), 2000);
     }
 
     // Private data, one collection at a time.
@@ -181,8 +209,14 @@ service cloud.firestore {
         return isOwner(uid) && isAllowed();
       }
 
-      allow read: if mine();
-      allow write: if mine() && request.resource.data.keys().size() <= 20;
+      allow read, delete: if mine();
+      // Split exactly as the subcollections are, and for the reason
+      // `keepsCreatedAt` documents: `write` covers delete, and on a delete
+      // `request.resource` is null, so reaching into it is an evaluation error.
+      // This document was the one place that kept the combined form, and
+      // deleting it therefore failed with a message about null rather than
+      // about permission — the failure mode account deletion would have hit.
+      allow create, update: if mine() && request.resource.data.keys().size() <= 20;
 
       match /entries/{entryId} {
         allow read, delete: if mine();
@@ -200,12 +234,20 @@ service cloud.firestore {
       }
 
       // One document holding every entry's progress — see ProgressRepository
-      // for why it is a map rather than a collection. Its size is bounded by
-      // the 1 MiB document cap and by the notebook it mirrors, so the only
-      // thing worth asserting is that it belongs to the owner.
-      match /progress/{documentId} {
+      // for why it is a map rather than a collection.
+      //
+      // `progress/entries` and not `progress/{id}`: the adapter addresses that
+      // one fixed id and nothing else, and a wildcard here was the one path in
+      // the file with no bound of any kind. An allowed account could create
+      // progress/junk-1, progress/junk-2 and so on, each holding as much as a
+      // document can — which is precisely the threat the section above names.
+      //
+      // `ownedBy` too, because `mine()` asserts the owner of the *path* and
+      // every sibling checks the field as well.
+      match /progress/entries {
         allow read, delete: if mine();
-        allow create, update: if mine();
+        allow create, update: if mine() && ownedBy(uid)
+                              && request.resource.data.keys().size() <= 5;
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc -b && vite build",
     "build:e2e": "vite build --mode e2e",
     "preview": "vite preview",
-    "typecheck": "tsc -b --noEmit && tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.migration.json --noEmit",
+    "typecheck": "tsc -b --noEmit && tsc -p tsconfig.test.json --noEmit && tsc -p tsconfig.scripts.json --noEmit",
     "test": "yarn test:unit && yarn test:emulator",
     "test:unit": "vitest run --project unit --project dom",
     "test:emulator": "firebase emulators:exec --only firestore --project demo-goitei 'vitest run --project emulator'",
@@ -29,6 +29,7 @@
     "migrate:parse": "node migration/parse.mjs",
     "migrate:upload": "node migration/upload.mjs",
     "migrate:accents": "vite-node migration/accents.ts --",
+    "allow": "vite-node admin/allow-user.ts --",
     "rules:dev": "firebase deploy --only firestore:rules --project dev",
     "rules:prod": "firebase deploy --only firestore:rules --project prod"
   },

--- a/src/infra/firebase/client.ts
+++ b/src/infra/firebase/client.ts
@@ -65,12 +65,19 @@ export const app = initializeApp(config);
  * does appear in the bundle, but every occurrence is the SDK reading it, and
  * the assignment is not there.
  *
- * **This needs a Content-Security-Policy change before the policy is enforced.**
- * reCAPTCHA Enterprise loads from `https://www.google.com/recaptcha/` and frames
- * a challenge from the same origin, and the policy in `firebase.json` allows
- * neither today. It is Report-Only, so nothing breaks now — but promoting the
- * policy without adding `https://www.google.com` to `script-src` and
- * `frame-src` would silently disable exactly the protection this adds.
+ * **This needs a Content-Security-Policy change before one is enforced.**
+ * v3 pulls its script from `https://www.gstatic.com/recaptcha/` *and*
+ * `https://www.google.com/recaptcha/`, and frames from `https://www.google.com`.
+ * Wherever a policy exists in this repository gstatic is already allowed and
+ * `www.google.com` is not, in either directive.
+ *
+ * Deliberately not a statement about what `firebase.json` holds today: the
+ * headers block arrives on a different branch, so anything asserted here would
+ * be true or false depending on which merged first. `tests/unit/csp.test.ts`
+ * asserts the conditional instead — *if* an enforcing `Content-Security-Policy`
+ * is present, `script-src` and `frame-src` must allow `https://www.google.com`.
+ * Green with no headers, green under Report-Only, red at the moment the policy
+ * is promoted without the hosts, which is the only moment it matters.
  */
 const siteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
 

--- a/src/infra/firebase/client.ts
+++ b/src/infra/firebase/client.ts
@@ -1,4 +1,5 @@
 import { initializeApp } from 'firebase/app';
+import { ReCaptchaEnterpriseProvider, initializeAppCheck } from 'firebase/app-check';
 import { GoogleAuthProvider, getAuth } from 'firebase/auth';
 import {
   initializeFirestore,
@@ -30,6 +31,59 @@ if (missing.length) {
 }
 
 export const app = initializeApp(config);
+
+/**
+ * App Check — the only thing standing between the published config above and
+ * anybody's script.
+ *
+ * Every value in `config` is readable from the deployed bundle, by design:
+ * Firestore rules and not obscurity are what protect the data. What rules
+ * cannot do is tell a request from this app apart from a request from a loop on
+ * somebody's laptop, and both are billed. App Check attests the *origin* of the
+ * call, which is the question rules were never asked.
+ *
+ * **Off unless a site key is configured**, and that is deliberate rather than
+ * lazy: a build with App Check enforced and no key attaches no token and every
+ * request is refused, which turns a missing environment variable into an outage
+ * with no error pointing at it. Absent key means absent App Check, and the
+ * console reports the state either way.
+ *
+ * Enforcement is a separate switch in the Firebase console and should stay off
+ * until its metrics show real traffic attesting successfully. Shipping the
+ * client first is what produces those metrics.
+ *
+ * The debug token below is for `yarn dev` only. It is compiled out of a
+ * production build by the mode check, so it cannot ship: a debug token is a
+ * bypass, and a bypass in a released bundle is the absence of App Check with
+ * extra steps. Verified against a real build rather than assumed — the string
+ * does appear in the bundle, but every occurrence is the SDK reading it, and
+ * the assignment is not there.
+ *
+ * **This needs a Content-Security-Policy change before the policy is enforced.**
+ * reCAPTCHA Enterprise loads from `https://www.google.com/recaptcha/` and frames
+ * a challenge from the same origin, and the policy in `firebase.json` allows
+ * neither today. It is Report-Only, so nothing breaks now — but promoting the
+ * policy without adding `https://www.google.com` to `script-src` and
+ * `frame-src` would silently disable exactly the protection this adds.
+ */
+const siteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+
+if (siteKey) {
+  if (import.meta.env.DEV) {
+    // Registered per browser in the console; without it a local build fails
+    // attestation against a key bound to the deployed domain.
+    (self as unknown as { FIREBASE_APPCHECK_DEBUG_TOKEN?: boolean }).FIREBASE_APPCHECK_DEBUG_TOKEN =
+      true;
+  }
+  initializeAppCheck(app, {
+    provider: new ReCaptchaEnterpriseProvider(siteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+} else if (import.meta.env.PROD) {
+  // Loud, because the failure it describes is silent: the app works perfectly
+  // and the protection simply is not there.
+  console.warn('App Check is not configured (VITE_RECAPTCHA_SITE_KEY is unset).');
+}
 
 /**
  * Persistent cache lets a review session keep working on the train and sync

--- a/src/infra/firebase/client.ts
+++ b/src/infra/firebase/client.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { ReCaptchaEnterpriseProvider, initializeAppCheck } from 'firebase/app-check';
+import { ReCaptchaV3Provider, initializeAppCheck } from 'firebase/app-check';
 import { GoogleAuthProvider, getAuth } from 'firebase/auth';
 import {
   initializeFirestore,
@@ -52,6 +52,12 @@ export const app = initializeApp(config);
  * until its metrics show real traffic attesting successfully. Shipping the
  * client first is what produces those metrics.
  *
+ * **v3, not Enterprise**, and that is a plan constraint rather than a
+ * preference: reCAPTCHA Enterprise is a Cloud product and its API cannot be
+ * enabled on a project without billing, so on Spark it is not an option at all.
+ * v3 is free, needs no card, and App Check treats the two identically —
+ * swapping providers later is this one import and the line below it.
+ *
  * The debug token below is for `yarn dev` only. It is compiled out of a
  * production build by the mode check, so it cannot ship: a debug token is a
  * bypass, and a bypass in a released bundle is the absence of App Check with
@@ -76,7 +82,7 @@ if (siteKey) {
       true;
   }
   initializeAppCheck(app, {
-    provider: new ReCaptchaEnterpriseProvider(siteKey),
+    provider: new ReCaptchaV3Provider(siteKey),
     isTokenAutoRefreshEnabled: true,
   });
 } else if (import.meta.env.PROD) {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,13 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_STORAGE_BUCKET: string;
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
+  /**
+   * Optional, unlike the rest: without it the app runs with App Check off
+   * rather than failing attestation on every request. Declared as `string`
+   * because Vite substitutes it textually — an unset variable becomes
+   * `undefined` at build time and the branch reading it is eliminated.
+   */
+  readonly VITE_RECAPTCHA_SITE_KEY: string;
 }
 
 interface ImportMeta {

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -184,11 +184,15 @@ describe('the allowedUsers gate', () => {
   /**
    * Revocation is the claim going away, not a document being deleted.
    *
-   * That is a real change in what "revoked" means and it is worth stating: the
-   * claim lives in the ID token, so clearing it takes effect when the token
-   * next refreshes — up to an hour — unless the refresh tokens are revoked at
-   * the same time, which forces re-authentication immediately. `admin/allow-user.ts`
-   * does both, and this test is the state *after* that has happened.
+   * That is a real change in what "revoked" means: the claim lives in the ID
+   * token, and Firestore rules have no revocation check, so clearing it takes
+   * effect only when that token expires — up to an hour. Revoking the refresh
+   * tokens ends the session at the next refresh but does not invalidate the
+   * token already in hand.
+   *
+   * **This test is the state after the token has turned over**, which is the
+   * one this harness can express: `@firebase/rules-unit-testing` mints tokens
+   * directly, so the window itself is not reachable from here.
    */
   it('revokes update and delete on already-published copies, not just create', async () => {
     const db = asStranger(ALICE);
@@ -465,6 +469,75 @@ describe('what the adapters write is what the rules accept', () => {
           { ownerUid: ALICE, entries: { e1: { status: 'wrong', attempts: 1 } } },
           { merge: true },
         ),
+    );
+  });
+});
+
+/**
+ * The four things the review measured, kept measured.
+ *
+ * Each was true of an earlier version of this file and each contradicted a
+ * paragraph in it — which is the pattern worth guarding, not the four cases
+ * individually: a rules file whose comments describe a property it does not
+ * have is worse than one with no comments, because the next person stops
+ * checking.
+ */
+describe('what the comments in the rules claim', () => {
+  /** "Deliberately not a full schema" — which was false while every named field was required. */
+  it('accepts an entry missing every optional field', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/entries/minimal`).set({ ownerUid: ALICE, headword: '清高' }),
+    );
+  });
+
+  it('still refuses one with no headword at all', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`users/${ALICE}/entries/nameless`).set({ ownerUid: ALICE }));
+    await assertFails(
+      db.doc(`users/${ALICE}/entries/blank`).set({ ownerUid: ALICE, headword: '' }),
+    );
+  });
+
+  it('accepts a word set and a session missing their optional fields', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/wordSets/minimal`).set({ ownerUid: ALICE, name: '仕事' }),
+    );
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/practiceSessions/minimal`).set({ ownerUid: ALICE }),
+    );
+  });
+
+  /**
+   * `write` covers delete, and on a delete `request.resource` is null — the
+   * same trap `keepsCreatedAt` guards. The parent document was the one place
+   * that kept the combined form, so deleting it failed with a message about
+   * null rather than about permission. Account deletion is the next caller.
+   */
+  it('lets the owner delete their own user document', async () => {
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      await context.firestore().doc(`users/${ALICE}`).set({ nickname: 'alice' });
+    });
+    await assertSucceeds(as(ALICE).doc(`users/${ALICE}`).delete());
+  });
+
+  /**
+   * `progress` was a wildcard with no bound of any kind — the one path in the
+   * file that was the threat the file names rather than a defence against it.
+   */
+  it('refuses a progress document other than the one the adapter writes', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries: {} }),
+    );
+    await assertFails(db.doc(`users/${ALICE}/progress/junk`).set({ ownerUid: ALICE, entries: {} }));
+  });
+
+  it('refuses a progress document claiming another owner', async () => {
+    const db = as(ALICE);
+    await assertFails(
+      db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: BOB, entries: {} }),
     );
   });
 });

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -447,6 +447,97 @@ describe('what the adapters write is what the rules accept', () => {
     );
   });
 
+  /**
+   * The update path, which none of the creates above reaches.
+   *
+   * `keepsCreatedAt` compares the incoming `createdAt` against the stored one,
+   * and on a create it takes the `resource == null` branch and never makes the
+   * comparison — so a suite of creates stays green whatever that comparison
+   * does. `entryRepo.update` is the call that meets it: `updateDoc` with the
+   * whole draft and a fresh `updatedAt`, and deliberately without `createdAt`
+   * or `ownerUid`, both of which therefore reach `request.resource.data` only
+   * through the merge.
+   *
+   * `createdAt` is stored as a `Date` rather than an ISO string because that is
+   * what `serverTimestamp()` leaves behind, and the comparison is against
+   * whatever type is really in the document.
+   */
+  it('accepts the whole-draft update entryRepo.update sends over a stored entry', async () => {
+    const db = as(ALICE);
+    const ref = db.doc(`users/${ALICE}/entries/editable`);
+    await assertSucceeds(
+      ref.set({
+        ...emptyDraft(),
+        headword: '清高',
+        ownerUid: ALICE,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    );
+    await assertSucceeds(
+      ref.update({
+        ...emptyDraft(),
+        headword: '清廉',
+        definition: '心が清らかで欲がないこと。',
+        updatedAt: new Date('2026-08-13T00:00:00.000Z'),
+      }),
+    );
+  });
+
+  it('accepts the whole-draft update wordSetRepo.update sends over a stored set', async () => {
+    const db = as(ALICE);
+    const ref = db.doc(`users/${ALICE}/wordSets/editable`);
+    await assertSucceeds(
+      ref.set({
+        name: '仕事',
+        description: '',
+        entryIds: [],
+        level: '',
+        topics: [],
+        ownerUid: ALICE,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    );
+    await assertSucceeds(
+      ref.update({
+        name: '仕事（改）',
+        description: '',
+        entryIds: ['e1'],
+        level: 'N2',
+        topics: [],
+        updatedAt: new Date('2026-08-13T00:00:00.000Z'),
+      }),
+    );
+  });
+
+  /**
+   * Why the adapter omits `createdAt` rather than re-sending what it read.
+   *
+   * The stored value is a Timestamp and a client that round-trips it through
+   * the domain type sends back an ISO string. That is not the same value, so
+   * `keepsCreatedAt` refuses it — an edit that looks like it changes nothing.
+   */
+  it('refuses an update that re-sends a stored Timestamp createdAt as a string', async () => {
+    const db = as(ALICE);
+    const ref = db.doc(`users/${ALICE}/entries/round-tripped`);
+    await assertSucceeds(
+      ref.set({
+        ...emptyDraft(),
+        headword: '清高',
+        ownerUid: ALICE,
+        createdAt: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    );
+    await assertFails(ref.update({ headword: '清廉', createdAt: '2026-08-01T00:00:00.000Z' }));
+  });
+
   /** `recordSession` writes both documents in one batch; both have to pass. */
   it('accepts both documents recordSession sends', async () => {
     const db = as(ALICE);

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -28,7 +28,55 @@ const MALLORY = 'uid-mallory';
 
 let testEnv: RulesTestEnvironment;
 
-const as = (uid: string) => testEnv.authenticatedContext(uid, { email_verified: true }).firestore();
+/**
+ * Signed in *and* allowed. The gate is a custom claim now rather than a
+ * document read, so a test that forgets it is denied for the right reason.
+ */
+const as = (uid: string) =>
+  testEnv.authenticatedContext(uid, { email_verified: true, allowed: true }).firestore();
+
+/** Signed in, verified, and not on the list. */
+const asStranger = (uid: string) =>
+  testEnv.authenticatedContext(uid, { email_verified: true }).firestore();
+
+/** A whole entry, the shape `sanitizeDraft` produces. Overrides go last. */
+const entry = (ownerUid: string, over: Record<string, unknown> = {}) => ({
+  ownerUid,
+  headword: '清高',
+  reading: 'せいこう',
+  definition: '清らかで気高いこと。',
+  definitionSub: '',
+  source: '',
+  citationForm: '',
+  pitchAccent: 0,
+  pos: ['名詞'],
+  tags: [],
+  senses: [],
+  examples: [],
+  related: [],
+  ...over,
+});
+
+const wordSet = (ownerUid: string, over: Record<string, unknown> = {}) => ({
+  ownerUid,
+  name: '仕事',
+  description: '',
+  entryIds: [],
+  topics: [],
+  ...over,
+});
+
+const session = (ownerUid: string, over: Record<string, unknown> = {}) => ({
+  ownerUid,
+  filterLabel: 'すべて',
+  total: 10,
+  correct: 8,
+  missed: ['e1'],
+  ...over,
+});
+
+/** `n` characters, for the length caps. */
+const long = (n: number) => 'あ'.repeat(n);
 
 const snapshotEntry = (ownerUid: string) => ({
   ownerUid,
@@ -64,7 +112,7 @@ beforeEach(async () => {
     await db.doc(`allowedUsers/${ALICE}`).set({ email: 'alice@example.com' });
     await db.doc(`allowedUsers/${BOB}`).set({ email: 'bob@example.com' });
 
-    await db.doc(`users/${ALICE}/entries/e1`).set({ ownerUid: ALICE, headword: '清高' });
+    await db.doc(`users/${ALICE}/entries/e1`).set(entry(ALICE));
     await db.doc(`publicEntries/pe-alice`).set(snapshotEntry(ALICE));
     await db.doc(`publicSets/set-alice`).set({ ...snapshotEntry(ALICE), entryCount: 1 });
     await db.doc(`publicSets/set-alice/entries/x1`).set(snapshotEntry(ALICE));
@@ -76,7 +124,7 @@ describe('private data under users/{uid}', () => {
   it('lets the owner read and write their own notebook', async () => {
     const db = as(ALICE);
     await assertSucceeds(db.doc(`users/${ALICE}/entries/e1`).get());
-    await assertSucceeds(db.doc(`users/${ALICE}/entries/e2`).set({ ownerUid: ALICE }));
+    await assertSucceeds(db.doc(`users/${ALICE}/entries/e2`).set(entry(ALICE)));
     await assertSucceeds(db.collection(`users/${ALICE}/entries`).get());
   });
 
@@ -86,7 +134,7 @@ describe('private data under users/{uid}', () => {
     await assertFails(db.collection(`users/${ALICE}/entries`).get());
     await assertFails(db.doc(`users/${ALICE}/entries/e1`).update({ headword: 'x' }));
     await assertFails(db.doc(`users/${ALICE}/entries/e1`).delete());
-    await assertFails(db.doc(`users/${ALICE}/entries/e9`).set({ ownerUid: BOB }));
+    await assertFails(db.doc(`users/${ALICE}/entries/e9`).set(entry(BOB)));
   });
 
   it('denies the subcollections too, not just the top document', async () => {
@@ -96,7 +144,7 @@ describe('private data under users/{uid}', () => {
     // word's progress, and one document per finished session.
     await assertFails(db.doc(`users/${ALICE}/progress/entries`).get());
     await assertFails(db.doc(`users/${ALICE}/progress/entries`).set({ entries: {} }));
-    await assertFails(db.doc(`users/${ALICE}/practiceSessions/p1`).set({ total: 1 }));
+    await assertFails(db.doc(`users/${ALICE}/practiceSessions/p1`).set(session(BOB)));
   });
 
   it('denies an unauthenticated client', async () => {
@@ -108,8 +156,8 @@ describe('private data under users/{uid}', () => {
 
 describe('the allowedUsers gate', () => {
   it('denies a signed-in user who is not on the allowlist', async () => {
-    const db = as(MALLORY);
-    await assertFails(db.doc(`users/${MALLORY}/entries/e1`).set({ ownerUid: MALLORY }));
+    const db = asStranger(MALLORY);
+    await assertFails(db.doc(`users/${MALLORY}/entries/e1`).set(entry(MALLORY)));
     await assertFails(db.doc(`users/${MALLORY}/entries/e1`).get());
     await assertFails(db.doc(`publicEntries/pe-alice`).get());
     await assertFails(db.doc(`publicSets/set-alice`).get());
@@ -132,11 +180,17 @@ describe('the allowedUsers gate', () => {
    * it had already put in front of other people — the one thing revocation is
    * for.
    */
+  /**
+   * Revocation is the claim going away, not a document being deleted.
+   *
+   * That is a real change in what "revoked" means and it is worth stating: the
+   * claim lives in the ID token, so clearing it takes effect when the token
+   * next refreshes — up to an hour — unless the refresh tokens are revoked at
+   * the same time, which forces re-authentication immediately. `admin/allow-user.ts`
+   * does both, and this test is the state *after* that has happened.
+   */
   it('revokes update and delete on already-published copies, not just create', async () => {
-    await testEnv.withSecurityRulesDisabled(async (context) => {
-      await context.firestore().doc(`allowedUsers/${ALICE}`).delete();
-    });
-    const db = as(ALICE);
+    const db = asStranger(ALICE);
 
     await assertFails(db.doc(`publicEntries/pe-alice`).update({ searchText: 'edited' }));
     await assertFails(db.doc(`publicEntries/pe-alice`).delete());
@@ -256,4 +310,83 @@ describe('collections that no longer exist', () => {
       await assertFails(db.doc(path).set({ ownerUid: ALICE }));
     },
   );
+});
+
+/**
+ * Shape and size, which exist for one threat and it is not shape.
+ *
+ * A legitimately signed-in account can write as many documents as it likes, as
+ * large as it likes, and on a metered project that is the operator's bill.
+ * These are the bounds rules can actually see — **not a schema**: requiring
+ * every field to exist turns every schema change into a rules deploy, and a
+ * rules deploy that lags a client release denies writes from a version already
+ * shipped.
+ */
+describe('bounds on what an owner may write', () => {
+  it('accepts an ordinary entry, word set and session', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(db.doc(`users/${ALICE}/entries/ok`).set(entry(ALICE)));
+    await assertSucceeds(db.doc(`users/${ALICE}/wordSets/ok`).set(wordSet(ALICE)));
+    await assertSucceeds(db.doc(`users/${ALICE}/practiceSessions/ok`).set(session(ALICE)));
+  });
+
+  it('refuses an entry whose text is far past anything a person types', async () => {
+    const db = as(ALICE);
+    await assertFails(
+      db.doc(`users/${ALICE}/entries/big`).set(entry(ALICE, { headword: long(201) })),
+    );
+    await assertFails(
+      db.doc(`users/${ALICE}/entries/big`).set(entry(ALICE, { definition: long(20001) })),
+    );
+  });
+
+  it('refuses an entry carrying an unbounded number of rows', async () => {
+    const db = as(ALICE);
+    const many = Array.from({ length: 101 }, () => ({ label: 'x' }));
+    await assertFails(db.doc(`users/${ALICE}/entries/big`).set(entry(ALICE, { senses: many })));
+  });
+
+  /** The one list a word set is made of, and the one that grows without limit. */
+  it('refuses a word set holding more ids than a notebook has words', async () => {
+    const db = as(ALICE);
+    const ids = Array.from({ length: 2001 }, (_, i) => `e${i}`);
+    await assertFails(db.doc(`users/${ALICE}/wordSets/big`).set(wordSet(ALICE, { entryIds: ids })));
+  });
+
+  it('refuses a session claiming more correct answers than questions', async () => {
+    const db = as(ALICE);
+    await assertFails(
+      db.doc(`users/${ALICE}/practiceSessions/x`).set(session(ALICE, { total: 3, correct: 9 })),
+    );
+  });
+
+  /**
+   * ownerUid is what a published snapshot copies, so a row claiming somebody
+   * else's uid inside one's own notebook is the seed of a snapshot attributed
+   * to a person who never wrote it.
+   */
+  it("refuses a row in your own notebook that claims somebody else's uid", async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`users/${ALICE}/entries/x`).set(entry(BOB)));
+    await assertFails(db.doc(`users/${ALICE}/wordSets/x`).set(wordSet(BOB)));
+  });
+
+  it('refuses to rewrite createdAt on an existing row', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/entries/dated`).set(entry(ALICE, { createdAt: '2026-01-01' })),
+    );
+    await assertFails(db.doc(`users/${ALICE}/entries/dated`).update({ createdAt: '2020-01-01' }));
+    await assertSucceeds(db.doc(`users/${ALICE}/entries/dated`).update({ headword: '別の語' }));
+  });
+
+  /**
+   * The recursive wildcard is gone, so an unlisted path is denied rather than
+   * allowed. That is the intended direction and the thing most likely to
+   * surprise: adding a collection to the app now means adding it here.
+   */
+  it('denies a collection nobody listed, even to its owner', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`users/${ALICE}/somethingNew/x`).set({ ownerUid: ALICE }));
+  });
 });

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -6,6 +6,7 @@ import {
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import { emptyDraft } from '@/lib/draft';
 
 /**
  * Security rules are the only thing protecting this data: the app is pure
@@ -388,5 +389,82 @@ describe('bounds on what an owner may write', () => {
   it('denies a collection nobody listed, even to its owner', async () => {
     const db = as(ALICE);
     await assertFails(db.doc(`users/${ALICE}/somethingNew/x`).set({ ownerUid: ALICE }));
+  });
+});
+
+/**
+ * The shapes the app actually writes, against the rules that will judge them.
+ *
+ * This exists because nothing else checks it. `tests/integration` connects with
+ * `mockUserToken: 'owner'`, which is the emulator's owner credential and
+ * **bypasses rules entirely** — so a green adapter suite says nothing about
+ * whether the documents it produces are writable in production. The bounds
+ * added here are the first rules that can reject a well-formed write, which
+ * makes this the first time that gap matters.
+ *
+ * Built from the production factories rather than by hand: a hand-written copy
+ * of the shape is exactly what stops failing when the schema moves.
+ */
+describe('what the adapters write is what the rules accept', () => {
+  it('accepts the document entryRepo.create sends', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/entries/real`).set({
+        ...emptyDraft(),
+        headword: '清高',
+        definition: '清らかで気高いこと。',
+        ownerUid: ALICE,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: '2026-08-13T00:00:00.000Z',
+        updatedAt: '2026-08-13T00:00:00.000Z',
+      }),
+    );
+  });
+
+  it('accepts the document wordSetRepo.create sends', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/wordSets/real`).set({
+        // The literal WordSets.tsx sends; there is no factory for it.
+        name: '仕事',
+        description: '',
+        entryIds: [],
+        level: '',
+        topics: [],
+        ownerUid: ALICE,
+        publishedId: null,
+        publishedVersion: 0,
+        copiedFrom: null,
+        createdAt: '2026-08-13T00:00:00.000Z',
+        updatedAt: '2026-08-13T00:00:00.000Z',
+      }),
+    );
+  });
+
+  /** `recordSession` writes both documents in one batch; both have to pass. */
+  it('accepts both documents recordSession sends', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/practiceSessions/real`).set({
+        mode: 'flashcard',
+        filterLabel: 'すべて',
+        total: 10,
+        correct: 8,
+        missed: ['e1', 'e2'],
+        startedAt: '2026-08-13T00:00:00.000Z',
+        ownerUid: ALICE,
+        finishedAt: '2026-08-13T00:01:00.000Z',
+      }),
+    );
+    await assertSucceeds(
+      db
+        .doc(`users/${ALICE}/progress/entries`)
+        .set(
+          { ownerUid: ALICE, entries: { e1: { status: 'wrong', attempts: 1 } } },
+          { merge: true },
+        ),
+    );
   });
 });

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Promoting the Content-Security-Policy must not switch App Check off.
+ *
+ * reCAPTCHA v3 loads `https://www.google.com/recaptcha/…` and frames a
+ * challenge from the same origin. A policy that omits the host does not fail
+ * loudly: attestation stops, the app keeps working, and the App Check metrics
+ * that are supposed to say whether enforcement is safe to turn on go quiet for
+ * a reason nothing surfaces.
+ *
+ * Written as a conditional rather than as a fixed expectation because the
+ * headers block and the App Check client arrive on different branches: this is
+ * green while `firebase.json` has no headers, green while the policy is
+ * Report-Only, and red only when someone drops `-Report-Only` — which is the
+ * one edit that turns a missing host into a live outage of the protection.
+ */
+
+const RECAPTCHA_HOST = 'https://www.google.com';
+
+const firebaseJson = readFileSync(new URL('../../firebase.json', import.meta.url), 'utf8');
+const client = readFileSync(new URL('../../src/infra/firebase/client.ts', import.meta.url), 'utf8');
+
+interface Header {
+  key: string;
+  value: string;
+}
+
+const config = JSON.parse(firebaseJson) as {
+  hosting?: { headers?: { headers: Header[] }[] };
+};
+
+const enforcedPolicies = (config.hosting?.headers ?? [])
+  .flatMap((rule) => rule.headers)
+  // Exact match: `Content-Security-Policy-Report-Only` is the state this test
+  // deliberately permits, and it starts with the same string.
+  .filter((header) => header.key === 'Content-Security-Policy')
+  .map((header) => header.value);
+
+const directive = (policy: string, name: string): string =>
+  policy
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part === name || part.startsWith(`${name} `)) ?? '';
+
+describe('Content-Security-Policy against App Check', () => {
+  it('never enforces a policy that would stop reCAPTCHA loading, which fails silently', () => {
+    for (const policy of enforcedPolicies) {
+      expect(directive(policy, 'script-src')).toContain(RECAPTCHA_HOST);
+      expect(directive(policy, 'frame-src')).toContain(RECAPTCHA_HOST);
+    }
+  });
+
+  // The guard above passes vacuously with no enforcing policy, which is
+  // intended. It would also pass vacuously if App Check were removed and the
+  // requirement quietly became wrong — this is what stops that reading.
+  it('still has the App Check provider the guard above exists to protect', () => {
+    expect(client).toContain('new ReCaptchaV3Provider(');
+  });
+});

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,7 +1,8 @@
 {
-  // Standalone, and a third pass in `yarn typecheck`, for the same reason
-  // tsconfig.test.json is: these files reach into src and a composite project
-  // may only do that through a reference tsconfig.app.json cannot provide.
+  // Every script outside src and tests — migration and admin — in one pass.
+  // Standalone for the same reason tsconfig.test.json is: these files reach
+  // into src, and a composite project may only do that through a reference
+  // tsconfig.app.json cannot provide.
   //
   // The folder was plain .mjs until accents.ts, so it sat outside both existing
   // passes and nobody noticed. Measured at the time: importing a symbol that
@@ -10,6 +11,8 @@
   // folder writes is what goes to production.
   "compilerOptions": {
     "target": "ES2022",
+    // Top-level await, which the admin scripts are written with.
+    "module": "ESNext",
     "lib": ["ES2022"],
     "module": "ESNext",
     "moduleResolution": "bundler",
@@ -33,5 +36,5 @@
     "baseUrl": ".",
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["migration"]
+  "include": ["migration", "admin"]
 }

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -11,9 +11,8 @@
   // folder writes is what goes to production.
   "compilerOptions": {
     "target": "ES2022",
-    // Top-level await, which the admin scripts are written with.
-    "module": "ESNext",
     "lib": ["ES2022"],
+    // Top-level await, which the admin scripts are written with.
     "module": "ESNext",
     "moduleResolution": "bundler",
     "types": ["node"],


### PR DESCRIPTION
### ⚠️ This changes the deploy procedure. Read the order before deploying rules.

Setting the claim **before** deploying the rules is a seamless change. Deploying
the rules first locks everybody out, including the operator, for up to an hour.

```
1. yarn allow you@example.com        # old rules ignore the claim entirely
2. sign out, sign in                 # the new token carries it
3. yarn rules:dev / rules:prod       # only now
```

`yarn allow` needs the account to have signed in at least once — the uid has to
be the one Google issued.

### Summary

The security half of the external production review. The product half is
`feat/production-readiness`; the two touch no file in common.

Branch protection on `main` is already applied and is not in this diff:
`verify`, `emulator` and `e2e` are now all required, with `strict`, linear
history and conversation resolution. Approvals stay at 0 deliberately — GitHub
does not let an author approve their own pull request, so requiring one would
lock a solo maintainer out of their own repository.

### What changed

**The gate is a custom claim, not a document read.** `exists(/allowedUsers/$(uid))`
is billed as a read on every request to every path — on a public service that
doubles the read cost of the application to answer a question whose answer
changes twice in an account's lifetime.

**Writes are bounded.** Sizes and list lengths on entries, word sets and
sessions; `ownerUid` must match the path; `createdAt` cannot be rewritten.

**App Check**, off until a site key is configured.

### Decisions a reviewer should not have to re-derive

**The recursive wildcard had to go, and that is the whole change.** Rules are a
union: `match /{document=**}` granting write is an unconditional allow, so every
validation added beneath it would have been evaluated *beside* it rather than
*after*. Hardening while leaving it in place would have looked like hardening
and enforced nothing. Verified by putting it back — seven of the new cases go
green that should be red. The cost is that an unlisted collection is now denied
rather than allowed, which is the right direction and is itself a test.

**Revocation became two operations.** A claim lives in the ID token, so clearing
it changes nothing until that token expires. `admin/allow-user.ts` also revokes
the refresh tokens, and doing only the first step leaves up to an hour of access
after a ban. The test says so where somebody will read it.

**Bounds are sizes, not a schema.** Requiring every field to exist turns each
schema change into a rules deploy, and a rules deploy lagging a client release
denies writes from a version already shipped. **What rules cannot check is
recorded in the file**: there is no way to iterate a list, so the length of
`senses[3].description` is invisible there.

**App Check is off unless a key is set.** A build enforcing it with no key
attaches no token and every request is refused — a missing environment variable
becoming an outage with nothing pointing at the cause. Enforcement stays off in
the console until its metrics show real traffic attesting.

**reCAPTCHA v3, not Enterprise.** Enterprise was taken from the review without
checking what it needs: it is a Cloud product whose API cannot be enabled
without a billing account, so on Spark the key could never have been created.

### A gap this found in the existing suite

`tests/integration` connects with `mockUserToken: 'owner'` — the emulator's
owner credential, which **bypasses rules entirely**. A green adapter suite has
therefore never said anything about whether the documents it produces are
writable in production. That did not matter while the only rule was ownership;
it matters the moment a well-formed write can be rejected. Three cases now build
the real payloads from the production factories and put them through the rules.

### Impact, measured

- **Existing data**: nothing is near a cap. Across the 67 migrated entries the
  worst case is 25 keys against a limit of 40; `definition` peaks at 218
  characters against 20,000. Rules gate writes and not reads, so an
  over-sized document would still be readable but no longer editable — there
  are none.
- **The adapters**: `entryRepo.create`, `wordSetRepo.create` and both documents
  `recordSession` writes in one batch are accepted.
- **`allowedUsers`**: nothing reads it any more. It is dead data, not deleted.

### Testing

516 unit, 64 rules and adapter, 62 end-to-end. Two breaks verified: restoring
the recursive wildcard, and dropping the claim check.

### Not in this PR

- **Opening signups.** The decision is taken — production allows any verified
  account, development keeps an allowlist — and the mechanism is two rules files
  with a test asserting they differ only in `isAllowed()`. It is sequenced after
  App Check has a key and its metrics look right, because opening registration
  before then is the window with neither a gate nor attestation.
- **Production deploy lockdown** and **`EntriesProvider` loading the whole
  notebook**, which is the largest remaining quota risk and is not mentioned in
  the review at all.