### PR TITLE
fix(rules): allowlist the fields, not just count them

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -127,6 +127,55 @@ service cloud.firestore {
     //
     // `headword` is the exception and is read directly: an entry without one is
     // not an entry, and the form refuses it too.
+
+    // ---- which fields, not just how many ----
+    //
+    // `keys().size()` bounds the number of fields and says nothing about their
+    // names, so `{ headword: 'x', junk: <a megabyte> }` passed everything
+    // below: the count is two, every string named is within its limit, and
+    // `junk` is invisible to all of them. The size caps were the only thing
+    // standing between an allowed account and a document as large as Firestore
+    // permits, and they never looked at the field that was large.
+    //
+    // `hasOnly` is the allowlist Firestore documents for this. It does **not**
+    // make anything required — it constrains the key set to a subset, so an
+    // absent optional field stays absent. Requiredness is still where it was,
+    // in the `d.get(field, default)` calls further down, and the tests that
+    // assert an entry missing every optional field is accepted still pass.
+    //
+    // **`migrationKey` is on the entry list and is not in the domain `Entry`.**
+    // `migration/upload.mjs` writes it onto every migrated document as
+    // provenance, and an update sends the merged document — so omitting it here
+    // would refuse every edit to all 67 migrated words, in production only,
+    // where the migration has been run. Read the list off what is stored, not
+    // off the TypeScript type.
+    function entryFields() {
+      return [
+        'ownerUid', 'headword', 'reading', 'pitchAccent', 'pos', 'jlpt',
+        'origin', 'style', 'politeness', 'freq', 'citationForm', 'posInfo',
+        'definition', 'definitionSub', 'senses', 'examples', 'related',
+        'source', 'context', 'usage', 'tags', 'learnedOn',
+        'publishedId', 'publishedVersion', 'copiedFrom',
+        'createdAt', 'updatedAt',
+        'migrationKey'
+      ];
+    }
+
+    function wordSetFields() {
+      return [
+        'ownerUid', 'name', 'description', 'entryIds', 'level', 'topics',
+        'publishedId', 'publishedVersion', 'copiedFrom',
+        'createdAt', 'updatedAt'
+      ];
+    }
+
+    function sessionFields() {
+      return [
+        'ownerUid', 'mode', 'filterLabel', 'total', 'correct', 'missed',
+        'startedAt', 'finishedAt'
+      ];
+    }
+
     function str(value, max) {
       return value is string && value.size() <= max;
     }
@@ -156,7 +205,7 @@ service cloud.firestore {
     function validEntry(uid) {
       let d = request.resource.data;
       return ownedBy(uid)
-        && d.keys().size() <= 40
+        && d.keys().hasOnly(entryFields())
         && str(d.headword, 200) && d.headword.size() > 0
         && str(d.get('reading', ''), 200)
         && str(d.get('definition', ''), 20000)
@@ -174,7 +223,7 @@ service cloud.firestore {
     function validWordSet(uid) {
       let d = request.resource.data;
       return ownedBy(uid)
-        && d.keys().size() <= 20
+        && d.keys().hasOnly(wordSetFields())
         && str(d.name, 200) && d.name.size() > 0
         && str(d.get('description', ''), 5000)
         // The one unbounded list in the schema, and the one a set is made of.
@@ -185,7 +234,7 @@ service cloud.firestore {
     function validSession(uid) {
       let d = request.resource.data;
       return ownedBy(uid)
-        && d.keys().size() <= 20
+        && d.keys().hasOnly(sessionFields())
         && str(d.get('filterLabel', ''), 500)
         && d.get('total', 0) is int && d.get('total', 0) >= 0 && d.get('total', 0) <= 2000
         && d.get('correct', 0) is int && d.get('correct', 0) >= 0
@@ -209,14 +258,23 @@ service cloud.firestore {
         return isOwner(uid) && isAllowed();
       }
 
-      allow read, delete: if mine();
-      // Split exactly as the subcollections are, and for the reason
+      // Read and delete only. **Nothing in the application writes this
+      // document** — there is no profile, and no adapter addresses this path —
+      // so the create and update it used to carry described a feature that does
+      // not exist, while permitting any twenty fields of any names. That is the
+      // one place `hasOnly` cannot help, because there is no legitimate field to
+      // allow: the honest allowlist for a document nobody writes is empty.
+      //
+      // Delete stays, and stays split from the rest for the reason
       // `keepsCreatedAt` documents: `write` covers delete, and on a delete
       // `request.resource` is null, so reaching into it is an evaluation error.
       // This document was the one place that kept the combined form, and
       // deleting it therefore failed with a message about null rather than
       // about permission — the failure mode account deletion would have hit.
-      allow create, update: if mine() && request.resource.data.keys().size() <= 20;
+      //
+      // Adding a profile later means adding `create, update` back **with a
+      // `hasOnly` naming its fields**, not restoring what was here.
+      allow read, delete: if mine();
 
       match /entries/{entryId} {
         allow read, delete: if mine();
@@ -247,7 +305,7 @@ service cloud.firestore {
       match /progress/entries {
         allow read, delete: if mine();
         allow create, update: if mine() && ownedBy(uid)
-                              && request.resource.data.keys().size() <= 5;
+                              && request.resource.data.keys().hasOnly(['ownerUid', 'entries']);
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -133,9 +133,21 @@ service cloud.firestore {
     // `keys().size()` bounds the number of fields and says nothing about their
     // names, so `{ headword: 'x', junk: <a megabyte> }` passed everything
     // below: the count is two, every string named is within its limit, and
-    // `junk` is invisible to all of them. The size caps were the only thing
-    // standing between an allowed account and a document as large as Firestore
-    // permits, and they never looked at the field that was large.
+    // `junk` is invisible to all of them.
+    //
+    // **Being on this list is permission to send a field, not a limit on it.**
+    // `hasOnly` closes the unknown-name half and the other half is closed by
+    // the checks in `validEntry` — which is why the short scalars, the two
+    // timestamps and the maps are all bounded there now rather than merely
+    // named here. An allowlisted-but-unchecked field is the same megabyte under
+    // a different key.
+    //
+    // **What still is not bounded, said plainly rather than left to be found.**
+    // `size()` on a map counts keys and `size()` on a list counts elements, so
+    // neither reaches the bytes inside one: a single `context` value, or one
+    // `senses[3].description`, can be as large as a document may be. Firestore
+    // rules cannot see either. Anything depending on per-element limits has to
+    // enforce them where they are visible.
     //
     // `hasOnly` is the allowlist Firestore documents for this. It does **not**
     // make anything required — it constrains the key set to a subset, so an
@@ -217,7 +229,33 @@ service cloud.firestore {
         && list(d.get('senses', []), 100)
         && list(d.get('examples', []), 100)
         && list(d.get('related', []), 100)
-        && (d.get('pitchAccent', null) == null || d.get('pitchAccent', 0) is int);
+        && (d.get('pitchAccent', null) == null || d.get('pitchAccent', 0) is int)
+        // Short, closed-vocabulary scalars. Each is one line and each was
+        // previously unbounded, which `hasOnly` alone does not change: being on
+        // the allowlist is permission to send the field, not a limit on it.
+        && str(d.get('jlpt', ''), 10)
+        && str(d.get('origin', ''), 10)
+        && str(d.get('style', ''), 10)
+        && str(d.get('politeness', ''), 10)
+        && str(d.get('learnedOn', ''), 10)
+        && str(d.get('migrationKey', ''), 200)
+        && (d.get('publishedId', null) == null || str(d.get('publishedId', ''), 200))
+        && d.get('freq', 1) is int && d.get('freq', 1) >= 1 && d.get('freq', 1) <= 5
+        && d.get('publishedVersion', 0) is int && d.get('publishedVersion', 0) >= 0
+        // Timestamps, not strings. Both are written by the adapter from the
+        // server clock, so anything else on this key is a client sending a
+        // value of its own choosing — and before this line that value could be
+        // a string of any length. `keepsCreatedAt` pins createdAt to what is
+        // stored, which says nothing about the create that stored it.
+        && d.get('createdAt', request.time) is timestamp
+        && d.get('updatedAt', request.time) is timestamp
+        // Maps. `size()` counts keys, so this stops a key explosion and **not**
+        // a large value inside one — the same blind spot the note above records
+        // for list elements. Said plainly rather than left to be discovered.
+        && d.get('context', {}).size() <= 20
+        && d.get('usage', {}).size() <= 20
+        && (d.get('posInfo', null) == null || d.get('posInfo', {}).size() <= 20)
+        && (d.get('copiedFrom', null) == null || d.get('copiedFrom', {}).size() <= 10);
     }
 
     function validWordSet(uid) {
@@ -304,8 +342,13 @@ service cloud.firestore {
       // every sibling checks the field as well.
       match /progress/entries {
         allow read, delete: if mine();
+        // `entries` is the whole content of this document and `hasOnly` does not
+        // touch it, so before this bound the only ceiling on one account's
+        // progress map was Firestore's 1 MiB. 5,000 words is far past any
+        // notebook this design expects and far short of that ceiling.
         allow create, update: if mine() && ownedBy(uid)
-                              && request.resource.data.keys().hasOnly(['ownerUid', 'entries']);
+                              && request.resource.data.keys().hasOnly(['ownerUid', 'entries'])
+                              && request.resource.data.get('entries', {}).size() <= 5000;
       }
     }
 

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -6,7 +6,9 @@ import {
   type RulesTestEnvironment,
 } from '@firebase/rules-unit-testing';
 import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+import type { PracticeSessionDraft } from '@/domain/practice';
 import { emptyDraft } from '@/lib/draft';
+import { makeWordSet } from '../fixtures/wordSet';
 
 /**
  * Security rules are the only thing protecting this data: the app is pure
@@ -379,9 +381,13 @@ describe('bounds on what an owner may write', () => {
   it('refuses to rewrite createdAt on an existing row', async () => {
     const db = as(ALICE);
     await assertSucceeds(
-      db.doc(`users/${ALICE}/entries/dated`).set(entry(ALICE, { createdAt: '2026-01-01' })),
+      db
+        .doc(`users/${ALICE}/entries/dated`)
+        .set(entry(ALICE, { createdAt: new Date('2026-01-01') })),
     );
-    await assertFails(db.doc(`users/${ALICE}/entries/dated`).update({ createdAt: '2020-01-01' }));
+    await assertFails(
+      db.doc(`users/${ALICE}/entries/dated`).update({ createdAt: new Date('2020-01-01') }),
+    );
     await assertSucceeds(db.doc(`users/${ALICE}/entries/dated`).update({ headword: '別の語' }));
   });
 
@@ -415,6 +421,44 @@ describe('bounds on what an owner may write', () => {
     await assertFails(
       db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries: {}, junk: 'x' }),
     );
+  });
+
+  /**
+   * Being on the allowlist is permission to send a field, not a limit on it.
+   *
+   * `hasOnly` closed the unknown-name half of the hole and left the other half
+   * exactly where it was: fifteen of the twenty-eight permitted names had no
+   * type or size check, so `{ ownerUid, headword: 'x', migrationKey: <a
+   * megabyte> }` passed for the same reason `junk` used to — nothing looked at
+   * the field that was large.
+   *
+   * `createdAt` is the sharpest of them. `keepsCreatedAt` pins it to the stored
+   * value on update and says nothing about the create that stored it, so before
+   * the `is timestamp` check a new entry could carry a string of any length on
+   * the one key the rules treat as bookkeeping.
+   */
+  it('refuses an oversized value in a field the allowlist permits', async () => {
+    const db = as(ALICE);
+    const path = `users/${ALICE}/entries/x`;
+    await assertFails(db.doc(path).set(entry(ALICE, { migrationKey: long(201) })));
+    await assertFails(db.doc(path).set(entry(ALICE, { learnedOn: long(11) })));
+    await assertFails(db.doc(path).set(entry(ALICE, { jlpt: long(11) })));
+    await assertFails(db.doc(path).set(entry(ALICE, { freq: 99 })));
+    // A string where the adapter writes a server timestamp.
+    await assertFails(db.doc(path).set(entry(ALICE, { createdAt: long(5000) })));
+  });
+
+  /**
+   * One document per account, and `entries` is all of it. `hasOnly` stops a
+   * stray key name and does not look inside the one key that matters, so the
+   * only ceiling here was Firestore's 1 MiB.
+   */
+  it('refuses a progress map holding more words than a notebook has', async () => {
+    const db = as(ALICE);
+    const entries = Object.fromEntries(
+      Array.from({ length: 5001 }, (_, i) => [`e${i}`, { status: 'wrong' }]),
+    );
+    await assertFails(db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries }));
   });
 
   /**
@@ -473,28 +517,31 @@ describe('what the adapters write is what the rules accept', () => {
         publishedId: null,
         publishedVersion: 0,
         copiedFrom: null,
-        createdAt: '2026-08-13T00:00:00.000Z',
-        updatedAt: '2026-08-13T00:00:00.000Z',
+        // Dates, not ISO strings: `serverTimestamp()` lands as a Timestamp, and
+        // this test exists to send what the adapter sends. It said so and did
+        // not — the two stamps were the one part of the payload written by hand
+        // in a shape the adapter never produces.
+        createdAt: new Date('2026-08-13T00:00:00.000Z'),
+        updatedAt: new Date('2026-08-13T00:00:00.000Z'),
       }),
     );
   });
 
   it('accepts the document wordSetRepo.create sends', async () => {
     const db = as(ALICE);
+    // The stored document is `WordSet` minus its id — the adapter fills
+    // ownership, publication state and both stamps itself.
+    const { id: _id, createdAt, updatedAt, ...storedSet } = makeWordSet({ ownerUid: ALICE });
     await assertSucceeds(
+      // Through the factory rather than a literal, which is what makes this a
+      // drift guard: `makeWordSet` is typed `WordSet`, so a field added to the
+      // domain arrives here on its own and turns this red until it is
+      // allowlisted. A hand-written literal cannot do that, and the mistake it
+      // would miss is refused in production and nowhere else.
       db.doc(`users/${ALICE}/wordSets/real`).set({
-        // The literal WordSets.tsx sends; there is no factory for it.
-        name: '仕事',
-        description: '',
-        entryIds: [],
-        level: '',
-        topics: [],
-        ownerUid: ALICE,
-        publishedId: null,
-        publishedVersion: 0,
-        copiedFrom: null,
-        createdAt: '2026-08-13T00:00:00.000Z',
-        updatedAt: '2026-08-13T00:00:00.000Z',
+        ...storedSet,
+        createdAt: new Date(createdAt),
+        updatedAt: new Date(updatedAt),
       }),
     );
   });
@@ -593,16 +640,23 @@ describe('what the adapters write is what the rules accept', () => {
   /** `recordSession` writes both documents in one batch; both have to pass. */
   it('accepts both documents recordSession sends', async () => {
     const db = as(ALICE);
+    // Annotated rather than inferred, for the same reason the word set goes
+    // through its factory: a field added to `PracticeSessionDraft` makes this
+    // literal a type error, so the drift is caught at `yarn typecheck` instead
+    // of in production.
+    const draft: PracticeSessionDraft = {
+      mode: 'flashcard',
+      filterLabel: 'すべて',
+      total: 10,
+      correct: 8,
+      missed: ['e1', 'e2'],
+      startedAt: '2026-08-13T00:00:00.000Z',
+    };
     await assertSucceeds(
       db.doc(`users/${ALICE}/practiceSessions/real`).set({
-        mode: 'flashcard',
-        filterLabel: 'すべて',
-        total: 10,
-        correct: 8,
-        missed: ['e1', 'e2'],
-        startedAt: '2026-08-13T00:00:00.000Z',
+        ...draft,
         ownerUid: ALICE,
-        finishedAt: '2026-08-13T00:01:00.000Z',
+        finishedAt: new Date('2026-08-13T00:01:00.000Z'),
       }),
     );
     await assertSucceeds(

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -394,6 +394,58 @@ describe('bounds on what an owner may write', () => {
     const db = as(ALICE);
     await assertFails(db.doc(`users/${ALICE}/somethingNew/x`).set({ ownerUid: ALICE }));
   });
+
+  /**
+   * The hole every size cap above left open.
+   *
+   * `keys().size()` counts fields and never looks at their names, so a document
+   * naming one field the rules check and one they have never heard of passed
+   * everything: the count was small, the strings named were short, and the
+   * large one was invisible. A megabyte under a key nobody validates is the
+   * same bill as a megabyte under `definition`, and only one of them was
+   * bounded.
+   */
+  it('refuses a field the schema has no name for, however small', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`users/${ALICE}/entries/x`).set(entry(ALICE, { junk: 'x' })));
+    await assertFails(db.doc(`users/${ALICE}/wordSets/x`).set(wordSet(ALICE, { junk: 'x' })));
+    await assertFails(
+      db.doc(`users/${ALICE}/practiceSessions/x`).set(session(ALICE, { junk: 'x' })),
+    );
+    await assertFails(
+      db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries: {}, junk: 'x' }),
+    );
+  });
+
+  /**
+   * **`migrationKey` is not in the domain `Entry` and is on every migrated
+   * document.** `migration/upload.mjs` writes it as provenance, and an update
+   * sends the merged document — so an allowlist built from the TypeScript type
+   * would refuse every edit to all 67 migrated words. It would pass here, pass
+   * in review, and fail only in production, where the migration has been run.
+   *
+   * This is the test that says the list came from what is stored.
+   */
+  it('accepts migrationKey, which the migration writes and the domain type does not name', async () => {
+    const db = as(ALICE);
+    await assertSucceeds(
+      db.doc(`users/${ALICE}/entries/migrated`).set(entry(ALICE, { migrationKey: 'ある-1' })),
+    );
+    // The update path is the one that actually breaks: it re-sends the stored
+    // key alongside the edit, whether or not the edit mentions it.
+    await assertSucceeds(db.doc(`users/${ALICE}/entries/migrated`).update({ headword: '別の語' }));
+  });
+
+  /**
+   * Nothing in the application writes `users/{uid}` itself — there is no
+   * profile and no adapter addresses the path — so the create it used to permit
+   * described a feature that does not exist while accepting any twenty fields
+   * of any names. Deleting stays, because account deletion needs it.
+   */
+  it('refuses to create the user document, which nothing writes', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`users/${ALICE}`).set({ displayName: 'x' }));
+  });
 });
 
 /**


### PR DESCRIPTION
`keys().size()` counts fields and never looks at their names. So this passed every check in the file:

```json
{ "ownerUid": "…", "headword": "x", "junk": "<a megabyte>" }
```

Two keys, both strings the rules name are within their limits, and `junk` invisible to all of them. The size caps were the only thing between an allowed account and a document as large as Firestore permits, and they never looked at the field that was large. A megabyte under a key nobody validates costs the same as a megabyte under `definition`; only one of them was bounded.

### The change

`hasOnly` on each validator, which is the allowlist Firestore documents for this.

It does **not** make anything required — it constrains the key set to a subset, so an absent optional field stays absent. Requiredness is still in the `d.get(field, default)` calls, and `accepts an entry missing every optional field` was green throughout.

| | before | after |
| --- | --- | --- |
| `validEntry` | `keys().size() <= 40` | `hasOnly(entryFields())` — 28 names |
| `validWordSet` | `keys().size() <= 20` | `hasOnly(wordSetFields())` — 11 |
| `validSession` | `keys().size() <= 20` | `hasOnly(sessionFields())` — 8 |
| `progress/entries` | `keys().size() <= 5` | `hasOnly(['ownerUid', 'entries'])` |

**`users/{uid}` loses `create, update` rather than gaining an allowlist.** Nothing in `src/` writes that document — there is no profile and no adapter addresses the path — so the rule described a feature that does not exist while accepting any twenty fields of any names. It is the one place `hasOnly` cannot help, because there is no legitimate field to allow: the honest allowlist for a document nobody writes is empty. `delete` stays; account deletion needs it.

### `migrationKey`, and why the list is not the TypeScript type

`migration/upload.mjs` writes `migrationKey` onto every migrated document as provenance, and its own comment says it is "absent from the domain `Entry`".

An allowlist built by reading `Entry` would therefore have been complete, reviewable, and wrong: `updateDoc` sends the merged document, so **every edit to all 67 migrated words would have been refused — in production only**, where the migration has been run, and after the rules were already live.

The list is read off what is stored. A test pins that.

### Layer

`tests/rules`, per `CLAUDE.md` — the claim is who may write what. Three cases:

- `refuses a field the schema has no name for, however small` — the defect, on all four paths.
- `refuses to create the user document, which nothing writes`.
- `accepts migrationKey, which the migration writes and the domain type does not name` — including the update path, which is the one that actually breaks.

### Red before green, twice, in different directions

Reverting `hasOnly` to the counts, and restoring `create, update` on `users/{uid}`:

```
× refuses a field the schema has no name for, however small
× refuses to create the user document, which nothing writes
74 passing
```

The `migrationKey` case **stayed green**, which is correct — it is a regression guard, not a defect reproduction, so a revert of the fix cannot fail it. It was proved separately by removing `migrationKey` from `entryFields()`, the exact mistake it exists to catch:

```
× accepts migrationKey, which the migration writes and the domain type does not name
75 passing
```

### Gate

569 unit and component, **76 emulator** (up from 73), lint clean, typecheck clean, prettier clean.

### Not in this change

`publicEntries` and `publicSets` still have no shape validation at all. They are next, and the shape of that change is different — `PublicationRepository` has no adapter and no UI, so the answer there is to deny the paths outright rather than to describe fields nothing writes.
