### PR TITLE
docs(rules): say why `mode` is bounded by length and not by value

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -284,9 +284,22 @@ service cloud.firestore {
         && d.get('correct', 0) is int && d.get('correct', 0) >= 0
         && d.get('correct', 0) <= d.get('total', 0)
         && list(d.get('missed', []), 2000)
-        // Same again. `mode` is one of four words and `startedAt` is an ISO
-        // instant the client sends; `finishedAt` comes from the server clock and
-        // is a timestamp or it is not this document.
+        // Same again, and `mode` is bounded by length rather than by value on
+        // purpose. `PRACTICE_MODES` in `src/domain/practice.ts` holds two words
+        // today, and an earlier version of this comment said four — but writing
+        // either number here couples a rules deploy to a client deploy: adding
+        // a third mode would ship a client whose every session write is refused
+        // until the rules follow, and the two go out through separate jobs.
+        //
+        // What rules are for is the megabyte, and 20 characters is the megabyte.
+        // A wrong-but-short `mode` is left to the client, which handles it the
+        // way it must anyway: `MODE_LABEL` is keyed by `PracticeMode`, so a mode
+        // it has never heard of yields `undefined` and renders as a blank label
+        // rather than throwing. Not good, and not a rules problem — a document
+        // written by a newer client reaches an older one the same way.
+        //
+        // `startedAt` is an ISO instant the client sends; `finishedAt` comes
+        // from the server clock and is a timestamp or it is not this document.
         && str(d.get('mode', ''), 20)
         && str(d.get('startedAt', ''), 40)
         && d.finishedAt is timestamp;


### PR DESCRIPTION
### Summary

The third of the three description drifts a pre-production review found. The
other two were fixed in #41; this one lives in a comment that only reached
`develop` with the 0.1.0 back-merge, so it could not be touched until now.

### What was wrong

`validSession` said:

> `mode` is one of four words

`PRACTICE_MODES` in `src/domain/practice.ts` has two — `flashcard` and
`dictation`. The rule itself checks neither number: it is `str(d.get('mode', ''), 20)`,
a length bound.

### Why the fix is not "check the enum"

Correcting four to two would have left the more misleading half standing — a
comment describing a value check next to a rule that does not perform one. And
performing one is the wrong move here, not a missing one:

**Naming the values in rules couples a rules deploy to a client deploy.** Adding
a third mode would ship a client whose every session write is refused until the
rules catch up, and the two go out through separate jobs. That is a release
sequencing problem bought in exchange for rejecting a short string.

What rules exist to stop is the megabyte, and 20 characters is the megabyte.

### Where an unrecognised mode actually lands

Stated in the comment rather than left implied, and verified rather than
assumed: `MODE_LABEL` is a `Record<PracticeMode, string>`, so indexing it with a
mode the client has never heard of yields `undefined`, which React renders as
nothing. A blank label, not a throw.

That is not good, and it is not a rules problem — the same thing happens when a
document written by a newer client is read by an older one, which no rule can
prevent.

### Testing

Comment-only, so there is nothing here a test can observe, and no assertion
would have been red before it.

`yarn test:emulator` — 4 files, 72 passed. Unchanged, which is the point: a
change to this file that moved a number would not have been comment-only.