### PR TITLE
fix(migration): check the claim instead of writing a collection nothing reads

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -164,14 +164,21 @@ production has been loaded and verified.
 
 Production has never been written to and has no rules deployed. In order:
 
-1. `yarn rules:prod` — deploy `firestore.rules` first, so the collection is
-   never briefly writable by anyone but the owner. (Or run the production deploy
-   workflow, which deploys rules before hosting for the same reason.)
+1. Run _Deploy (production)_. It deploys rules **then** hosting, which is the
+   order that matters: a client briefly older than its rules fails closed, and
+   the other way round fails open.
+
+   **Hosting is what makes step 2 possible.** On a project that has never been
+   deployed there is no app to sign into, so this cannot be shortened to
+   `yarn rules:prod` — that deploys rules only, and leaves you at step 2 with
+   nothing to open. It is the right command later, when hosting is already live
+   and only the rules have changed.
+
 2. Sign into the production app once, so the account exists and `--owner` can
    resolve to a uid.
 3. `yarn allow you@example.com prod`, **then sign out and sign back in.** The
    rules gate on a custom claim, and a claim reaches a client only in a freshly
-   minted ID token — an open session stays denied for up to an hour. Step 4
+   minted ID token — an open session stays denied for up to an hour. Step 5
    refuses to run until the claim is set, but it cannot tell whether you have
    signed in again since.
 4. Fill the accents — see above. Cheap now, 67 hand edits later.

--- a/migration/README.md
+++ b/migration/README.md
@@ -55,10 +55,18 @@ node migration/upload.mjs prod --owner you@example.com --confirm      # goitei
 
 `--owner` is mandatory. Entries live at `users/{uid}/entries/{autoId}`, and the
 uid is resolved from that address through the Admin SDK rather than guessed, so
-the account must have signed into the app at least once. The uploader also
-ensures `allowedUsers/{uid}` exists — the security rules gate every path on it
-and no client can write that collection, so uploading a notebook its owner would
-then be denied access to is the easy mistake to make.
+the account must have signed into the app at least once.
+
+**The uploader checks that the owner carries the `allowed` custom claim and
+refuses to run without it.** It used to _write_ `allowedUsers/{uid}`, back when
+the rules read that collection; they gate on the claim now and nothing reads it,
+so the write had stopped granting anything while still reporting that it had.
+Uploading a notebook its owner is then denied access to is the easy mistake, and
+the check is what stops it — before 67 documents are written rather than after.
+
+What it cannot check is the other half: a claim reaches a client only in a
+freshly minted ID token, so an account granted access while signed in still sees
+nothing until it signs out and back in. Nothing server-side can observe that.
 
 `upload.mjs` uses `set()` without merge, so a document is fully replaced and
 stale fields disappear. It is still idempotent, but by a different mechanism:
@@ -157,12 +165,21 @@ production has been loaded and verified.
 Production has never been written to and has no rules deployed. In order:
 
 1. `yarn rules:prod` — deploy `firestore.rules` first, so the collection is
-   never briefly writable by anyone but the owner.
+   never briefly writable by anyone but the owner. (Or run the production deploy
+   workflow, which deploys rules before hosting for the same reason.)
 2. Sign into the production app once, so the account exists and `--owner` can
    resolve to a uid.
-3. Fill the accents — see above. Cheap now, 67 hand edits later.
-4. `node migration/upload.mjs prod --owner you@example.com --confirm` — loads
-   the 67 entries and adds the `allowedUsers` record.
-5. Verify the count is 67 and spot-check one entry with a 📌 context section.
+3. `yarn allow you@example.com prod`, **then sign out and sign back in.** The
+   rules gate on a custom claim, and a claim reaches a client only in a freshly
+   minted ID token — an open session stays denied for up to an hour. Step 4
+   refuses to run until the claim is set, but it cannot tell whether you have
+   signed in again since.
+4. Fill the accents — see above. Cheap now, 67 hand edits later.
+5. `node migration/upload.mjs prod --owner you@example.com --confirm` — loads
+   the 67 entries.
+6. Verify the count is 67 and spot-check one entry with a 📌 context section.
+7. **Then use the app** — add, edit and delete a word. Everything above runs
+   through the Admin SDK, which bypasses rules entirely, so nothing before this
+   proves the paths, `ownerUid` and the deployed rules agree.
 
 Step 1 before step 2 is the whole point of the ordering; do not reverse it.

--- a/migration/upload.mjs
+++ b/migration/upload.mjs
@@ -165,13 +165,28 @@ console.log(`件数  : ${entries.length}`);
 // minted ID token, so an account granted access while signed in still cannot
 // read anything until it signs in again. Nothing server-side can observe that,
 // which is why the message says it rather than checking it.
+//
+// **Both halves, because the gate is both.** `isAllowed()` is
+// `signedIn() && request.auth.token.allowed == true`, and `signedIn()` requires
+// `email_verified`. Standing in for one of them would report an account ready
+// when the rules will still refuse it — which is the same failure this block
+// replaces, in a smaller size.
+//
+// Low impact and worth saying so: `client.ts` registers Google as the only
+// provider and a Google account arrives verified. This is the check matching the
+// rule, not a case anyone is likely to hit.
+if (owner.emailVerified !== true) {
+  console.error(`許可    : ${ownerEmail} のメールアドレスが未確認です。`);
+  console.error('          ルールは email_verified を要求します。');
+  process.exit(1);
+}
 if (owner.customClaims?.allowed !== true) {
   console.error(`許可    : ${ownerEmail} に allowed クレームがありません。`);
   console.error(`          yarn allow ${ownerEmail}${env === 'prod' ? ' prod' : ''}`);
   console.error('          を実行し、サインアウトしてからサインインし直してください。');
   process.exit(1);
 }
-console.log(`許可    : allowed クレームを確認しました`);
+console.log('許可    : email_verified と allowed クレームを確認しました');
 console.log('          （付与直後の場合は、一度サインアウトして入り直す必要があります）');
 
 // One read of the collection buys idempotency: without the key -> id map a

--- a/migration/upload.mjs
+++ b/migration/upload.mjs
@@ -146,15 +146,33 @@ console.log(`認証  : ${how}`);
 console.log(`所有者: ${ownerEmail} (${owner.uid})`);
 console.log(`件数  : ${entries.length}`);
 
-// The rules gate every path on allowedUsers/{uid} existing, and no client can
-// write that collection, so uploading a notebook the owner would then be denied
-// access to is the obvious way to get this wrong. Done here rather than by hand
-// because the uid is only resolvable through the Admin SDK anyway.
-await db
-  .collection('allowedUsers')
-  .doc(owner.uid)
-  .set({ email: ownerEmail, addedAt: Timestamp.now() }, { merge: true });
-console.log(`許可    : allowedUsers/${owner.uid} を確認しました`);
+// **This checks. It used to grant, and the difference went unreported.**
+//
+// Until the claim gate landed, the rules read `allowedUsers/{uid}` and this
+// script wrote it, so an owner could not end up locked out of a notebook it had
+// just uploaded. Nothing has read that collection since. The write went on
+// succeeding and the line below went on saying 「確認しました」 — a confirmation
+// of something that had stopped being true, printed by the tool an operator
+// trusts most at the one moment they most need it to be right.
+//
+// The failure that produces is not subtle and not recoverable by retrying: the
+// script reports access confirmed, the operator opens the app, and every screen
+// says it could not load. Checking the claim instead costs nothing —
+// `getUserByEmail` above already returned it — and it fails *before* 67
+// documents are written rather than after.
+//
+// It cannot see the other half. A claim reaches a client only in a freshly
+// minted ID token, so an account granted access while signed in still cannot
+// read anything until it signs in again. Nothing server-side can observe that,
+// which is why the message says it rather than checking it.
+if (owner.customClaims?.allowed !== true) {
+  console.error(`許可    : ${ownerEmail} に allowed クレームがありません。`);
+  console.error(`          yarn allow ${ownerEmail}${env === 'prod' ? ' prod' : ''}`);
+  console.error('          を実行し、サインアウトしてからサインインし直してください。');
+  process.exit(1);
+}
+console.log(`許可    : allowed クレームを確認しました`);
+console.log('          （付与直後の場合は、一度サインアウトして入り直す必要があります）');
 
 // One read of the collection buys idempotency: without the key -> id map a
 // second run cannot tell an already-uploaded note from a new one.


### PR DESCRIPTION
Closes #26.

`migration/upload.mjs` wrote `allowedUsers/{uid}` and printed:

```
許可    : allowedUsers/<uid> を確認しました
```

Nothing has read that collection since the gate became a custom claim. The write went on succeeding and the line went on saying "confirmed" — a confirmation of something that had stopped being true, printed by the tool an operator trusts most at the moment they most need it to be right.

The failure that produces is not subtle and is not fixed by retrying: the script reports access confirmed, the operator opens the app, and every screen reports that it could not load. That is the wall #22 exists to make legible, reached by following the tooling's own success message — and by then 67 documents have been written.

### Checked, not deleted

Deleting the write alone would leave the script silent about the one thing most likely to go wrong. It now checks the claim instead, and refuses:

```js
if (owner.customClaims?.allowed !== true) {
  console.error(`許可    : ${ownerEmail} に allowed クレームがありません。`);
  console.error(`          yarn allow ${ownerEmail}${env === 'prod' ? ' prod' : ''}`);
  console.error('          を実行し、サインアウトしてからサインインし直してください。');
  process.exit(1);
}
```

It costs nothing: `getUserByEmail` at `:133` already returned the record. And it fails **before** the 67 documents are written rather than after.

Same field on both sides, checked rather than assumed — `admin/allow-user.ts` writes `{ ...user.customClaims, allowed: true }`, this reads `owner.customClaims?.allowed`.

### What it cannot check, said rather than implied

A claim reaches a client only in a freshly minted ID token, so an account granted access while signed in still sees nothing until it signs out and back in. Nothing server-side can observe that. The script does not pretend to — it prints the caveat under the success line, because that is the half most likely to be hit.

### Documentation

`migration/README.md` described the replaced mechanism in two places.

The production rollout also went from five steps to seven. It never mentioned `yarn allow` or signing in again at all — the two steps without which the rest cannot work — and it ended at "verify the count is 67". Using the app afterwards is now step 7, because everything above it runs through the Admin SDK, which bypasses rules entirely: nothing before that step proves the paths, `ownerUid` and the deployed rules agree.

### Tests

**None, and the reason is not that it seemed unnecessary.** `CLAUDE.md`'s layer table covers `src`, not the one-shot migration scripts, and `upload.mjs` has never had a test — `tests/unit/migrationOutput.test.ts` covers the field mapping, not the script's control flow. Exercising this condition needs Auth Admin, which the Firestore emulator does not provide, against a real project.

What was done instead: `node --check`, a repository-wide grep confirming the only remaining `allowedUsers` references are the two historical explanations, and reading the claim's shape off `allow-user.ts` rather than assuming it.

`eslint` clean (`migration/**/*.mjs` is linted), prettier clean, 500 unit passing.

### Base

`release/0.1.0`, not `develop`. This is needed for the 0.1.0 rollout itself: the migration follows the first production deploy, and this line sits directly on that path.
