### PR TITLE
ci: refuse a production deploy that names anything but a commit

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -42,12 +42,25 @@ jobs:
       # A 40-character hex string cannot move. Everything downstream depends on
       # that and nothing downstream re-establishes it, which is why this is the
       # first step in the file.
+      #
+      # `[[ =~ ]]` and not `grep -Eq`. **grep is line-oriented**: `-q` exits 0
+      # when any *line* matches, so a value carrying a well-formed SHA on one
+      # line and a branch name on another satisfied it. Inputs arrive as JSON
+      # strings, so a newline is a shape that reaches here. That is the same
+      # failure this file already documents two steps down — `grep -q ""` — a
+      # line-oriented tool answering a question about a whole value.
+      #
+      # The value is deliberately not echoed back. By construction this branch
+      # runs only when the input failed to validate, so it is exactly the case
+      # where it may contain a newline, and a newline inside a `::error`
+      # workflow command ends the command and lets what follows be read as
+      # another one.
       - name: Refuse anything that is not a full commit SHA
         env:
           SHA: ${{ inputs.sha }}
         run: |
-          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{40}$'; then
-            echo "::error title=Not a commit SHA::'$SHA' is not 40 lowercase hex characters. Branch names and short SHAs are refused because they resolve separately in each job."
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Not a commit SHA::The sha input is not 40 lowercase hex characters. Branch names, short SHAs and anything spanning more than one line are refused, because each job resolves this input separately and only an immutable value survives that."
             exit 1
           fi
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -30,11 +30,42 @@ jobs:
       contents: read
 
     steps:
+      # Before the checkout, because the checkout is what this protects.
+      #
+      # `ref:` accepts a branch name, and `merge-base --is-ancestor main main`
+      # is true — so `main` passed every check below and then got resolved
+      # separately by each job. Two jobs, two resolutions, and a merge landing
+      # between them ships `dist` from one commit with rules from another. That
+      # is precisely the state the rules-before-hosting order exists to avoid,
+      # reached by the input rather than by the sequence.
+      #
+      # A 40-character hex string cannot move. Everything downstream depends on
+      # that and nothing downstream re-establishes it, which is why this is the
+      # first step in the file.
+      - name: Refuse anything that is not a full commit SHA
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "::error title=Not a commit SHA::'$SHA' is not 40 lowercase hex characters. Branch names and short SHAs are refused because they resolve separately in each job."
+            exit 1
+          fi
+
       - uses: actions/checkout@v5
         with:
           # The whole history, because the ancestry check below needs main.
           fetch-depth: 0
           ref: ${{ inputs.sha }}
+
+      - name: Confirm the checkout is the commit that was named
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$SHA" ]; then
+            echo "::error title=Wrong commit::Checked out $actual, expected $SHA."
+            exit 1
+          fi
 
       # The check that makes the input safe. Without it this workflow deploys
       # any commit in the repository — including one that only ever existed on
@@ -172,6 +203,20 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.sha }}
+
+      # Repeated here rather than inherited from `build`. This job resolves the
+      # ref a second time, so `build` having checked out the right commit says
+      # nothing about what this one is holding — and this is the job that
+      # deploys the rules.
+      - name: Confirm the checkout is the commit that was named
+        env:
+          SHA: ${{ inputs.sha }}
+        run: |
+          actual=$(git rev-parse HEAD)
+          if [ "$actual" != "$SHA" ]; then
+            echo "::error title=Wrong commit::Checked out $actual, expected $SHA."
+            exit 1
+          fi
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
`workflow_dispatch` takes a `sha` input described as "Full commit SHA on main to deploy (40 characters)", and nothing checked that it was one.

`main` satisfied every gate: `git merge-base --is-ancestor main origin/main` is true, so the ancestry check passed it through. Both jobs then resolved that ref independently — `build` for the bundle, `deploy` for the rules. A merge landing between them ships `dist` from one commit against rules from another, which is the exact state the rules-before-hosting order exists to prevent, reached through the input instead of through the sequence.

### The change

Two guards, both cheap.

**A format check, placed before the checkout**, because the checkout is what it protects. A 40-character lowercase hex string cannot move; everything downstream depends on that and nothing downstream re-establishes it.

**A `git rev-parse HEAD` assertion after each checkout.** Repeated in `deploy` rather than inherited from `build`: that job resolves the ref a second time, so `build` having checked out the right commit says nothing about what `deploy` is holding — and `deploy` is the job that ships the rules.

### Verification

No test — `CLAUDE.md` lists the deploy pipeline under "Deliberately not tested" and asks before adding coverage there. The question is raised with the author rather than answered here.

The shell was exercised directly instead, against every input shape that reaches it:

```
REFUSED:  'main'                                       ← the reported defect
REFUSED:  ''                                           ← no fail-open
REFUSED:  '6a19a75'                                    ← short SHA
REFUSED:  '6A19A7555BC2B7963025C9AD481468A4B5325C21'   ← uppercase
REFUSED:  '  6a19a755…  '                              ← padded
REFUSED:  '6a19a755…x'                                 ← 41 characters
REFUSED:  $'refs/heads/main\n6a19a755…'                ← a SHA on its own line
REFUSED:  $'6a19a755…\nrefs/heads/main'                ← and the other way round
accepted: '6a19a7555bc2b7963025c9ad481468a4b5325c21'
accepted: '0123456789012345678901234567890123456789'
```

**The last two refusals are a correction, and the first version of this table is why they are listed.** It stopped at the 41-character case, which reads as proof that trailing junk is refused — and under `grep -Eq` it was not, once the junk was on its own line. `grep` is line-oriented: `-q` exits 0 when *any* line matches. Review measured it, and both multi-line cases were accepted.

The guard is `[[ "$SHA" =~ ^[0-9a-f]{40}$ ]]`, which is not line-oriented. `run:` defaults to `bash` on `ubuntu-latest`, so no `shell:` key is needed.

This is the same failure the file already carries a comment about two steps down — `grep -q ""` matching every line and exiting 0 — a line-oriented tool answering a question about a whole value. The empty case was checked *because of* that comment, and the multi-line case was not.

The `::error` message no longer echoes the input. That branch runs only when the value failed to validate, so it is exactly the case where it may contain a newline, and a newline inside a workflow command ends the command.

The empty case is checked deliberately, and the pattern is a literal rather than an interpolated variable.

The last accepted line is accepted on purpose: a format check is not an existence check. A well-formed SHA that names no object fails at `actions/checkout`, and the ancestry check stands behind that.

The workflow parses, and step order was confirmed rather than assumed:

```
build : Refuse anything that is not a full commit SHA | checkout | Confirm the checkout … | Refuse a commit that is not on main | …
deploy: checkout | Confirm the checkout … | …
```

`deploy` carries no format check because it `needs: build`, which does.
