### PR TITLE
fix(account): prove the session first, and notice a stuck walk on page two

### DIFF
--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -133,6 +133,18 @@ export interface AuthPort {
   signIn(): Promise<void>;
   signOut(): Promise<void>;
   /**
+   * Prove the session is current, before anything irreversible depends on it.
+   *
+   * Providers refuse a sensitive operation on a stale session, and `deleteAccount`
+   * is one — so a deletion that runs the data first and the account last will,
+   * on an old-enough session, succeed at every irreversible step and fail at the
+   * one that needed proving. The user is then left with an account and no data.
+   *
+   * Calling this first moves that failure to the front, where it costs a
+   * re-authentication prompt instead of everything the account had.
+   */
+  reauthenticate(): Promise<void>;
+  /**
    * Delete the account itself, not just its data.
    *
    * Providers generally refuse this on a stale session — Firebase raises

--- a/src/infra/firebase/authAdapter.ts
+++ b/src/infra/firebase/authAdapter.ts
@@ -1,5 +1,11 @@
 import type { User } from 'firebase/auth';
-import { deleteUser, onAuthStateChanged, signInWithPopup, signOut } from 'firebase/auth';
+import {
+  deleteUser,
+  onAuthStateChanged,
+  reauthenticateWithPopup,
+  signInWithPopup,
+  signOut,
+} from 'firebase/auth';
 import type { AuthPort, AuthUser } from '@/domain/ports';
 import { auth, googleProvider } from './client';
 
@@ -25,6 +31,18 @@ export const firebaseAuth: AuthPort = {
   },
   signOut: async () => {
     await signOut(auth);
+  },
+  /**
+   * The same popup as signing in, against the account already signed in.
+   *
+   * `reauthenticateWithPopup` rather than `signInWithPopup`: the latter would
+   * succeed for a *different* Google account, and the caller is about to delete
+   * everything belonging to the current one. Firebase refuses the swap here.
+   */
+  reauthenticate: async () => {
+    const user = auth.currentUser;
+    if (!user) throw new Error('ログインしていません。');
+    await reauthenticateWithPopup(user, googleProvider);
   },
   /**
    * Firebase refuses this on a session that is not recent, raising

--- a/src/lib/accountData.ts
+++ b/src/lib/accountData.ts
@@ -45,10 +45,25 @@ const PAGE = 100;
 async function drain<T>(read: (q: PageQuery) => Promise<Page<T>>): Promise<T[]> {
   const all: T[] = [];
   let cursor: string | null = null;
+  // A cursor already handed out means the walk is not advancing. Recognising
+  // that is the guard; the page count below is only a backstop.
+  //
+  // It used to be the other way round, and the cost of that was the whole
+  // point: a stuck cursor ran the loop to its 10,000-page limit at 100 records
+  // a page, so the failure mode of "this query stopped moving" was a million
+  // document reads — twenty times the free daily allowance, spent proving
+  // something the second page already showed. Worse, `deleteEverything` drains
+  // twice too, so it was reachable from the delete button as well as from
+  // export.
+  const seen = new Set<string>();
   for (let page = 0; page < 10_000; page += 1) {
     const result: Page<T> = await read({ limit: PAGE, cursor });
     all.push(...result.items);
     if (!result.cursor) return all;
+    if (seen.has(result.cursor)) {
+      throw new Error('エクスポートが終わりませんでした。時間をおいて再度お試しください。');
+    }
+    seen.add(result.cursor);
     cursor = result.cursor;
   }
   throw new Error('エクスポートが終わりませんでした。時間をおいて再度お試しください。');
@@ -134,6 +149,20 @@ export async function deleteEverything({
   progress: ProgressRepository;
   auth: AuthPort;
 }): Promise<{ entries: number; wordSets: number }> {
+  // **First, and before anything irreversible.**
+  //
+  // The order below — data, then the account — is deliberate and stays: delete
+  // the account first and there is no session left to delete the data with.
+  // What that order cannot survive is the provider refusing the last step. On a
+  // session old enough for `auth/requires-recent-login`, every destructive write
+  // succeeded and only the account remained, so a user who pressed delete was
+  // left with an account holding nothing and a message telling them some of it
+  // was already gone.
+  //
+  // Proving the session up front costs a popup and moves that failure to the
+  // one place where nothing has happened yet.
+  await auth.reauthenticate();
+
   const setList = await drain((q) => wordSets.list(q));
   for (const set of setList) await wordSets.remove(set.id);
 

--- a/src/lib/accountData.ts
+++ b/src/lib/accountData.ts
@@ -42,6 +42,13 @@ const PAGE = 100;
  * The guard is a page count rather than a timeout: a cursor that stops moving
  * would otherwise spin forever, and 10,000 pages is far past any real notebook.
  */
+/**
+ * One literal, because `deleteEverything` drains as well — so this string is
+ * already reachable from a path it does not describe. Two copies would drift,
+ * and the copy that drifts is the one nobody is looking at.
+ */
+const WALK_STOPPED = 'エクスポートが終わりませんでした。時間をおいて再度お試しください。';
+
 async function drain<T>(read: (q: PageQuery) => Promise<Page<T>>): Promise<T[]> {
   const all: T[] = [];
   let cursor: string | null = null;
@@ -60,13 +67,11 @@ async function drain<T>(read: (q: PageQuery) => Promise<Page<T>>): Promise<T[]> 
     const result: Page<T> = await read({ limit: PAGE, cursor });
     all.push(...result.items);
     if (!result.cursor) return all;
-    if (seen.has(result.cursor)) {
-      throw new Error('エクスポートが終わりませんでした。時間をおいて再度お試しください。');
-    }
+    if (seen.has(result.cursor)) throw new Error(WALK_STOPPED);
     seen.add(result.cursor);
     cursor = result.cursor;
   }
-  throw new Error('エクスポートが終わりませんでした。時間をおいて再度お試しください。');
+  throw new Error(WALK_STOPPED);
 }
 
 export async function exportEverything({
@@ -138,6 +143,33 @@ export function exportFilename(now = new Date()): string {
  * decision worth making on its own rather than as a side effect of adding a
  * delete button.
  */
+/**
+ * The session could not be proved, so **nothing was deleted**.
+ *
+ * This exists because the caller was inferring that from a provider error code
+ * and could not. `auth/requires-recent-login` is the clearest case: it is
+ * `CREDENTIAL_TOO_OLD_LOGIN_AGAIN`, which the backend returns for a *sensitive
+ * operation* — here `deleteAccount()`, the last statement below. Reading it as
+ * "the re-authentication was refused" inverts the truth exactly: by the time it
+ * can be raised, every word set, entry, session and the progress map are gone.
+ *
+ * `reauthenticateWithPopup` raises `auth/user-mismatch`, `auth/popup-blocked`
+ * and the cancellation codes; `authAdapter` can also throw with no `code` at
+ * all. That list is provider-defined and moves between SDK versions. This
+ * function is the only place that knows which half it got through, so it says
+ * so and the caller stops guessing.
+ */
+export class NothingDeleted extends Error {
+  /** What the provider actually raised, for the console. */
+  readonly reason: unknown;
+
+  constructor(reason: unknown) {
+    super('reauthentication failed, so nothing was deleted');
+    this.name = 'NothingDeleted';
+    this.reason = reason;
+  }
+}
+
 export async function deleteEverything({
   entries,
   wordSets,
@@ -161,7 +193,11 @@ export async function deleteEverything({
   //
   // Proving the session up front costs a popup and moves that failure to the
   // one place where nothing has happened yet.
-  await auth.reauthenticate();
+  try {
+    await auth.reauthenticate();
+  } catch (cause) {
+    throw new NothingDeleted(cause);
+  }
 
   const setList = await drain((q) => wordSets.list(q));
   for (const set of setList) await wordSets.remove(set.id);

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -119,9 +119,10 @@ export const authPort: AuthPort = {
     notify();
     return Promise.resolve();
   },
-  // The real adapter can refuse this on a stale session; the fake never does,
-  // because the end-to-end suite has no way to age a session and a test that
-  // cannot reach the happy path covers nothing.
+  // The real adapter opens a popup here. The fake resolves, for the same reason
+  // it never refuses `deleteAccount`: the end-to-end suite has no way to age a
+  // session, and a test that cannot reach the happy path covers nothing.
+  reauthenticate: () => Promise.resolve(),
   deleteAccount(): Promise<void> {
     currentUser = null;
     notify();

--- a/src/routes/Account.tsx
+++ b/src/routes/Account.tsx
@@ -80,13 +80,23 @@ export function Component() {
       await signOutUser();
     } catch (cause) {
       console.error(cause);
-      // `requires-recent-login` is not a failure the user can act on without
-      // being told what it is: the provider refuses to delete an account on a
-      // stale session, and the fix is to sign in again.
+      // The re-authentication now runs before the first delete, so these two
+      // messages describe genuinely different situations rather than the same
+      // half-finished one.
+      //
+      // A cancelled or refused popup happens with **nothing deleted**, and the
+      // message says so plainly — the previous wording warned that some data
+      // might already be gone, which was true then and would be a false alarm
+      // now. Anything else still fails part-way, and still has to say so.
       const code = (cause as { code?: string }).code;
+      const cancelled =
+        code === 'auth/popup-closed-by-user' ||
+        code === 'auth/cancelled-popup-request' ||
+        code === 'auth/user-cancelled' ||
+        code === 'auth/requires-recent-login';
       setError(
-        code === 'auth/requires-recent-login'
-          ? 'セキュリティのため、一度ログインし直してから削除してください。データの一部はすでに削除されている可能性があります。'
+        cancelled
+          ? 'セキュリティのため、削除の前に本人確認が必要です。データは削除されていません。もう一度お試しください。'
           : // Deliberately not "failed": some of it may be gone. Saying so is
             // the difference between a user retrying and a user assuming their
             // data is intact when half of it is not.

--- a/src/routes/Account.tsx
+++ b/src/routes/Account.tsx
@@ -2,7 +2,12 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { CopyDiagnostics } from '@/components/CopyDiagnostics';
-import { deleteEverything, exportEverything, exportFilename } from '@/lib/accountData';
+import {
+  deleteEverything,
+  exportEverything,
+  exportFilename,
+  NothingDeleted,
+} from '@/lib/accountData';
 import { useAuth } from '@/lib/auth';
 import { authPort } from '@/lib/backend';
 import { appVersion, buildLine } from '@/lib/build';
@@ -80,22 +85,20 @@ export function Component() {
       await signOutUser();
     } catch (cause) {
       console.error(cause);
-      // The re-authentication now runs before the first delete, so these two
-      // messages describe genuinely different situations rather than the same
-      // half-finished one.
+      // Branching on what happened, not on which code the provider chose.
       //
-      // A cancelled or refused popup happens with **nothing deleted**, and the
-      // message says so plainly — the previous wording warned that some data
-      // might already be gone, which was true then and would be a false alarm
-      // now. Anything else still fails part-way, and still has to say so.
-      const code = (cause as { code?: string }).code;
-      const cancelled =
-        code === 'auth/popup-closed-by-user' ||
-        code === 'auth/cancelled-popup-request' ||
-        code === 'auth/user-cancelled' ||
-        code === 'auth/requires-recent-login';
+      // The list this replaces was wrong in both directions, and one of the
+      // errors was the dangerous kind. `auth/requires-recent-login` is
+      // `CREDENTIAL_TOO_OLD_LOGIN_AGAIN`, raised for a *sensitive operation* —
+      // which here is `deleteAccount()`, the last thing `deleteEverything`
+      // does. Treating it as "the popup was refused" meant telling a user
+      // 「データは削除されていません」 at the one moment everything already had
+      // been. It also missed `auth/user-mismatch`, `auth/popup-blocked` and the
+      // adapter's own error, which carries no `code` at all.
+      //
+      // `NothingDeleted` is thrown by the only code that knows.
       setError(
-        cancelled
+        cause instanceof NothingDeleted
           ? 'セキュリティのため、削除の前に本人確認が必要です。データは削除されていません。もう一度お試しください。'
           : // Deliberately not "failed": some of it may be gone. Saying so is
             // the difference between a user retrying and a user assuming their

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Page, PageQuery } from '@/domain/ports';
-import { deleteEverything, exportEverything, exportFilename } from '@/lib/accountData';
+import {
+  deleteEverything,
+  exportEverything,
+  exportFilename,
+  NothingDeleted,
+} from '@/lib/accountData';
 
 /** A repository holding `count` rows and serving them `PAGE` at a time. */
 const paged = <T>(items: T[]) => {
@@ -160,16 +165,48 @@ describe('deleteEverything', () => {
    */
   it('refuses to delete anything at all when the session cannot be proved', async () => {
     const p = ports(5, 5, 5);
+    // A code `reauthenticateWithPopup` actually raises. It is the one the
+    // adapter chose that call for: the user picked a different Google account,
+    // and the caller is about to delete everything belonging to this one.
     (p.auth.reauthenticate as ReturnType<typeof vi.fn>).mockRejectedValue(
-      Object.assign(new Error('stale'), { code: 'auth/requires-recent-login' }),
+      Object.assign(new Error('different account'), { code: 'auth/user-mismatch' }),
     );
 
-    await expect(deleteEverything(p)).rejects.toThrow('stale');
+    await expect(deleteEverything(p)).rejects.toBeInstanceOf(NothingDeleted);
 
     expect((p.entries.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     expect((p.wordSets.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     expect((p.progress.removeAll as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     expect((p.auth.deleteAccount as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+
+  /**
+   * The state a user must never be told is safe.
+   *
+   * `auth/requires-recent-login` is `CREDENTIAL_TOO_OLD_LOGIN_AGAIN`, which the
+   * backend returns for a sensitive operation — and the only sensitive
+   * operation here is `deleteAccount()`, which runs last. So this code can only
+   * reach a caller *after* every word set, entry, session and the progress map
+   * are already gone. Reading it as "the re-authentication was refused" and
+   * reporting 「データは削除されていません」 is the exact inverse of what
+   * happened, and it is unrecoverable: the reader retries later into an account
+   * holding nothing.
+   *
+   * The window is real rather than theoretical — the removals are one sequential
+   * `await` each, and nothing bounds how long that takes.
+   */
+  it('does not report a late refusal as nothing having been deleted', async () => {
+    const p = ports(5, 5, 5);
+    (p.auth.deleteAccount as ReturnType<typeof vi.fn>).mockRejectedValue(
+      Object.assign(new Error('stale'), { code: 'auth/requires-recent-login' }),
+    );
+
+    const failure = await deleteEverything(p).catch((cause: unknown) => cause);
+
+    expect(failure).not.toBeInstanceOf(NothingDeleted);
+    // ...because plenty was.
+    expect((p.entries.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(5);
+    expect((p.progress.removeAll as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 });
 

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -24,7 +24,10 @@ const ports = (entryCount: number, setCount: number, sessionCount: number) => {
     listSessions: paged(rows(sessionCount, 'p')),
     removeAll: vi.fn(() => Promise.resolve()),
   };
-  const auth = { deleteAccount: vi.fn(() => Promise.resolve()) };
+  const auth = {
+    reauthenticate: vi.fn(() => Promise.resolve()),
+    deleteAccount: vi.fn(() => Promise.resolve()),
+  };
   // Only the methods under test are implemented; the ports are wider.
   return {
     entries,
@@ -142,5 +145,58 @@ describe('deleteEverything', () => {
     await deleteEverything(p);
 
     expect(order).toEqual(['data', 'account']);
+  });
+
+  /**
+   * The state the order above cannot survive on its own.
+   *
+   * Providers refuse a sensitive operation on a stale session, so with the
+   * account deleted last a session old enough for `auth/requires-recent-login`
+   * succeeded at every irreversible step and failed only at the one that needed
+   * proving. The user pressed delete and was left holding an account with
+   * nothing in it — the worst of both outcomes, and unrecoverable.
+   *
+   * Proving the session first turns that into a popup.
+   */
+  it('refuses to delete anything at all when the session cannot be proved', async () => {
+    const p = ports(5, 5, 5);
+    (p.auth.reauthenticate as ReturnType<typeof vi.fn>).mockRejectedValue(
+      Object.assign(new Error('stale'), { code: 'auth/requires-recent-login' }),
+    );
+
+    await expect(deleteEverything(p)).rejects.toThrow('stale');
+
+    expect((p.entries.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect((p.wordSets.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect((p.progress.removeAll as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+    expect((p.auth.deleteAccount as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+  });
+});
+
+/**
+ * A cursor that stops advancing is a query that has stopped working, and the
+ * page cap alone answered that with a million document reads.
+ *
+ * `drain` walked to its 10,000-page limit at 100 records a page before giving
+ * up — twenty times the free daily read allowance, spent proving something the
+ * second page already showed. `deleteEverything` drains twice as well, so the
+ * delete button reached it too.
+ */
+describe('drain, when the walk stops moving', () => {
+  it('stops on the second page rather than after ten thousand', async () => {
+    const stuck = vi.fn((_q: PageQuery) =>
+      // Always more, always from the same place.
+      Promise.resolve({ items: [{ id: 'e-0' }], cursor: 'same' }),
+    );
+    const p = ports(0, 0, 0);
+    (p.entries.list as unknown) = stuck;
+
+    await expect(exportEverything({ ...p, appVersion: '0.1.0' })).rejects.toThrow(
+      'エクスポートが終わりませんでした',
+    );
+
+    // Two: the first hands out `same`, the second hands it out again and is
+    // recognised. Anything higher means the cap is doing the work.
+    expect(stuck.mock.calls).toHaveLength(2);
   });
 });

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -203,6 +203,13 @@ describe('deleteEverything', () => {
 
     const failure = await deleteEverything(p).catch((cause: unknown) => cause);
 
+    // Both, and the first is not redundant. `not.toBeInstanceOf` is satisfied by
+    // anything that is not that class — including `deleteEverything` returning
+    // normally, in which case `failure` is the `{ entries, wordSets }` result
+    // and the call counts below hold anyway. Without this line the test is
+    // equally happy with the account silently failing to delete, which is a
+    // neighbouring defect it is named to exclude.
+    expect(failure).toBeInstanceOf(Error);
     expect(failure).not.toBeInstanceOf(NothingDeleted);
     // ...because plenty was.
     expect((p.entries.remove as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(5);


### PR DESCRIPTION
Two failures on the same two paths, both of which cost more than they should when they go wrong.

## Deleting could succeed at everything irreversible and fail at the end

`deleteEverything()` removes word sets, entries and practice history, then deletes the account. **That order is correct and is unchanged**: delete the account first and there is no session left to delete the data with.

What the order cannot survive on its own is the provider refusing the last step. Firebase raises `auth/requires-recent-login` on a stale session, so a delete run from an old-enough one succeeded at every destructive write and failed only at the one needing proof. The user pressed delete and was left holding an account with nothing in it — both halves of the outcome they did not want, and unrecoverable.

`AuthPort` gains `reauthenticate()`, called as the **first statement** of `deleteEverything()`. The failure moves to the one point where nothing has happened yet, and costs a popup.

`reauthenticateWithPopup`, not `signInWithPopup`: the latter succeeds for a *different* Google account, and the caller is about to delete everything belonging to the current one.

### The two messages now describe two situations

A cancelled or refused popup leaves **nothing deleted**, and `Account.tsx` says so. The previous wording warned that some data might already be gone — true when it was written, a false alarm now. The part-way message stays for everything else, because everything else can still fail part-way.

## A stuck walk cost a million reads

`drain()` gave up after 10,000 pages at 100 records each. A cursor that stops advancing therefore spent **1,000,000 document reads** — twenty times the free daily allowance — establishing something the second page already showed.

A `Set` of cursors already handed out catches it on the second read. The page count stays as a backstop rather than as the mechanism.

**`deleteEverything` drains twice as well**, so this was reachable from the delete button and not only from export.

## Layer

`tests/unit`, per `CLAUDE.md`. Both claims are functions of their inputs — no DOM, no clock, no emulator. Two tests:

- `refuses to delete anything at all when the session cannot be proved` — asserts all four removal ports were untouched, which is the property; asserting only that it threw would pass with the data already gone.
- `stops on the second page rather than after ten thousand` — asserts the call count is exactly 2. Asserting only that it threw would pass with the old code, since the old code threw too, a million reads later.

## Red before green, each fix separately

```
reauthenticate call removed:
  × refuses to delete anything at all when the session cannot be proved      497 passing

cursor guard removed, page cap alone:
  × stops on the second page rather than after ten thousand                  497 passing
```

Removing either leaves the other green, so neither test is standing in for the other.

## Also changed

`src/lib/backend.e2e.ts` implements `reauthenticate` as a resolved promise, for the same reason it never refuses `deleteAccount`: the end-to-end suite cannot age a session, and a fake that refuses covers nothing.

571 unit and component (up from 569), lint clean, both typecheck passes clean, prettier clean. Nothing in `tests/` was pinned to the previous wording — checked.
