### PR TITLE
feat(vocabulary): refine tag filters and search input

### DIFF
--- a/src/components/browse/VocabularySearch.tsx
+++ b/src/components/browse/VocabularySearch.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function VocabularySearch({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const composing = useRef(false);
+  const justCommitted = useRef<string | null>(null);
+  const [compositionValue, setCompositionValue] = useState<string | null>(null);
+
+  // Once the URL has accepted the completed composition, its value becomes
+  // the source of truth again. Until then the draft prevents React's controlled
+  // input reconciliation from replacing the browser's IME candidate text.
+  useEffect(() => {
+    if (!composing.current) setCompositionValue(null);
+  }, [value]);
+
+  return (
+    <input
+      type="search"
+      value={compositionValue ?? value}
+      onChange={(event) => {
+        const next = event.currentTarget.value;
+        if (composing.current) {
+          setCompositionValue(next);
+          return;
+        }
+        if (justCommitted.current === next) {
+          justCommitted.current = null;
+          return;
+        }
+        justCommitted.current = null;
+        setCompositionValue(null);
+        onChange(next);
+      }}
+      onCompositionStart={(event) => {
+        composing.current = true;
+        justCommitted.current = null;
+        setCompositionValue(event.currentTarget.value);
+      }}
+      onCompositionEnd={(event) => {
+        composing.current = false;
+        justCommitted.current = event.currentTarget.value;
+        setCompositionValue(event.currentTarget.value);
+        onChange(event.currentTarget.value);
+      }}
+      placeholder="見出し語・読み方・タグ・意味・例文で検索"
+      className="min-h-12 w-full rounded-pill border border-line bg-card px-5 text-sm text-ink placeholder:text-muted"
+    />
+  );
+}

--- a/src/components/practice/PracticeSetup.tsx
+++ b/src/components/practice/PracticeSetup.tsx
@@ -81,6 +81,7 @@ export function PracticeSetup({
     onChange({ ...filters, [key]: value });
 
   const active = activeQuickRange(filters, now);
+  const selectedHiddenTags = filters.tags.filter((tag) => !allTags.includes(tag));
 
   // A quick range clears any end the learner had set: 「直近1ヶ月」 means
   // "since that day", and leaving an old end in place would silently produce a
@@ -119,9 +120,25 @@ export function PracticeSetup({
         </div>
       )}
 
-      {allTags.length > 0 && (
+      {(selectedHiddenTags.length > 0 || allTags.length > 0) && (
         <div className="space-y-1.5">
           <p className="text-[11px] text-muted">タグ</p>
+          {selectedHiddenTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-[11px] text-muted">選択中</span>
+              {selectedHiddenTags.map((tag) => (
+                <button
+                  key={tag}
+                  type="button"
+                  aria-pressed="true"
+                  onClick={() => update('tags', toggle(filters.tags, tag))}
+                  className={chipClass(true)}
+                >
+                  #{tag}
+                </button>
+              ))}
+            </div>
+          )}
           <div className="flex flex-wrap gap-1.5">
             {allTags.map((tag) => (
               <button

--- a/src/lib/tags.ts
+++ b/src/lib/tags.ts
@@ -1,0 +1,20 @@
+import type { Entry } from '@/domain/entry';
+
+/** Unique tags from the most recently created entries, newest first. */
+export function recentTags(entries: Entry[], limit = 10): string[] {
+  if (limit <= 0) return [];
+
+  const tags = new Set<string>();
+  const newest = [...entries].sort(
+    (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id),
+  );
+
+  for (const entry of newest) {
+    for (const tag of entry.tags) {
+      tags.add(tag);
+      if (tags.size === limit) return [...tags];
+    }
+  }
+
+  return [...tags];
+}

--- a/src/routes/Browse.tsx
+++ b/src/routes/Browse.tsx
@@ -12,6 +12,7 @@ import {
   toSearchParams,
 } from '@/lib/filters';
 import type { Filters } from '@/lib/filters';
+import { recentTags } from '@/lib/tags';
 
 export function Component() {
   const { entries, loading, error } = useEntries();
@@ -20,11 +21,7 @@ export function Component() {
   const filters = useMemo(() => fromSearchParams(searchParams), [searchParams]);
   const update = (next: Filters) => setSearchParams(toSearchParams(next), { replace: true });
 
-  const allTags = useMemo(
-    () =>
-      [...new Set(entries.flatMap((entry) => entry.tags))].sort((a, b) => a.localeCompare(b, 'ja')),
-    [entries],
-  );
+  const visibleTags = useMemo(() => recentTags(entries), [entries]);
 
   const results = useMemo(
     () =>
@@ -50,7 +47,7 @@ export function Component() {
         className="min-h-12 w-full rounded-pill border border-line bg-card px-5 text-sm text-ink placeholder:text-muted"
       />
 
-      <FilterPanel filters={filters} allTags={allTags} onChange={update} />
+      <FilterPanel filters={filters} allTags={visibleTags} onChange={update} />
 
       {!isDefault(filters) && (
         <div className="flex flex-wrap items-center gap-1.5">

--- a/src/routes/Browse.tsx
+++ b/src/routes/Browse.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { EntryCard } from '@/components/browse/EntryCard';
 import { FilterPanel } from '@/components/browse/FilterPanel';
+import { VocabularySearch } from '@/components/browse/VocabularySearch';
 import { useEntries } from '@/lib/entries';
 import {
   EMPTY_FILTERS,
@@ -39,13 +40,7 @@ export function Component() {
 
   return (
     <div className="space-y-4">
-      <input
-        type="search"
-        value={filters.q}
-        onChange={(event) => update({ ...filters, q: event.target.value })}
-        placeholder="見出し語・読み方・タグ・意味・例文で検索"
-        className="min-h-12 w-full rounded-pill border border-line bg-card px-5 text-sm text-ink placeholder:text-muted"
-      />
+      <VocabularySearch value={filters.q} onChange={(q) => update({ ...filters, q })} />
 
       <FilterPanel filters={filters} allTags={visibleTags} onChange={update} />
 

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/lib/practice';
 import type { Answer, PracticeFilters } from '@/lib/practice';
 import { useProgress } from '@/lib/progress';
+import { recentTags } from '@/lib/tags';
 import { membersOf } from '@/lib/wordSetMembers';
 import { useWordSets } from '@/lib/wordSets';
 
@@ -94,11 +95,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
   // re-render happened to cross midnight.
   const now = useMemo(() => new Date(), []);
 
-  const allTags = useMemo(
-    () =>
-      [...new Set(entries.flatMap((entry) => entry.tags))].sort((a, b) => a.localeCompare(b, 'ja')),
-    [entries],
-  );
+  const visibleTags = useMemo(() => recentTags(entries), [entries]);
 
   /**
    * Counted over the entries in hand, not over progress rows. A word answered
@@ -216,7 +213,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
       <PracticeSetup
         mode={mode}
         filters={filters}
-        allTags={allTags}
+        allTags={visibleTags}
         allSets={setChips}
         now={now}
         matchCount={matches.length}

--- a/tests/component/VocabularySearch.test.tsx
+++ b/tests/component/VocabularySearch.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { VocabularySearch } from '@/components/browse/VocabularySearch';
+
+const placeholder = '見出し語・読み方・タグ・意味・例文で検索';
+
+function setup() {
+  const searched = vi.fn();
+
+  function Harness() {
+    const [value, setValue] = useState('');
+    return (
+      <VocabularySearch
+        value={value}
+        onChange={(next) => {
+          searched(next);
+          setValue(next);
+        }}
+      />
+    );
+  }
+
+  render(<Harness />);
+  return { input: screen.getByPlaceholderText(placeholder), searched };
+}
+
+describe('VocabularySearch — IME composition', () => {
+  it.each([
+    { name: 'Cangjie', interim: ['十', '十一', '十一尸', '十一尸人'], final: '家' },
+    { name: 'Romaji', interim: ['h', 'hi', 'ひ'], final: '久' },
+  ])('waits for $name to choose the character before searching', ({ interim, final }) => {
+    const { input, searched } = setup();
+
+    fireEvent.compositionStart(input);
+    for (const value of interim) fireEvent.change(input, { target: { value } });
+    expect(searched).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: final } });
+    fireEvent.compositionEnd(input);
+
+    expect(searched).toHaveBeenCalledOnce();
+    expect(searched).toHaveBeenCalledWith(final);
+    expect(input).toHaveValue(final);
+  });
+
+  it('searches ordinary non-IME input immediately', () => {
+    const { input, searched } = setup();
+
+    fireEvent.change(input, { target: { value: 'manifest' } });
+
+    expect(searched).toHaveBeenCalledWith('manifest');
+  });
+});

--- a/tests/component/VocabularySearch.test.tsx
+++ b/tests/component/VocabularySearch.test.tsx
@@ -44,6 +44,24 @@ describe('VocabularySearch — IME composition', () => {
     expect(input).toHaveValue(final);
   });
 
+  it('deduplicates a final change after compositionend without swallowing later input', () => {
+    const { input, searched } = setup();
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'か' } });
+    fireEvent.compositionEnd(input, { target: { value: '家' } });
+    // Some browsers emit the committed value as a final input event after
+    // compositionend. It is the same edit, not a second search navigation.
+    fireEvent.change(input, { target: { value: '家' } });
+
+    expect(searched).toHaveBeenCalledTimes(1);
+    expect(searched).toHaveBeenLastCalledWith('家');
+
+    fireEvent.change(input, { target: { value: '家族' } });
+    expect(searched).toHaveBeenCalledTimes(2);
+    expect(searched).toHaveBeenLastCalledWith('家族');
+  });
+
   it('searches ordinary non-IME input immediately', () => {
     const { input, searched } = setup();
 

--- a/tests/e2e/practice.spec.ts
+++ b/tests/e2e/practice.spec.ts
@@ -156,6 +156,27 @@ test.describe('dictation', () => {
 });
 
 test.describe('the practice setup screen', () => {
+  test('shows and can clear an older tag selected from the URL', async ({ page }) => {
+    const entries = Array.from({ length: 11 }, (_, index) => ({
+      ...WORDS[0],
+      id: `tagged-${index}`,
+      headword: `語${index}`,
+      tags: [index === 0 ? '古いタグ' : `タグ${index}`],
+      createdAt: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
+    }));
+    await seed(page, { signedIn: true, entries });
+
+    await page.goto('/practice/flashcards?tag=' + encodeURIComponent('古いタグ'));
+
+    const selected = page.getByRole('button', { name: '#古いタグ' });
+    await expect(selected).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByText('1 件が対象')).toBeVisible();
+
+    await selected.click();
+    await expect(selected).toBeHidden();
+    await expect(page.getByText('11 件が対象')).toBeVisible();
+  });
+
   test('offers 苦手のみ against the words already recorded wrong', async ({ page }) => {
     await seed(page, { signedIn: true, entries: WORDS, weak: ['w-choukou'] });
     await page.goto('/practice/flashcards');

--- a/tests/unit/tags.test.ts
+++ b/tests/unit/tags.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { recentTags } from '@/lib/tags';
+import { makeEntry } from '../fixtures/entry';
+
+describe('recentTags', () => {
+  it('returns at most ten unique tags from the newest entries', () => {
+    const entries = Array.from({ length: 12 }, (_, index) =>
+      makeEntry({
+        id: `e-${index}`,
+        tags: [`tag-${index}`, 'shared'],
+        createdAt: new Date(Date.UTC(2026, 0, index + 1)).toISOString(),
+      }),
+    );
+
+    expect(recentTags(entries)).toEqual([
+      'tag-11',
+      'shared',
+      'tag-10',
+      'tag-9',
+      'tag-8',
+      'tag-7',
+      'tag-6',
+      'tag-5',
+      'tag-4',
+      'tag-3',
+    ]);
+  });
+
+  it('uses createdAt rather than the input or learning-date order', () => {
+    const older = makeEntry({
+      id: 'older',
+      tags: ['older'],
+      learnedOn: '2026-12-31',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+    const newer = makeEntry({
+      id: 'newer',
+      tags: ['newer'],
+      learnedOn: '2025-01-01',
+      createdAt: '2026-02-01T00:00:00.000Z',
+    });
+
+    expect(recentTags([older, newer])).toEqual(['newer', 'older']);
+  });
+});


### PR DESCRIPTION
### 概要

[N/A]
Limit visible vocabulary filters to recent tags and make vocabulary search compatible with IME composition.

### 変更内容

- Show at most 10 unique tags from the most recently created entries on the vocabulary, flashcard, and dictation setup screens.
- Keep all entry tags searchable through the vocabulary search field.
- Buffer Cangjie and Romaji composition locally and update the URL only after the IME commits the selected character.
- Add regression coverage for recent-tag ordering and Chinese/Japanese IME input.

### テスト方法

1. Open the vocabulary screen and confirm that no more than 10 recent tag chips are shown.
2. Confirm that older tags remain searchable.
3. Enter Chinese with Cangjie and Japanese with Romaji, then confirm that only the selected character updates the search.
4. Open flashcard and dictation setup and confirm that they show the same recent tags.

**Unit / integration tests:**

- Commands: `yarn test:unit`, `yarn typecheck`, `yarn lint`, `yarn format:check`, `yarn build`