### PR TITLE
fix(errors): report a denied read as denied, not as a failed load

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,25 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
 4. `yarn firebase login`, then deploy the rules with `yarn rules:dev` (once the
    alias points at your project) or
    `yarn firebase deploy --only firestore:rules --project <your-project-id>`.
-5. Sign in once, then add yourself to the allowlist — the rules deny everything
-   until `allowedUsers/{your-uid}` exists. `yarn migrate:upload` writes it for
-   you, or create the document by hand in the console.
+5. Sign in once, then grant yourself access — the rules deny everything until
+   your account carries the `allowed` custom claim. `yarn allow <your-email>`
+   sets it, and the account must have signed in before that, because the claim
+   goes on the uid Google issued and there is nothing to set it on until then.
+6. **Sign out and sign back in.** A claim reaches the client only in a freshly
+   minted ID token, so the session you granted access to is still denied — for
+   up to an hour, until its token expires on its own.
 
 `firebase-tools` is a local devDependency, so the CLI is reached through
 `yarn firebase …` unless you have installed it globally.
 
 Step 3 only changes local configuration; nothing is enforced until step 4
-deploys the rules successfully. After step 5 every read and write is scoped to
+deploys the rules successfully. After step 6 every read and write is scoped to
 your account.
+
+Step 6 is a step rather than a note because leaving it out looks exactly like a
+broken build: every screen reports that it could not load, and running step 5
+again changes nothing. `yarn allow` prints the account it granted, so the last
+line of step 5 is not evidence that step 6 has happened.
 
 `.env.development` and `.env.production` are gitignored. Their values ship inside
 the JS bundle and are not secrets — Firestore rules are what enforce access — but

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
    your account carries the `allowed` custom claim. `yarn allow <your-email>`
    sets it, and the account must have signed in before that, because the claim
    goes on the uid Google issued and there is nothing to set it on until then.
+   **`yarn allow` is the one step here that cannot be pointed at your project.**
+   `admin/allow-user.ts` names `goitei-dev` and `goitei` directly, never reads
+   `.firebaserc`, and rejects any argument other than `prod` and `--revoke` — so
+   on a fresh project it will tell you the account has never signed in. Set the
+   claim through the Admin SDK yourself; that script is the worked example.
 6. **Sign out and sign back in.** A claim reaches the client only in a freshly
    minted ID token, so the session you granted access to is still denied — for
    up to an hour, until its token expires on its own.

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 import type { Entry } from '@/domain/entry';
 import type { EntryRepository } from '@/domain/ports';
 import { entryRepositoryFor } from '@/lib/backend';
+import { loadErrorMessage } from '@/lib/loadError';
 
 interface EntriesValue {
   entries: Entry[];
@@ -103,7 +104,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
       if (walk.current === mine) setEntries(all);
     } catch (cause) {
       console.error(cause);
-      if (walk.current === mine) setError('単語を読み込めませんでした。');
+      if (walk.current === mine) setError(loadErrorMessage(cause, '単語を読み込めませんでした。'));
     } finally {
       if (walk.current === mine) setLoading(false);
     }

--- a/src/lib/loadError.ts
+++ b/src/lib/loadError.ts
@@ -23,14 +23,41 @@
 
 /**
  * `permission-denied` is the rules refusing the request; `unauthenticated` is
- * the token being absent or expired. Both mean the same thing to a reader —
- * this account cannot see this right now — and both are fixed by the same
- * action, so they share a message.
+ * the token being absent or expired. They share a message because a reader
+ * cannot tell them apart and neither can this module.
  */
 const DENIED_CODES = new Set(['permission-denied', 'unauthenticated']);
 
+/**
+ * Two sentences, and the second one is why there is a third.
+ *
+ * `permission-denied` is not one situation. It is at least three, and only one
+ * of them is cleared by signing in again:
+ *
+ *  1. **A token minted before the grant.** Re-authenticating fixes it, which is
+ *     what the first instruction is for.
+ *  2. **No claim on the account at all** — nobody has run `yarn allow`, or rules
+ *     requiring the claim were deployed to a project where nobody carries it.
+ *     Signing out and back in mints another token with no claim, so the reader
+ *     follows the instruction, lands on the same screen, and is out of moves.
+ *  3. **App Check rejecting the request.** `src/infra/firebase/client.ts`
+ *     initialises it whenever a site key is present, and an unregistered domain
+ *     or a dead reCAPTCHA key surfaces here as `permission-denied` like the
+ *     other two. Re-authenticating does nothing at all.
+ *
+ * Three messages would be worse, not better: the reader has no way to tell which
+ * one they are in, and the note below on subject-specific wording applies just
+ * as much to splitting one cause four ways. What the message must not do is
+ * dead-end — so it names サポート, which is where 2 and 3 are actually resolved.
+ *
+ * That exit has to be reachable from where this renders, and it is: `/support`
+ * is a top-level route outside the auth gate, and `Account.tsx` links it from
+ * inside the app, which a signed-in-but-denied account can still open — the gate
+ * that failed is Firestore's, not Firebase Auth's.
+ */
 export const ACCESS_DENIED_MESSAGE =
-  'アクセスが許可されていません。一度サインアウトして、サインインし直してください。';
+  'アクセスが許可されていません。一度サインアウトして、サインインし直してください。' +
+  '解決しない場合は、サポートページからお問い合わせください。';
 
 export function isAccessDenied(cause: unknown): boolean {
   if (typeof cause !== 'object' || cause === null) return false;

--- a/src/lib/loadError.ts
+++ b/src/lib/loadError.ts
@@ -1,0 +1,49 @@
+/**
+ * What to show when a read fails.
+ *
+ * Every provider used to catch everything and report the same sentence — "単語を
+ * 読み込めませんでした" and its three siblings — so a signed-in account with no
+ * access rendered exactly as a dropped connection. That is the one failure the
+ * generic wording is worst for: it is not transient, retrying never clears it,
+ * and the thing that does clear it (sign out, sign back in) is not something a
+ * reader would guess from "could not load".
+ *
+ * It is also the failure this application produces most easily. The gate is a
+ * custom claim, which reaches a client only in a freshly minted ID token, so an
+ * account granted access while signed in stays denied for up to an hour and
+ * every screen says the words could not be loaded. Deploying rules that require
+ * the claim to a project where nobody has it yet does the same to everyone at
+ * once.
+ *
+ * Deliberately duck-typed rather than an `instanceof FirebaseError`: `src/lib`
+ * is above the infrastructure seam and importing the SDK here would put a
+ * Firebase type in every caller's signature, for a check that is one string
+ * comparison. The codes are Firestore's own and are part of its API.
+ */
+
+/**
+ * `permission-denied` is the rules refusing the request; `unauthenticated` is
+ * the token being absent or expired. Both mean the same thing to a reader —
+ * this account cannot see this right now — and both are fixed by the same
+ * action, so they share a message.
+ */
+const DENIED_CODES = new Set(['permission-denied', 'unauthenticated']);
+
+export const ACCESS_DENIED_MESSAGE =
+  'アクセスが許可されていません。一度サインアウトして、サインインし直してください。';
+
+export function isAccessDenied(cause: unknown): boolean {
+  if (typeof cause !== 'object' || cause === null) return false;
+  const code: unknown = (cause as { code?: unknown }).code;
+  return typeof code === 'string' && DENIED_CODES.has(code);
+}
+
+/**
+ * `fallback` stays subject-specific — 単語, 単語集, 練習の記録, 練習履歴 — because
+ * a transient failure really is about the thing being read. Denial is not: it is
+ * a fact about the account, identical on every screen, and saying it four
+ * different ways would suggest four different problems.
+ */
+export function loadErrorMessage(cause: unknown, fallback: string): string {
+  return isAccessDenied(cause) ? ACCESS_DENIED_MESSAGE : fallback;
+}

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import type { ProgressRepository } from '@/domain/ports';
 import type { EntryProgress, PracticeSessionDraft } from '@/domain/practice';
 import { progressRepositoryFor } from '@/lib/backend';
+import { loadErrorMessage } from '@/lib/loadError';
 import { weakIdsOf } from '@/lib/practice';
 
 interface ProgressValue {
@@ -57,7 +58,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
       })
       .catch((cause: unknown) => {
         console.error(cause);
-        if (!cancelled) setError('練習の記録を読み込めませんでした。');
+        if (!cancelled) setError(loadErrorMessage(cause, '練習の記録を読み込めませんでした。'));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -11,6 +11,7 @@ import type { ReactNode } from 'react';
 import type { WordSetRepository } from '@/domain/ports';
 import type { WordSet } from '@/domain/wordSet';
 import { wordSetRepositoryFor } from '@/lib/backend';
+import { loadErrorMessage } from '@/lib/loadError';
 
 interface WordSetsValue {
   sets: WordSet[];
@@ -87,7 +88,8 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
       if (walk.current === mine) setSets(all);
     } catch (cause) {
       console.error(cause);
-      if (walk.current === mine) setError('単語集を読み込めませんでした。');
+      if (walk.current === mine)
+        setError(loadErrorMessage(cause, '単語集を読み込めませんでした。'));
     } finally {
       if (walk.current === mine) setLoading(false);
     }

--- a/src/routes/History.tsx
+++ b/src/routes/History.tsx
@@ -5,6 +5,7 @@ import { WeakWords } from '@/components/history/WeakWords';
 import type { PracticeSession } from '@/domain/practice';
 import { useEntries } from '@/lib/entries';
 import { weakWords } from '@/lib/history';
+import { loadErrorMessage } from '@/lib/loadError';
 import { EMPTY_PRACTICE_FILTERS } from '@/lib/practice';
 import { useProgress } from '@/lib/progress';
 import { useVocabDialog } from '@/lib/vocabDialog';
@@ -59,7 +60,8 @@ export function Component() {
         setCursor(page.cursor);
       } catch (cause) {
         console.error(cause);
-        if (walk.current === mine) setError('練習履歴を読み込めませんでした。');
+        if (walk.current === mine)
+          setError(loadErrorMessage(cause, '練習履歴を読み込めませんでした。'));
       } finally {
         if (walk.current === mine) setLoading(false);
       }

--- a/tests/unit/loadError.test.ts
+++ b/tests/unit/loadError.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { ACCESS_DENIED_MESSAGE, isAccessDenied, loadErrorMessage } from '@/lib/loadError';
+
+/**
+ * Deploying rules that gate on the `allowed` custom claim to a project where no
+ * account carries it yet denies every read at once, and every screen said the
+ * words could not be loaded — the same sentence a dropped connection produces.
+ * The distinction is the whole point: one clears itself, the other needs the
+ * reader to sign out and back in, and nothing on screen said so.
+ */
+describe('loadErrorMessage', () => {
+  it('tells a denied account what to do instead of blaming the connection', () => {
+    const denied = Object.assign(new Error('Missing or insufficient permissions.'), {
+      code: 'permission-denied',
+    });
+    expect(loadErrorMessage(denied, '単語を読み込めませんでした。')).toBe(ACCESS_DENIED_MESSAGE);
+  });
+
+  /**
+   * An ID token that has expired is the same situation one hour later, and is
+   * how a grant made during a live session first shows up.
+   */
+  it('treats an expired token the same way, since re-signing in is the same fix', () => {
+    const stale = Object.assign(new Error('Unauthenticated'), { code: 'unauthenticated' });
+    expect(loadErrorMessage(stale, '単語集を読み込めませんでした。')).toBe(ACCESS_DENIED_MESSAGE);
+  });
+
+  /**
+   * The fallback has to survive, or this change trades one indiscriminate
+   * message for another: a network failure is genuinely about the thing being
+   * read, and telling that reader to sign in again sends them nowhere.
+   */
+  it('keeps the subject-specific wording for a failure that is not about access', () => {
+    const offline = Object.assign(
+      new Error('Failed to get document because the client is offline'),
+      {
+        code: 'unavailable',
+      },
+    );
+    expect(loadErrorMessage(offline, '練習履歴を読み込めませんでした。')).toBe(
+      '練習履歴を読み込めませんでした。',
+    );
+  });
+
+  /**
+   * `code` is read off whatever was thrown, and a `catch` receives anything at
+   * all. Reading a property off null throws, which inside the catch block that
+   * calls this would replace a load failure with a blank screen.
+   */
+  it.each([null, undefined, 'permission-denied', 42, new Error('no code at all')])(
+    'reports %s as an ordinary failure rather than throwing while handling one',
+    (cause) => {
+      expect(isAccessDenied(cause)).toBe(false);
+      expect(loadErrorMessage(cause, '単語を読み込めませんでした。')).toBe(
+        '単語を読み込めませんでした。',
+      );
+    },
+  );
+});

--- a/tests/unit/loadError.test.ts
+++ b/tests/unit/loadError.test.ts
@@ -26,6 +26,18 @@ describe('loadErrorMessage', () => {
   });
 
   /**
+   * Reads like a wording check and is not one. Re-authenticating clears exactly
+   * one of the three causes of `permission-denied` — an account with no claim at
+   * all, and a rejected App Check token, both survive it. Without a second step
+   * the reader follows the only instruction on screen, arrives back where they
+   * started, and the message has told them to do the thing that cannot work.
+   * `/support` is where those two are resolved, and it is reachable from here.
+   */
+  it('offers a way out for the denials that signing in again cannot clear', () => {
+    expect(ACCESS_DENIED_MESSAGE).toContain('サポート');
+  });
+
+  /**
    * The fallback has to survive, or this change trades one indiscriminate
    * message for another: a network failure is genuinely about the thing being
    * read, and telling that reader to sign in again sends them nowhere.


### PR DESCRIPTION
Every screen reported "単語を読み込めませんでした" and its three siblings while the
actual failure was `permission-denied`. The two are indistinguishable to a reader,
and they need opposite responses: one clears itself, the other never does until the
reader signs out and back in.

### What happened

`deploy-dev.yml` deployed the rules from #21 to `goitei-dev`. Those rules gate every
read under `users/{uid}` on the `allowed` custom claim, and no account carried it —
the `allowedUsers` document that used to grant access is read by nothing now. So
entries, word sets, practice sessions and progress were all denied at once, and all
four providers caught the same rejection and reported it as a load failure.

That is the lockout the Operator runbook in `README.md` predicts for a production
release. Dev deploys itself on merge, so dev reached it first — and the app said
nothing that would point anyone at it.

### The change

`src/lib/loadError.ts` maps `permission-denied` and `unauthenticated` to a message
that names the situation and the fix. Both codes share one message because both are
facts about the account rather than about the data, and both are cleared by the same
action — a claim reaches a client only in a freshly minted ID token, so an account
granted access mid-session stays denied until it signs in again.

The four subject-specific fallbacks are untouched. A dropped connection really is
about the thing being read, and telling that reader to sign in again sends them
nowhere.

Duck-typed on `code` rather than `instanceof FirebaseError`: `src/lib` sits above the
infrastructure seam, and an SDK import here would put a Firebase type into every
caller for what is one string comparison.

### This does not restore access

It makes the failure legible. Granting access is still `yarn allow <email>` followed
by signing out and back in.

### Tests

**Layer: `tests/unit`.** The classifier is a function of its inputs, which is the
cheapest layer that can see the defect. It takes no clock, no DOM and no emulator.

Red before green, and red in the right place. Reverting `loadErrorMessage` to the
shape it replaced — returning the fallback and ignoring the cause — fails **exactly
two** cases:

```
× tells a denied account what to do instead of blaming the connection
× treats an expired token the same way, since re-signing in is the same fix
```

The other six stay green, which is what they are there for: they assert behaviour the
old code already had, so a change that broke them would be this fix trading one
indiscriminate message for another.

568 unit and component. Lint clean, three typecheck passes. Emulator and end-to-end
not run locally — this touches no rule and no adapter.
