### PR TITLE
fix(rules): close the publishing paths until publishing exists

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -251,8 +251,28 @@ service cloud.firestore {
     //  * `exportEverything()` does not include them either.
     //
     // **What has to come back with the feature**, restored as properties rather
-    // than as rules — the tests that covered them are named in
-    // `tests/rules/firestore-rules.test.ts` where this block used to be tested:
+    // than as rules. The twelve tests that covered them were removed with the
+    // rules and are not recoverable from this list — they are in pull request
+    // #30, which is where to read them, and their names are the specification.
+    //
+    // Reads first, because they are the access model rather than a detail:
+    //
+    //  * **A published copy is readable by any allowed account, not only its
+    //    owner.** That is the whole point of publishing and the first decision
+    //    somebody rebuilding this has to make; the old rule was
+    //    `allow read: if isAllowed()` on both collections.
+    //  * **A snapshot entry is readable only while its parent set exists** —
+    //    `allow read: if isAllowed() && exists(setPath(publicSetId))`. Firestore
+    //    does not cascade deletes, so without it an unpublish that fails
+    //    part-way leaves a snapshot readable from a path somebody already noted.
+    //    This is the half of the orphan story that fails **open**; the delete
+    //    exemption below is the half that fails closed.
+    //  * **The owner must be able to publish, republish and unpublish.** A list
+    //    of prohibitions with nothing that must succeed is how rules nobody can
+    //    publish through get written — which is exactly what the `getAfter`
+    //    point below exists to prevent.
+    //
+    // Then the writes:
     //
     //  * ownerUid may never be reassigned on an existing copy, and may never be
     //    somebody else's on a new one.
@@ -266,7 +286,12 @@ service cloud.firestore {
     //    account must lose the ability to edit what it has already put in front
     //    of other people.
     //  * Shape and size validation, which never existed here and must, on the
-    //    same `hasOnly` footing as the private collections above.
+    //    same footing as the private collections above — which by then means
+    //    `hasOnly` plus per-field bounds. That arrives in #29, not here: this
+    //    branch still bounds the private collections with `keys().size()`, and
+    //    the intended order is #29 first. The two merge cleanly either way; it
+    //    is this sentence that stops being true if they land the other way
+    //    round.
     //  * Deletion and export have to cover published copies before the feature
     //    is reachable, not after.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,9 @@
 rules_version = '2';
 
 // Private data lives under users/{uid} and is reachable by that account alone.
-// Published copies are separate, deliberately duplicated documents in their own
-// top-level collections.
+// **That is currently all of it.** Publishing is designed and unbuilt, and the
+// collections it would use are closed rather than waiting open — see the block
+// further down for what has to come back with the feature.
 //
 // Two properties are worth stating because they are what make this simple:
 //
@@ -22,29 +23,6 @@ service cloud.firestore {
 
     function isOwner(uid) {
       return request.auth != null && request.auth.uid == uid;
-    }
-
-    function setPath(publicSetId) {
-      return /databases/$(database)/documents/publicSets/$(publicSetId);
-    }
-
-    // Carrying ownerUid on a snapshot entry answers "who wrote this row", but
-    // not "may this row be in this set". Without checking the parent, any
-    // allowlisted account could create an entry under somebody else's published
-    // set — or under a set id that does not exist — and it would be served as
-    // part of that set to everyone reading or adopting it.
-    //
-    // getAfter, not get: a first publish writes the set and its first entries in
-    // one batch, and get() only sees committed state, so the child would be
-    // evaluated against a parent that does not exist yet and every first publish
-    // would be denied. getAfter evaluates the batch's end state, which is what
-    // "does this row belong here once this write lands" actually means. It still
-    // returns null for a set nobody is creating, so an entry under an unrelated
-    // or non-existent set stays denied.
-    //
-    // One document read per call, paid only on publish.
-    function ownsParentSet(publicSetId) {
-      return getAfter(setPath(publicSetId)).data.ownerUid == request.auth.uid;
     }
 
     // The single gate that keeps this a private notebook.
@@ -251,49 +229,46 @@ service cloud.firestore {
       }
     }
 
-    // A published copy is an immutable snapshot. Republishing overwrites it
-    // wholesale and bumps its version; unpublishing deletes it. Only the owner
-    // writes, and ownerUid can never be reassigned to somebody else.
+    // ---- publishing: closed until it exists ----
     //
-    // Every mutation is gated on isAllowed(), not just create. Removing an
-    // account from allowedUsers has to revoke it completely — otherwise a
-    // revoked account keeps the ability to edit what it has already put in front
-    // of other people, which is the one thing revocation is for. The cost is
-    // that it can no longer delete its own published copies either; admin
-    // tooling cleans those up, which is the right way round for a ban.
-    match /publicEntries/{publicEntryId} {
-      allow read: if isAllowed();
-      allow create: if isAllowed() && isOwner(request.resource.data.ownerUid);
-      allow update: if isAllowed() && isOwner(resource.data.ownerUid)
-                    && request.resource.data.ownerUid == resource.data.ownerUid;
-      allow delete: if isAllowed() && isOwner(resource.data.ownerUid);
-    }
-
-    match /publicSets/{publicSetId} {
-      allow read: if isAllowed();
-      allow create: if isAllowed() && isOwner(request.resource.data.ownerUid);
-      allow update: if isAllowed() && isOwner(resource.data.ownerUid)
-                    && request.resource.data.ownerUid == resource.data.ownerUid;
-      allow delete: if isAllowed() && isOwner(resource.data.ownerUid);
-
-      match /entries/{entryId} {
-        // Deleting publicSets/{id} does NOT delete this subcollection —
-        // Firestore has no cascading delete. Requiring the parent to exist means
-        // an unpublish that fails part-way through cannot leave a snapshot
-        // readable from a path somebody already knows. PublicationRepository
-        // still has to delete the children first; this is the backstop, not the
-        // mechanism.
-        allow read: if isAllowed() && exists(setPath(publicSetId));
-        allow create: if isAllowed() && isOwner(request.resource.data.ownerUid)
-                      && ownsParentSet(publicSetId);
-        allow update: if isAllowed() && isOwner(resource.data.ownerUid)
-                      && request.resource.data.ownerUid == resource.data.ownerUid
-                      && ownsParentSet(publicSetId);
-        // Deliberately no parent check: orphans left by a half-finished
-        // unpublish must stay deletable by their owner.
-        allow delete: if isAllowed() && isOwner(resource.data.ownerUid);
-      }
-    }
+    // `publicEntries` and `publicSets` had full create/update/delete rules and
+    // **no shape or size validation of any kind** — no `hasOnly`, no length
+    // caps, nothing. Meanwhile `PublicationRepository` is a port in
+    // `src/domain/ports.ts` with no adapter behind it and no interface in front
+    // of it, so nothing in the application has ever written to either.
+    //
+    // That combination is the worst way round. The paths nothing writes were
+    // the only ones an allowed account could write anything at all to, and an
+    // account is only ever one compromise away from being that account.
+    //
+    // Two further things would have been wrong on the day publishing shipped,
+    // and both are cheaper to fix while the feature is unbuilt:
+    //
+    //  * `deleteEverything()` removes entries, word sets, progress and
+    //    sessions. It does not touch published copies — so "アカウントおよび
+    //    データを削除できます" would have been false for exactly the data other
+    //    people can see.
+    //  * `exportEverything()` does not include them either.
+    //
+    // **What has to come back with the feature**, restored as properties rather
+    // than as rules — the tests that covered them are named in
+    // `tests/rules/firestore-rules.test.ts` where this block used to be tested:
+    //
+    //  * ownerUid may never be reassigned on an existing copy, and may never be
+    //    somebody else's on a new one.
+    //  * A snapshot entry's parent set must be owned by the writer, checked
+    //    with `getAfter` and not `get` — a first publish writes the set and its
+    //    first entries in one batch, and `get` sees only committed state, so it
+    //    denies every first publish.
+    //  * Delete on a snapshot entry deliberately skips that parent check, so an
+    //    orphan left by a half-finished unpublish stays cleanable by its owner.
+    //  * Every mutation gates on `isAllowed()`, not only create: a revoked
+    //    account must lose the ability to edit what it has already put in front
+    //    of other people.
+    //  * Shape and size validation, which never existed here and must, on the
+    //    same `hasOnly` footing as the private collections above.
+    //  * Deletion and export have to cover published copies before the feature
+    //    is reachable, not after.
 
     // Anything not listed above stays denied. The old top-level /entries,
     // /entryProgress, /practiceSessions and /wordSets collections are gone: they

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -176,12 +176,6 @@ describe('the allowedUsers gate', () => {
   });
 
   /**
-   * The gap the first review round found: update and delete were gated on
-   * ownership alone, so revoking an account left it able to keep editing what
-   * it had already put in front of other people — the one thing revocation is
-   * for.
-   */
-  /**
    * Revocation is the claim going away, not a document being deleted.
    *
    * That is a real change in what "revoked" means: the claim lives in the ID
@@ -193,116 +187,88 @@ describe('the allowedUsers gate', () => {
    * **This test is the state after the token has turned over**, which is the
    * one this harness can express: `@firebase/rules-unit-testing` mints tokens
    * directly, so the window itself is not reachable from here.
+   *
+   * The published-copy version of this went with the publishing rules. The
+   * property survives it: revocation has to take away update and delete on what
+   * the account already wrote, not only create. Gating `create` alone would
+   * leave a revoked account editing its own notebook indefinitely, which is the
+   * gap the first review round found.
    */
-  it('revokes update and delete on already-published copies, not just create', async () => {
+  it('takes away update and delete on what a revoked account already wrote', async () => {
     const db = asStranger(ALICE);
 
-    await assertFails(db.doc(`publicEntries/pe-alice`).update({ searchText: 'edited' }));
+    await assertFails(db.doc(`users/${ALICE}/entries/e1`).update({ headword: 'edited' }));
+    await assertFails(db.doc(`users/${ALICE}/entries/e1`).delete());
+    // ...and reading it, which it could do a moment ago.
+    await assertFails(db.doc(`users/${ALICE}/entries/e1`).get());
+  });
+});
+
+/**
+ * Publishing is designed and unbuilt, and the paths it would use are shut.
+ *
+ * `PublicationRepository` is a port with no adapter and no interface in front
+ * of it, so nothing in the application has ever written here — while the rules
+ * permitted create, update and delete with **no shape or size validation at
+ * all**. The only collections an allowed account could write anything it liked
+ * to were the two that nothing writes.
+ *
+ * These tests are what stops that reopening by accident. When publishing is
+ * built they are replaced by the properties named in `firestore.rules` where
+ * the old block was: ownerUid never reassigned, the parent set checked with
+ * `getAfter` so a first publish in one batch is not denied, delete on a
+ * snapshot entry exempt from that check so orphans stay cleanable, every
+ * mutation gated on `isAllowed()` rather than only create, `hasOnly`
+ * validation, and deletion and export covering published copies before the
+ * feature is reachable.
+ */
+describe('publishing, which is not built', () => {
+  /**
+   * The seeded documents exist — `beforeEach` writes them with rules disabled,
+   * as a partly-built feature or an earlier deploy would have left them. Being
+   * unreadable is therefore a fact about the rules and not about the fixture.
+   */
+  it('refuses to read a published copy, to its owner as much as to anyone else', async () => {
+    for (const db of [as(ALICE), as(BOB)]) {
+      await assertFails(db.doc(`publicEntries/pe-alice`).get());
+      await assertFails(db.doc(`publicSets/set-alice`).get());
+      await assertFails(db.doc(`publicSets/set-alice/entries/x1`).get());
+    }
+  });
+
+  it('refuses to create one, which is the write nothing in the app makes', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`publicEntries/pe-new`).set(snapshotEntry(ALICE)));
+    await assertFails(db.doc(`publicSets/set-new`).set({ ...snapshotEntry(ALICE), entryCount: 0 }));
+    await assertFails(db.doc(`publicSets/set-alice/entries/x2`).set(snapshotEntry(ALICE)));
+  });
+
+  /**
+   * Owning the document is not an exception. Ownership was the whole basis of
+   * the rules this replaces, so a check that let the owner through would leave
+   * the surface exactly as wide as it was.
+   */
+  it('refuses to update or delete one, including by its own owner', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`publicEntries/pe-alice`).update({ version: 2 }));
     await assertFails(db.doc(`publicEntries/pe-alice`).delete());
     await assertFails(db.doc(`publicSets/set-alice`).update({ entryCount: 99 }));
     await assertFails(db.doc(`publicSets/set-alice`).delete());
     await assertFails(db.doc(`publicSets/set-alice/entries/x1`).update({ searchText: 'e' }));
     await assertFails(db.doc(`publicSets/set-alice/entries/x1`).delete());
-    // ...and reading and creating stay denied, as they already were.
-    await assertFails(db.doc(`publicEntries/pe-alice`).get());
-    await assertFails(db.doc(`publicEntries/pe-new`).set(snapshotEntry(ALICE)));
-  });
-});
-
-describe('published copies', () => {
-  it("lets an allowlisted user read anyone's published content", async () => {
-    await assertSucceeds(as(BOB).doc(`publicEntries/pe-alice`).get());
-    await assertSucceeds(as(BOB).doc(`publicSets/set-alice`).get());
-    await assertSucceeds(as(BOB).doc(`publicSets/set-alice/entries/x1`).get());
-  });
-
-  it('lets the owner publish, republish and unpublish', async () => {
-    const db = as(ALICE);
-    await assertSucceeds(db.doc(`publicEntries/pe-2`).set(snapshotEntry(ALICE)));
-    await assertSucceeds(db.doc(`publicEntries/pe-alice`).update({ version: 2 }));
-    await assertSucceeds(db.doc(`publicEntries/pe-alice`).delete());
-  });
-
-  it('refuses to publish under someone else as owner', async () => {
-    await assertFails(as(ALICE).doc(`publicEntries/pe-3`).set(snapshotEntry(BOB)));
-  });
-
-  it('refuses to reassign ownerUid on an existing copy', async () => {
-    await assertFails(as(ALICE).doc(`publicEntries/pe-alice`).update({ ownerUid: BOB }));
-  });
-
-  it("refuses to touch another user's published copy", async () => {
-    const db = as(BOB);
-    await assertFails(db.doc(`publicEntries/pe-alice`).update({ searchText: 'x' }));
-    await assertFails(db.doc(`publicEntries/pe-alice`).delete());
-  });
-});
-
-describe('snapshot entries under a published set', () => {
-  /**
-   * The second gap the review found. Checking only the child's own ownerUid
-   * answers "who wrote this row" but not "may this row be in this set", so an
-   * allowlisted account could inject an entry into somebody else's published
-   * set, where it would be served and adopted as part of it.
-   */
-  it("refuses a create under another user's set", async () => {
-    await assertFails(
-      as(ALICE).doc(`publicSets/set-bob/entries/injected`).set(snapshotEntry(ALICE)),
-    );
-  });
-
-  it('refuses a create under a set that does not exist', async () => {
-    await assertFails(as(ALICE).doc(`publicSets/set-ghost/entries/x`).set(snapshotEntry(ALICE)));
   });
 
   /**
-   * A first publish writes the set and its first entries in one batch. Checking
-   * the parent with get() would evaluate the children against committed state,
-   * where the set does not exist yet, and deny every first publish — the parent
-   * check that fixed cross-user injection would have quietly broken publishing
-   * itself. getAfter() evaluates the batch's end state instead.
+   * The batch a first publish would have used. It is the one shape that could
+   * plausibly slip past a rule written only against single writes, which is why
+   * it is named here rather than folded into the create case above.
    */
-  it('allows a first publish creating the set and its first entry in one batch', async () => {
+  it('refuses the one-batch first publish the old getAfter check existed for', async () => {
     const db = as(ALICE);
     const batch = db.batch();
     batch.set(db.doc(`publicSets/set-first`), { ...snapshotEntry(ALICE), entryCount: 1 });
     batch.set(db.doc(`publicSets/set-first/entries/x1`), snapshotEntry(ALICE));
-    await assertSucceeds(batch.commit());
-  });
-
-  it('refuses a batch that creates the set under another owner', async () => {
-    const db = as(ALICE);
-    const batch = db.batch();
-    batch.set(db.doc(`publicSets/set-spoof`), { ...snapshotEntry(BOB), entryCount: 1 });
-    batch.set(db.doc(`publicSets/set-spoof/entries/x1`), snapshotEntry(ALICE));
     await assertFails(batch.commit());
-  });
-
-  it('allows a create under the writer own set', async () => {
-    await assertSucceeds(
-      as(ALICE).doc(`publicSets/set-alice/entries/x2`).set(snapshotEntry(ALICE)),
-    );
-  });
-
-  /**
-   * Firestore does not cascade deletes, so removing publicSets/{id} leaves this
-   * subcollection addressable by anyone who noted the id. Requiring the parent
-   * on read means a half-finished unpublish fails closed.
-   */
-  it('stops serving snapshot entries once the parent set is gone', async () => {
-    await testEnv.withSecurityRulesDisabled(async (context) => {
-      await context.firestore().doc(`publicSets/set-alice`).delete();
-    });
-    await assertFails(as(BOB).doc(`publicSets/set-alice/entries/x1`).get());
-    await assertFails(as(ALICE).doc(`publicSets/set-alice/entries/x1`).get());
-  });
-
-  /** Deliberately exempt from the parent check, so orphans stay cleanable. */
-  it('still lets the owner delete an orphaned snapshot entry', async () => {
-    await testEnv.withSecurityRulesDisabled(async (context) => {
-      await context.firestore().doc(`publicSets/set-alice`).delete();
-    });
-    await assertSucceeds(as(ALICE).doc(`publicSets/set-alice/entries/x1`).delete());
   });
 });
 

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -214,13 +214,16 @@ describe('the allowedUsers gate', () => {
  * to were the two that nothing writes.
  *
  * These tests are what stops that reopening by accident. When publishing is
- * built they are replaced by the properties named in `firestore.rules` where
- * the old block was: ownerUid never reassigned, the parent set checked with
- * `getAfter` so a first publish in one batch is not denied, delete on a
- * snapshot entry exempt from that check so orphans stay cleanable, every
- * mutation gated on `isAllowed()` rather than only create, `hasOnly`
- * validation, and deletion and export covering published copies before the
- * feature is reachable.
+ * built they are replaced by the properties listed in `firestore.rules` where
+ * the old block was — reads open to any allowed account, a snapshot entry
+ * readable only while its parent set exists, ownerUid never reassigned, the
+ * parent set checked with `getAfter`, delete exempt from that check, every
+ * mutation gated on `isAllowed()`, shape validation, and deletion and export
+ * covering published copies.
+ *
+ * The twelve tests that covered those properties are in pull request #30. This
+ * docblock points at the rules and the rules point at that pull request, so
+ * neither is a step in a circle.
  */
 describe('publishing, which is not built', () => {
   /**


### PR DESCRIPTION
`publicEntries` and `publicSets` carried create, update and delete with **no shape or size validation of any kind** — no `hasOnly`, no length caps, nothing. `PublicationRepository` is a port in `src/domain/ports.ts` with no adapter behind it and no interface in front of it, so nothing in the application has ever written to either.

That combination is the worst way round: the only collections an allowed account could write anything at all to were the two nothing writes.

### Deleted rather than disabled

Since the recursive wildcard went, an unlisted path is denied. So closing these is removing the blocks, not adding `if false` — and `setPath()` and `ownsParentSet()` go with them, having no other caller.

### Two things this also fixes early

Both would have been wrong on the day publishing shipped, and both are far cheaper now:

- **`deleteEverything()` does not touch published copies.** The privacy policy promises account deletion removes the user's data; that promise would have been false for precisely the data other people can see.
- **`exportEverything()` does not include them either.**

### The design is kept, as properties rather than as rules

The rules file keeps a block naming what has to come back **with** the feature, and the new `describe` docblock points at it:

- `ownerUid` never reassigned on an existing copy, never somebody else's on a new one.
- The parent set checked with `getAfter`, not `get` — a first publish writes the set and its first entries in one batch, and `get` sees only committed state, so it would deny every first publish.
- Delete on a snapshot entry deliberately exempt from that parent check, so an orphan from a half-finished unpublish stays cleanable by its owner.
- Every mutation gated on `isAllowed()`, not only create.
- `hasOnly` validation, which never existed here.
- Deletion and export covering published copies before the feature is reachable.

### One test changed direction instead of being deleted

`revokes update and delete on already-published copies` protected a real gap the first review round found: revoking an account has to take away update and delete on what it already wrote, not only create.

The path is gone; the property is not. It is now `takes away update and delete on what a revoked account already wrote`, against the private notebook. Not a duplicate of the existing stranger test, which writes to a path holding no document — this one edits and deletes an existing row.

### Layer

`tests/rules`. Four cases replacing eleven: read, create, update-or-delete, and the one-batch first publish. The batch case is named separately because it is the shape most likely to slip past a rule written only against single writes.

**Reads are denied to the owner too, and that is the point.** Ownership was the entire basis of the rules being removed, so a check that let the owner through would leave the surface exactly as wide as it was. The seeded documents are written with rules disabled — as a partly-built feature or an earlier deploy would have left them — so being unreadable is a fact about the rules and not about the fixture.

### Red before green

`git checkout develop -- firestore.rules`, restoring the publishing rules exactly:

```
× refuses to read a published copy, to its owner as much as to anyone else
× refuses to create one, which is the write nothing in the app makes
× refuses to update or delete one, including by its own owner
× refuses the one-batch first publish the old getAfter check existed for
61 passing
```

569 unit and component, 65 emulator, lint clean, typecheck clean, prettier clean. 59 lines net removed.
