### PR TITLE
docs: say what the code does, where a comment said otherwise

### DIFF
--- a/src/infra/firebase/client.ts
+++ b/src/infra/firebase/client.ts
@@ -48,9 +48,30 @@ export const app = initializeApp(config);
  * with no error pointing at it. Absent key means absent App Check, and the
  * console reports the state either way.
  *
- * Enforcement is a separate switch in the Firebase console and should stay off
- * until its metrics show real traffic attesting successfully. Shipping the
- * client first is what produces those metrics.
+ * **Enforcement is a separate switch in the Firebase console, and production
+ * was enforced from its first deploy.** The usual advice — ship the client,
+ * watch the metrics, enforce once real traffic is attesting successfully — was
+ * not available here, and not by oversight: the production project had never
+ * served a request, so the metrics it asks you to read were empty. Waiting
+ * would have meant waiting for traffic that only arrives once the operator
+ * signs in, which is the same event enforcement is being judged on.
+ *
+ * The cost of that order is worth stating, because whoever hits it will not
+ * recognise it. A client whose App Check token is refused is denied at
+ * Firestore, so the failure arrives as `permission-denied` on every read — and
+ * `loadError.ts` renders that as 「アクセスが許可されていません」, which points
+ * at the claim gate. The gate will be innocent.
+ *
+ * Telling them apart, and the rollback:
+ *
+ * 1. Open the browser console. An App Check failure logs a warning prefixed
+ *    `@firebase/app-check`; a missing claim logs nothing.
+ * 2. If it is App Check, turn enforcement off in the console. It takes effect
+ *    within minutes and needs no deploy.
+ * 3. The App Check metrics page then has what it never had: real requests,
+ *    split into verified and unverified, with a reason against each.
+ *
+ * Enforce again from that page, not from this comment.
  *
  * **v3, not Enterprise**, and that is a plan constraint rather than a
  * preference: reCAPTCHA Enterprise is a Cloud product and its API cannot be

--- a/src/lib/accountData.ts
+++ b/src/lib/accountData.ts
@@ -121,11 +121,22 @@ export function exportFilename(now = new Date()): string {
 /**
  * Delete everything this account owns, one document at a time, then the account.
  *
- * **Firestore does not cascade.** Deleting `users/{uid}` leaves every
- * subcollection under it addressable, so the only correct order is bottom-up:
- * the rows first, the parent last. Nothing here is atomic — a failure part way
- * leaves the account partly emptied, which is why it reports what it removed
- * and asks the user to run it again rather than claiming success.
+ * **Firestore does not cascade**, and this function deliberately does not
+ * delete `users/{uid}`, because that document does not exist. Nothing writes
+ * it: the three adapters address subcollections only, `UserRepository` has no
+ * adapter, and `firestore.rules` allows the client `read, delete` on the path
+ * and nothing else — so there is no code path, here or in `migration/`, that
+ * could bring one into being. Deleting a document that was never created is a
+ * write billed for nothing.
+ *
+ * That is an invariant, not an observation, and it is the reason there is no
+ * parent step below. If a profile is ever added, `create, update` come back to
+ * that rule — and this function grows a last step, after the rows, because a
+ * parent removed first leaves every subcollection under it addressable.
+ *
+ * Nothing here is atomic. A failure part way leaves the account partly emptied,
+ * which is why it reports what it removed and asks the user to run it again
+ * rather than claiming success.
  *
  * **All four collections, and the account.** An earlier version drained words
  * and word sets and stopped, while the button, the dialog and the privacy


### PR DESCRIPTION
### Summary

Two comments described behaviour the code does not have. A pre-production review
found them alongside a third, and this closes the two that live on `develop`.

Neither is a code change. Both are the kind of drift that costs someone an
afternoon: a comment is the only account of *why*, so a wrong one is worse than
none — the reader trusts it and stops looking.

### `src/infra/firebase/client.ts`

Said enforcement "should stay off until its metrics show real traffic attesting
successfully". Production was enforced from its first deploy instead.

That was not an oversight, and the comment should say why: the project had never
served a request, so the metrics it points at were empty. The traffic that would
fill them only arrives when the operator signs in, which is the same event
enforcement is being judged on. There was nothing to watch and no way to get
something to watch without enforcing or deciding not to.

The comment now also records the consequence, because whoever meets it will not
recognise it. A refused App Check token denies at Firestore, so it arrives as
`permission-denied` on every read — and `loadError.ts` renders that as
「アクセスが許可されていません」, which points at the claim gate. The gate will
be innocent. The console tells them apart: App Check logs a warning prefixed
`@firebase/app-check`, a missing claim logs nothing. Enforcement is a console
switch, so backing it out takes minutes and no deploy.

### `src/lib/accountData.ts`

Said the correct order is "the rows first, the parent last". `deleteEverything`
drains word sets, entries and progress, then deletes the Auth account. It never
deletes `users/{uid}`.

That is correct, and the comment now says so as an invariant rather than
describing a step that is not there. Verified rather than assumed:

- Every `doc(db, 'users', uid, …)` in `src/infra/firebase` names a subcollection
  segment — `entries`, `wordSets`, `progress`. None addresses the parent.
- `UserRepository` is declared in `src/domain/ports.ts` and has no adapter.
- `firestore.rules` allows the client `read, delete` on `users/{uid}` and
  nothing else, so no client write could create one either.

So the document cannot exist, and deleting it would be a write billed for
nothing. The comment states what would have to change — a profile arrives,
`create, update` come back to that rule, and a last step appears here — so the
next person adding one is told rather than left to find out.

### Not in this pull request

A third drift is in `firestore.rules`: the `validSession` comment claims `mode`
is "one of four words", while `PRACTICE_MODES` in `src/domain/practice.ts:3` has
two, and the rule bounds the string's length without checking the enum at all.

It cannot be fixed here. That comment arrived with the release branch and is not
on `develop`, so editing it here would be editing text that does not exist.
It follows the back-merge.

### Testing

No layer, deliberately — there is nothing here a test could observe. Both files
are comment-only; `git diff --stat` is 40 insertions and 8 deletions, all inside
block comments.

Run anyway, to show nothing moved:

- `yarn typecheck` — passes
- `yarn test:unit` — 579 passed, 37 files
- `prettier --write` on both files — unchanged