### PR TITLE
ci: verify preview sign-in, and delete the channel when the pull request closes

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -119,12 +119,6 @@ jobs:
       id-token: write
       pull-requests: write
 
-    # Consumed by `authorize`, which deliberately checks out nothing and so has
-    # no other way to learn either fact.
-    outputs:
-      configured: ${{ steps.gate.outputs.configured }}
-      preview-url: ${{ steps.preview.outputs.url }}
-
     steps:
       # Until the federation provider exists there is nothing to deploy to, and
       # failing every pull request over a setup step nobody has done yet trains
@@ -168,10 +162,15 @@ jobs:
           path: dist
 
       - uses: google-github-actions/auth@v3
+        id: auth
         if: steps.gate.outputs.configured == 'true'
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          # firebase-tools finds the credentials file on its own. The bearer
+          # token is for the verification step at the end, which talks to the
+          # Identity Toolkit admin API over plain HTTP.
+          token_format: access_token
 
       # Hosting and rules together, and only from develop. `--project dev` is
       # the .firebaserc alias for goitei-dev; prod is not reachable from this
@@ -206,86 +205,45 @@ jobs:
             > body.md
           gh pr comment "$PR" --body-file body.md --edit-last --create-if-none
 
-  # Google sign-in refuses an origin that is not on Firebase Auth's authorized
-  # domain list, and a preview channel's hostname carries a hash that is
-  # generated per channel — so every pull request lands on a domain nobody has
-  # ever seen before. The list takes no wildcard, which leaves three options:
-  # add each one by hand, ship previews that cannot sign in, or do this.
-  #
-  # The alternative worth naming, because it looks cheaper than it is: build
-  # previews with `yarn build:e2e`, whose in-memory adapters sign a user in
-  # without Google at all. That trades away the thing a preview is for. The
-  # comment below promises real goitei-dev data, and a Firestore query, index
-  # or cursor defect — the class of bug that has actually reached review here —
-  # is invisible against fakes.
-  #
-  # Runs as its own job rather than a step in `deploy` because of `concurrency`
-  # below, and takes the opportunity to check out nothing at all: it needs a
-  # token, `curl` and `jq`, none of which come from this repository.
-  authorize:
-    needs: deploy
-    if: github.event_name == 'pull_request' && needs.deploy.outputs.configured == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-
-    # The API offers no etag and no atomic append, so the update is
-    # read-modify-write and two pull requests deploying at once would leave one
-    # of the two domains off the list. The group is deliberately repository-wide
-    # rather than per pull request — serialising against *other* pull requests
-    # is the entire point — and `cancel-in-progress` stays false, because a
-    # cancelled write here is a preview that cannot sign in.
-    #
-    # False is not sufficient on its own, and the step below is shaped by why.
-    # A concurrency group holds one running job and one *pending* job; a third
-    # arrival evicts the pending one. `cancel-in-progress: false` protects the
-    # job that is running, never the one queued behind it, so three overlapping
-    # previews cancel the middle one's authorization outright — its channel is
-    # deployed and commented on the pull request, and sign-in there is broken
-    # for the week the channel lives. GitHub offers no deeper queue to ask for.
-    # So the step reconciles every live channel rather than appending its own
-    # hostname, and whichever job survives repairs what the evicted one never
-    # got to write.
-    #
-    # `preview-cleanup.yml` names the same group, so a prune cannot interleave
-    # with an append either.
-    concurrency:
-      group: firebase-auth-authorized-domains
-      cancel-in-progress: false
-
-    steps:
-      - uses: google-github-actions/auth@v3
-        id: auth
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
-          # `deploy` takes the credentials file and lets firebase-tools find it.
-          # This job talks to the Identity Toolkit admin API over plain HTTP, so
-          # it asks for the bearer token directly.
-          token_format: access_token
-
-      - name: Authorize the live preview domains for Google sign-in
+      # Google sign-in refuses an origin that is not on Firebase Auth's
+      # authorized domain list, and a channel's hostname carries a hash
+      # generated per channel, so every preview lands on a domain nobody has
+      # ever seen. `firebase hosting:channel:deploy` adds it to the list itself
+      # — `--no-authorized-domains` turns that off, and the step above does not
+      # pass it — and prunes the `goitei-dev--` domains no live channel claims
+      # while it is there.
+      #
+      # That call is also why previews could not sign in for weeks without
+      # anyone finding out. It needs `roles/firebaseauth.admin`, the service
+      # account did not have it, and firebase-tools answers a failure here with
+      # a warning and a successful deploy. `--json` above suppresses even the
+      # warning. The preview deployed, the comment below promised a working
+      # preview, and sign-in was broken on it for the seven days it lived.
+      #
+      # So this asks the question the deploy will not. Two things put the
+      # hostname back out of the list, and neither shows up as a failure:
+      # the role being revoked, and a concurrent channel deploy — the CLI reads
+      # the list, appends to it and writes it back, and the admin API offers no
+      # etag between the read and the write, so the later writer drops the
+      # earlier one's domain.
+      #
+      # Read-only, runs after the comment so a reviewer still gets the link,
+      # and a re-run of the job is the fix in both cases.
+      - name: Verify the preview domain is authorized for Google sign-in
+        if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
         env:
           TOKEN: ${{ steps.auth.outputs.access_token }}
-          URL: ${{ needs.deploy.outputs.preview-url }}
-          # The .firebaserc `dev` alias, spelled out because this job checks out
-          # no repository to read it from. The default Hosting site id is the
-          # project id, which is why one value serves as both.
+          URL: ${{ steps.preview.outputs.url }}
+          # The .firebaserc `dev` alias, spelled out: this reads the project's
+          # auth config rather than deploying to it, and takes no alias.
           PROJECT: goitei-dev
-          SITE: goitei-dev
-          # Firebase names a channel URL `<site>--<channel>-<hash>.web.app`.
-          # Only a domain carrying this prefix is a preview: the list also holds
-          # `localhost`, the two permanent Firebase domains and any custom one,
-          # and none of those are this job's business.
-          PREFIX: goitei-dev--
         run: |
           set -euo pipefail
 
           host=${URL#https://}
           host=${host%%/*}
           if [ -z "$host" ]; then
-            echo "::error::No preview URL to authorize."
+            echo "::error::No preview URL to check."
             exit 1
           fi
 
@@ -298,55 +256,17 @@ jobs:
           # API. The body is echoed on its own line rather than interpolated
           # into the `::error::`, because a workflow annotation keeps only its
           # first line and these responses are multi-line JSON.
-          #
-          # Every live preview channel is read, not just this pull request's,
-          # for the reason `concurrency` above gives: a job evicted from the
-          # queue never ran and nothing retries it, so the next append is the
-          # only thing that can repair the list.
-          channels="https://firebasehosting.googleapis.com/v1beta1/projects/$PROJECT/sites/$SITE/channels?pageSize=100"
-          if ! listed=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$channels"); then
-            echo "$listed"
-            echo "::error::Could not list the preview channels for $SITE. See the response above."
-            exit 1
-          fi
-          live=$(jq -c '[.channels[]?.url // empty | sub("^https?://"; "") | sub("/.*$"; "")]' <<<"$listed")
-          echo "Live preview channels: $live"
-
           api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
-
           if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
             echo "$config"
             echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
             exit 1
           fi
-          domains=$(jq -c '.authorizedDomains // []' <<<"$config")
 
-          # Additive on purpose. Taking a domain off is `preview-cleanup.yml`'s
-          # job, and doing it from here would mean deciding mid-deploy that
-          # another pull request's preview is dead — off one list read, while
-          # that pull request's own deploy may be seconds behind this one.
-          #
-          # This pull request's hostname is added whether or not the channel
-          # list mentions it: it comes from the deploy that just finished, so it
-          # is the one hostname here that cannot be stale.
-          add=$(jq -c --argjson live "$live" --arg h "$host" --arg p "$PREFIX" \
-            '. as $have | (($live | map(select(startswith($p)))) + [$h] | unique) - $have' <<<"$domains")
-
-          # Re-running a deploy on the same pull request reuses the channel and
-          # therefore the hostname, so nothing to add is the common case.
-          if [ "$add" = '[]' ]; then
-            echo "::notice::$host and every other live preview are already authorized."
+          if jq -e --arg h "$host" '.authorizedDomains // [] | index($h)' <<<"$config" >/dev/null; then
+            echo "::notice::$host is authorized for Google sign-in."
             exit 0
           fi
 
-          if ! updated=$(curl -sS --fail-with-body -X PATCH \
-            -H "Authorization: Bearer $TOKEN" \
-            -H 'Content-Type: application/json' \
-            "$api?updateMask=authorizedDomains" \
-            -d "$(jq -c --argjson add "$add" '{authorizedDomains: (. + $add)}' <<<"$domains")"); then
-            echo "$updated"
-            echo "::error::Could not add $(jq -r 'join(", ")' <<<"$add") to the authorized domains. See the response above."
-            exit 1
-          fi
-
-          echo "::notice::Authorized $(jq -r 'join(", ")' <<<"$add") for Google sign-in."
+          echo "::error::$host was deployed but is not on the Firebase Auth authorized domain list, so Google sign-in will fail on this preview. Check that the deploy service account still holds roles/firebaseauth.admin, then re-run this job. See README → Preview sign-in."
+          exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -237,6 +237,17 @@ jobs:
     # is the entire point — and `cancel-in-progress` stays false, because a
     # cancelled write here is a preview that cannot sign in.
     #
+    # False is not sufficient on its own, and the step below is shaped by why.
+    # A concurrency group holds one running job and one *pending* job; a third
+    # arrival evicts the pending one. `cancel-in-progress: false` protects the
+    # job that is running, never the one queued behind it, so three overlapping
+    # previews cancel the middle one's authorization outright — its channel is
+    # deployed and commented on the pull request, and sign-in there is broken
+    # for the week the channel lives. GitHub offers no deeper queue to ask for.
+    # So the step reconciles every live channel rather than appending its own
+    # hostname, and whichever job survives repairs what the evicted one never
+    # got to write.
+    #
     # `preview-cleanup.yml` names the same group, so a prune cannot interleave
     # with an append either.
     concurrency:
@@ -254,13 +265,20 @@ jobs:
           # it asks for the bearer token directly.
           token_format: access_token
 
-      - name: Authorize the preview domain for Google sign-in
+      - name: Authorize the live preview domains for Google sign-in
         env:
           TOKEN: ${{ steps.auth.outputs.access_token }}
           URL: ${{ needs.deploy.outputs.preview-url }}
           # The .firebaserc `dev` alias, spelled out because this job checks out
-          # no repository to read it from.
+          # no repository to read it from. The default Hosting site id is the
+          # project id, which is why one value serves as both.
           PROJECT: goitei-dev
+          SITE: goitei-dev
+          # Firebase names a channel URL `<site>--<channel>-<hash>.web.app`.
+          # Only a domain carrying this prefix is a preview: the list also holds
+          # `localhost`, the two permanent Firebase domains and any custom one,
+          # and none of those are this job's business.
+          PREFIX: goitei-dev--
         run: |
           set -euo pipefail
 
@@ -271,8 +289,6 @@ jobs:
             exit 1
           fi
 
-          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
-
           # `--fail-with-body` writes the API's own explanation to stdout before
           # exiting non-zero, and capturing it is what makes that worth having:
           # piping it into `jq` or to /dev/null hands the explanation to
@@ -282,6 +298,22 @@ jobs:
           # API. The body is echoed on its own line rather than interpolated
           # into the `::error::`, because a workflow annotation keeps only its
           # first line and these responses are multi-line JSON.
+          #
+          # Every live preview channel is read, not just this pull request's,
+          # for the reason `concurrency` above gives: a job evicted from the
+          # queue never ran and nothing retries it, so the next append is the
+          # only thing that can repair the list.
+          channels="https://firebasehosting.googleapis.com/v1beta1/projects/$PROJECT/sites/$SITE/channels?pageSize=100"
+          if ! listed=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$channels"); then
+            echo "$listed"
+            echo "::error::Could not list the preview channels for $SITE. See the response above."
+            exit 1
+          fi
+          live=$(jq -c '[.channels[]?.url // empty | sub("^https?://"; "") | sub("/.*$"; "")]' <<<"$listed")
+          echo "Live preview channels: $live"
+
+          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
+
           if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
             echo "$config"
             echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
@@ -289,10 +321,21 @@ jobs:
           fi
           domains=$(jq -c '.authorizedDomains // []' <<<"$config")
 
+          # Additive on purpose. Taking a domain off is `preview-cleanup.yml`'s
+          # job, and doing it from here would mean deciding mid-deploy that
+          # another pull request's preview is dead — off one list read, while
+          # that pull request's own deploy may be seconds behind this one.
+          #
+          # This pull request's hostname is added whether or not the channel
+          # list mentions it: it comes from the deploy that just finished, so it
+          # is the one hostname here that cannot be stale.
+          add=$(jq -c --argjson live "$live" --arg h "$host" --arg p "$PREFIX" \
+            '. as $have | (($live | map(select(startswith($p)))) + [$h] | unique) - $have' <<<"$domains")
+
           # Re-running a deploy on the same pull request reuses the channel and
-          # therefore the hostname, so this is the common case, not the edge one.
-          if jq -e --arg h "$host" 'index($h)' <<<"$domains" >/dev/null; then
-            echo "::notice::$host is already authorized."
+          # therefore the hostname, so nothing to add is the common case.
+          if [ "$add" = '[]' ]; then
+            echo "::notice::$host and every other live preview are already authorized."
             exit 0
           fi
 
@@ -300,10 +343,10 @@ jobs:
             -H "Authorization: Bearer $TOKEN" \
             -H 'Content-Type: application/json' \
             "$api?updateMask=authorizedDomains" \
-            -d "$(jq -c --arg h "$host" '{authorizedDomains: (. + [$h])}' <<<"$domains")"); then
+            -d "$(jq -c --argjson add "$add" '{authorizedDomains: (. + $add)}' <<<"$domains")"); then
             echo "$updated"
-            echo "::error::Could not add $host to the authorized domains. See the response above."
+            echo "::error::Could not add $(jq -r 'join(", ")' <<<"$add") to the authorized domains. See the response above."
             exit 1
           fi
 
-          echo "::notice::Authorized $host for Google sign-in."
+          echo "::notice::Authorized $(jq -r 'join(", ")' <<<"$add") for Google sign-in."

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -272,8 +272,22 @@ jobs:
           fi
 
           api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
-          domains=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api" |
-            jq -c '.authorizedDomains // []')
+
+          # `--fail-with-body` writes the API's own explanation to stdout before
+          # exiting non-zero, and capturing it is what makes that worth having:
+          # piping it into `jq` or to /dev/null hands the explanation to
+          # something that discards it, and leaves the run log holding a bare
+          # `curl: (22) ... 403` that cannot tell a missing
+          # `roles/firebaseauth.admin` apart from a disabled Identity Toolkit
+          # API. The body is echoed on its own line rather than interpolated
+          # into the `::error::`, because a workflow annotation keeps only its
+          # first line and these responses are multi-line JSON.
+          if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
+            echo "$config"
+            echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
+            exit 1
+          fi
+          domains=$(jq -c '.authorizedDomains // []' <<<"$config")
 
           # Re-running a deploy on the same pull request reuses the channel and
           # therefore the hostname, so this is the common case, not the edge one.
@@ -282,11 +296,14 @@ jobs:
             exit 0
           fi
 
-          curl -sS --fail-with-body -X PATCH \
+          if ! updated=$(curl -sS --fail-with-body -X PATCH \
             -H "Authorization: Bearer $TOKEN" \
             -H 'Content-Type: application/json' \
             "$api?updateMask=authorizedDomains" \
-            -d "$(jq -c --arg h "$host" '{authorizedDomains: (. + [$h])}' <<<"$domains")" \
-            >/dev/null
+            -d "$(jq -c --arg h "$host" '{authorizedDomains: (. + [$h])}' <<<"$domains")"); then
+            echo "$updated"
+            echo "::error::Could not add $host to the authorized domains. See the response above."
+            exit 1
+          fi
 
           echo "::notice::Authorized $host for Google sign-in."

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -119,6 +119,12 @@ jobs:
       id-token: write
       pull-requests: write
 
+    # Consumed by `authorize`, which deliberately checks out nothing and so has
+    # no other way to learn either fact.
+    outputs:
+      configured: ${{ steps.gate.outputs.configured }}
+      preview-url: ${{ steps.preview.outputs.url }}
+
     steps:
       # Until the federation provider exists there is nothing to deploy to, and
       # failing every pull request over a setup step nobody has done yet trains
@@ -199,3 +205,88 @@ jobs:
             "Serves this branch against the **goitei-dev** Firestore — the same data as the dev site, not a copy. Expires in 7 days." \
             > body.md
           gh pr comment "$PR" --body-file body.md --edit-last --create-if-none
+
+  # Google sign-in refuses an origin that is not on Firebase Auth's authorized
+  # domain list, and a preview channel's hostname carries a hash that is
+  # generated per channel — so every pull request lands on a domain nobody has
+  # ever seen before. The list takes no wildcard, which leaves three options:
+  # add each one by hand, ship previews that cannot sign in, or do this.
+  #
+  # The alternative worth naming, because it looks cheaper than it is: build
+  # previews with `yarn build:e2e`, whose in-memory adapters sign a user in
+  # without Google at all. That trades away the thing a preview is for. The
+  # comment below promises real goitei-dev data, and a Firestore query, index
+  # or cursor defect — the class of bug that has actually reached review here —
+  # is invisible against fakes.
+  #
+  # Runs as its own job rather than a step in `deploy` because of `concurrency`
+  # below, and takes the opportunity to check out nothing at all: it needs a
+  # token, `curl` and `jq`, none of which come from this repository.
+  authorize:
+    needs: deploy
+    if: github.event_name == 'pull_request' && needs.deploy.outputs.configured == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    # The API offers no etag and no atomic append, so the update is
+    # read-modify-write and two pull requests deploying at once would leave one
+    # of the two domains off the list. The group is deliberately repository-wide
+    # rather than per pull request — serialising against *other* pull requests
+    # is the entire point — and `cancel-in-progress` stays false, because a
+    # cancelled write here is a preview that cannot sign in.
+    #
+    # `preview-cleanup.yml` names the same group, so a prune cannot interleave
+    # with an append either.
+    concurrency:
+      group: firebase-auth-authorized-domains
+      cancel-in-progress: false
+
+    steps:
+      - uses: google-github-actions/auth@v3
+        id: auth
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          # `deploy` takes the credentials file and lets firebase-tools find it.
+          # This job talks to the Identity Toolkit admin API over plain HTTP, so
+          # it asks for the bearer token directly.
+          token_format: access_token
+
+      - name: Authorize the preview domain for Google sign-in
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          URL: ${{ needs.deploy.outputs.preview-url }}
+          # The .firebaserc `dev` alias, spelled out because this job checks out
+          # no repository to read it from.
+          PROJECT: goitei-dev
+        run: |
+          set -euo pipefail
+
+          host=${URL#https://}
+          host=${host%%/*}
+          if [ -z "$host" ]; then
+            echo "::error::No preview URL to authorize."
+            exit 1
+          fi
+
+          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
+          domains=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api" |
+            jq -c '.authorizedDomains // []')
+
+          # Re-running a deploy on the same pull request reuses the channel and
+          # therefore the hostname, so this is the common case, not the edge one.
+          if jq -e --arg h "$host" 'index($h)' <<<"$domains" >/dev/null; then
+            echo "::notice::$host is already authorized."
+            exit 0
+          fi
+
+          curl -sS --fail-with-body -X PATCH \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            "$api?updateMask=authorizedDomains" \
+            -d "$(jq -c --arg h "$host" '{authorizedDomains: (. + [$h])}' <<<"$domains")" \
+            >/dev/null
+
+          echo "::notice::Authorized $host for Google sign-in."

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,44 +1,29 @@
 name: Preview cleanup
 
-# `deploy-dev.yml` appends a preview channel's hostname to Firebase Auth's
-# authorized domain list so Google sign-in works there. Nothing removes it, and
-# the list is finite and project-wide — every stale entry is an origin that
-# stays trusted for authentication long after the site behind it is gone.
+# A preview channel lives for seven days after its last deploy, and its hostname
+# sits on Firebase Auth's authorized domain list for as long as the channel
+# exists — an origin trusted for authentication, on a site nobody is reading any
+# more. Closing the pull request is the moment we know the preview is finished
+# with, so the channel goes then rather than a week later.
 #
-# The prune is a reconciliation rather than a delete of "the domain this pull
-# request added", and that is the whole design. A channel expires on its own
-# after seven days, so by the time a pull request closes its hostname may
-# already resolve to nothing and be unrecoverable from the API. Comparing the
-# full list against the live channels catches those too, and is idempotent, so
-# a missed run costs nothing but a day.
+# Taking the domain off the list is deliberately not this workflow's job.
+# `firebase hosting:channel:deploy` prunes every `goitei-dev--` domain with no
+# live channel behind it on each run, so deleting the channel here is what makes
+# the next preview deploy drop the domain. Reimplementing that prune would put a
+# second writer on a list whose API has no etag, which is a way to lose a domain
+# rather than a way to remove one.
 on:
   pull_request:
     types: [closed]
     branches-ignore: [main, 'release/**']
-  # Sweeps up channels that expired without their pull request ever closing.
-  # GitHub only schedules workflows from the default branch, so this stays inert
-  # until the file reaches it.
-  schedule:
-    - cron: '17 3 * * *'
-  workflow_dispatch:
 
 permissions:
   contents: read
 
-# The same group `deploy-dev.yml` serialises its append on: the Identity Toolkit
-# config has no etag, so a prune reading the list while a deploy is writing it
-# would drop the domain that deploy just added.
-concurrency:
-  group: firebase-auth-authorized-domains
-  cancel-in-progress: false
-
 jobs:
-  prune:
+  delete-channel:
     # A fork's pull request never got a preview, so it has nothing to clean up.
-    # `schedule` and `workflow_dispatch` carry no pull request at all.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,7 +47,7 @@ jobs:
       - uses: actions/checkout@v7
         if: steps.gate.outputs.configured == 'true'
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: actions/setup-node@v7
         if: steps.gate.outputs.configured == 'true'
@@ -70,33 +55,28 @@ jobs:
           node-version-file: .nvmrc
           cache: yarn
 
+      # Installed before authenticating, so even a trusted postinstall script
+      # runs with no credential in the environment.
       - name: Install firebase-tools
         if: steps.gate.outputs.configured == 'true'
         run: yarn install --frozen-lockfile
 
       - uses: google-github-actions/auth@v3
-        id: auth
         if: steps.gate.outputs.configured == 'true'
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
-          token_format: access_token
 
-      # Closing the pull request is what makes its channel dead; without this
-      # the reconciliation below would keep treating it as live until it expires.
-      #
-      # A channel that has already expired is the ordinary case, not a failure,
-      # and the delete has to tolerate it — but tolerating it by swallowing
-      # every non-zero exit swallows a 403, an expired token and a Hosting
-      # outage with it. The prune below would then read the channel as live,
-      # keep its authorized domain, and the run would go green having deleted
+      # A channel that has already expired is the ordinary case rather than a
+      # failure, and the delete has to tolerate it — but tolerating it by
+      # swallowing every non-zero exit swallows a 403, an expired token and a
+      # Hosting outage with it, and the run then goes green having deleted
       # nothing. So the list decides whether there is anything to delete, and
-      # the delete itself is allowed to fail the job, which makes it something
-      # a re-run can fix. `hosting:channel:list` is the same call the prune
-      # makes, so this costs one extra invocation and no new assumption about
-      # how the CLI words its errors.
+      # the delete itself is left to fail the job, which makes it something a
+      # re-run can fix. That also costs no assumption about how firebase-tools
+      # words its errors, which a release is free to change.
       - name: Delete this pull request's channel
-        if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
+        if: steps.gate.outputs.configured == 'true'
         env:
           PR: ${{ github.event.pull_request.number }}
         run: |
@@ -111,52 +91,3 @@ jobs:
 
           ./node_modules/.bin/firebase hosting:channel:delete "pr-$PR" \
             --project dev --force --non-interactive
-
-      - name: Prune authorized domains with no live channel
-        if: steps.gate.outputs.configured == 'true'
-        env:
-          TOKEN: ${{ steps.auth.outputs.access_token }}
-          PROJECT: goitei-dev
-          # Firebase names a channel URL `<site>--<channel>-<hash>.web.app`, and
-          # the default site id is the project id. Only domains carrying this
-          # prefix are ours to remove: the list also holds `localhost`, the two
-          # permanent Firebase domains and any custom domain.
-          PREFIX: goitei-dev--
-        run: |
-          set -euo pipefail
-
-          live=$(./node_modules/.bin/firebase hosting:channel:list --project dev --json |
-            jq -c '[.result.channels[]?.url | sub("^https?://"; "") | sub("/.*$"; "")]')
-          echo "Live preview channels: $live"
-
-          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
-
-          # Captured rather than piped, for the reason `deploy-dev.yml` gives at
-          # the same call: `--fail-with-body` only helps if something keeps the
-          # body.
-          if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
-            echo "$config"
-            echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
-            exit 1
-          fi
-          domains=$(jq -c '.authorizedDomains // []' <<<"$config")
-
-          keep=$(jq -c --argjson live "$live" --arg p "$PREFIX" \
-            '[.[] | select((startswith($p) | not) or (IN(.; $live[])))]' <<<"$domains")
-
-          if [ "$keep" = "$domains" ]; then
-            echo "::notice::Nothing to prune."
-            exit 0
-          fi
-
-          echo "Removing: $(jq -c --argjson keep "$keep" '. - $keep' <<<"$domains")"
-
-          if ! updated=$(curl -sS --fail-with-body -X PATCH \
-            -H "Authorization: Bearer $TOKEN" \
-            -H 'Content-Type: application/json' \
-            "$api?updateMask=authorizedDomains" \
-            -d "$(jq -c '{authorizedDomains: .}' <<<"$keep")"); then
-            echo "$updated"
-            echo "::error::Could not prune the authorized domains. See the response above."
-            exit 1
-          fi

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -111,8 +111,16 @@ jobs:
           echo "Live preview channels: $live"
 
           api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
-          domains=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api" |
-            jq -c '.authorizedDomains // []')
+
+          # Captured rather than piped, for the reason `deploy-dev.yml` gives at
+          # the same call: `--fail-with-body` only helps if something keeps the
+          # body.
+          if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
+            echo "$config"
+            echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
+            exit 1
+          fi
+          domains=$(jq -c '.authorizedDomains // []' <<<"$config")
 
           keep=$(jq -c --argjson live "$live" --arg p "$PREFIX" \
             '[.[] | select((startswith($p) | not) or (IN(.; $live[])))]' <<<"$domains")
@@ -124,9 +132,12 @@ jobs:
 
           echo "Removing: $(jq -c --argjson keep "$keep" '. - $keep' <<<"$domains")"
 
-          curl -sS --fail-with-body -X PATCH \
+          if ! updated=$(curl -sS --fail-with-body -X PATCH \
             -H "Authorization: Bearer $TOKEN" \
             -H 'Content-Type: application/json' \
             "$api?updateMask=authorizedDomains" \
-            -d "$(jq -c '{authorizedDomains: .}' <<<"$keep")" \
-            >/dev/null
+            -d "$(jq -c '{authorizedDomains: .}' <<<"$keep")"); then
+            echo "$updated"
+            echo "::error::Could not prune the authorized domains. See the response above."
+            exit 1
+          fi

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -6,12 +6,13 @@ name: Preview cleanup
 # more. Closing the pull request is the moment we know the preview is finished
 # with, so the channel goes then rather than a week later.
 #
-# Taking the domain off the list is deliberately not this workflow's job.
-# `firebase hosting:channel:deploy` prunes every `goitei-dev--` domain with no
-# live channel behind it on each run, so deleting the channel here is what makes
-# the next preview deploy drop the domain. Reimplementing that prune would put a
-# second writer on a list whose API has no etag, which is a way to lose a domain
-# rather than a way to remove one.
+# Taking the hostname off Firebase Auth's authorized domain list is part of
+# deleting the channel: `hosting:channel:delete` calls `removeAuthDomain` once
+# the channel is gone. This workflow does not write to that list itself, and
+# should not — a second writer on an API with no etag is a way to lose a domain
+# rather than a way to remove one. It reads the list back afterwards instead,
+# because the CLI answers a failed removal with a warning and a successful
+# delete.
 on:
   pull_request:
     types: [closed]
@@ -62,10 +63,15 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - uses: google-github-actions/auth@v3
+        id: auth
         if: steps.gate.outputs.configured == 'true'
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          # firebase-tools finds the credentials file on its own. The bearer
+          # token is for the verification step at the end, which talks to the
+          # Identity Toolkit admin API over plain HTTP.
+          token_format: access_token
 
       # A channel that has already expired is the ordinary case rather than a
       # failure, and the delete has to tolerate it — but tolerating it by
@@ -91,3 +97,56 @@ jobs:
 
           ./node_modules/.bin/firebase hosting:channel:delete "pr-$PR" \
             --project dev --force --non-interactive
+
+      # Deleting the channel is what takes its hostname off Firebase Auth's
+      # authorized domain list, and firebase-tools answers a failure there with
+      # a warning and a successful delete — the same shape that kept preview
+      # sign-in broken for weeks on the other side of this. The warning does
+      # reach this log, since the step above passes no `--json`, but a warning
+      # on a closed pull request is a thing nobody reads.
+      #
+      # It runs whether or not a channel was deleted, and that is the point: a
+      # re-run after a failed removal takes the "already expired" branch above,
+      # so a check that only ran after a delete would go green having repaired
+      # nothing.
+      #
+      # Nothing is repaired here on purpose, for the reason at the top of the
+      # file. The next preview deploy on any pull request prunes the hostname —
+      # `hosting:channel:deploy` drops every `goitei-dev--` domain no live
+      # channel claims — so this goes green on a re-run once that happens, or
+      # once somebody removes the entry in the console.
+      - name: Verify no domain is left authorized for this pull request
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          # The .firebaserc `dev` alias, spelled out: this reads the project's
+          # auth config rather than deploying to it, and takes no alias.
+          PROJECT: goitei-dev
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Captured rather than piped, for the reason `deploy-dev.yml` gives at
+          # the same call: `--fail-with-body` only helps if something keeps the
+          # body, and a 403 with no body cannot tell a missing
+          # `roles/firebaseauth.admin` apart from a disabled Identity Toolkit
+          # API.
+          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
+          if ! config=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api"); then
+            echo "$config"
+            echo "::error::Could not read the Firebase Auth config for $PROJECT. See the response above."
+            exit 1
+          fi
+
+          # The trailing hyphen is load-bearing: without it `pr-6` matches the
+          # hostname of `pr-60`.
+          left=$(jq -c --arg p "goitei-dev--pr-$PR-" \
+            '.authorizedDomains // [] | map(select(startswith($p)))' <<<"$config")
+
+          if [ "$left" = '[]' ]; then
+            echo "::notice::No authorized domain is left for pr-$PR."
+            exit 0
+          fi
+
+          echo "::error::$(jq -r 'join(", ")' <<<"$left") is still on the Firebase Auth authorized domain list with no channel behind it, so a dead hostname stays trusted for Google sign-in. Check that the deploy service account still holds roles/firebaseauth.admin. The next preview deploy prunes it; removing it in the console clears it now. See README → Preview sign-in."
+          exit 1

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,132 @@
+name: Preview cleanup
+
+# `deploy-dev.yml` appends a preview channel's hostname to Firebase Auth's
+# authorized domain list so Google sign-in works there. Nothing removes it, and
+# the list is finite and project-wide — every stale entry is an origin that
+# stays trusted for authentication long after the site behind it is gone.
+#
+# The prune is a reconciliation rather than a delete of "the domain this pull
+# request added", and that is the whole design. A channel expires on its own
+# after seven days, so by the time a pull request closes its hostname may
+# already resolve to nothing and be unrecoverable from the API. Comparing the
+# full list against the live channels catches those too, and is idempotent, so
+# a missed run costs nothing but a day.
+on:
+  pull_request:
+    types: [closed]
+    branches-ignore: [main, 'release/**']
+  # Sweeps up channels that expired without their pull request ever closing.
+  # GitHub only schedules workflows from the default branch, so this stays inert
+  # until the file reaches it.
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# The same group `deploy-dev.yml` serialises its append on: the Identity Toolkit
+# config has no etag, so a prune reading the list while a deploy is writing it
+# would drop the domain that deploy just added.
+concurrency:
+  group: firebase-auth-authorized-domains
+  cancel-in-progress: false
+
+jobs:
+  prune:
+    # A fork's pull request never got a preview, so it has nothing to clean up.
+    # `schedule` and `workflow_dispatch` carry no pull request at all.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check for deploy credentials
+        id: gate
+        env:
+          PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        run: |
+          if [ -n "$PROVIDER" ]; then
+            echo 'configured=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'configured=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::Cleanup skipped: GCP_WORKLOAD_IDENTITY_PROVIDER is not set. See README → Deploy credentials.'
+          fi
+
+      # The pull request's base, for the same reason `deploy-dev.yml` does it:
+      # this job holds a credential and must not run code from the branch.
+      - uses: actions/checkout@v7
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+
+      - uses: actions/setup-node@v7
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          node-version-file: .nvmrc
+          cache: yarn
+
+      - name: Install firebase-tools
+        if: steps.gate.outputs.configured == 'true'
+        run: yarn install --frozen-lockfile
+
+      - uses: google-github-actions/auth@v3
+        id: auth
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
+          token_format: access_token
+
+      # Closing the pull request is what makes its channel dead; without this
+      # the reconciliation below would keep treating it as live until it expires.
+      - name: Delete this pull request's channel
+        if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          ./node_modules/.bin/firebase hosting:channel:delete "pr-$PR" \
+            --project dev --force --non-interactive ||
+            echo "::notice::Channel pr-$PR was already gone."
+
+      - name: Prune authorized domains with no live channel
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          TOKEN: ${{ steps.auth.outputs.access_token }}
+          PROJECT: goitei-dev
+          # Firebase names a channel URL `<site>--<channel>-<hash>.web.app`, and
+          # the default site id is the project id. Only domains carrying this
+          # prefix are ours to remove: the list also holds `localhost`, the two
+          # permanent Firebase domains and any custom domain.
+          PREFIX: goitei-dev--
+        run: |
+          set -euo pipefail
+
+          live=$(./node_modules/.bin/firebase hosting:channel:list --project dev --json |
+            jq -c '[.result.channels[]?.url | sub("^https?://"; "") | sub("/.*$"; "")]')
+          echo "Live preview channels: $live"
+
+          api="https://identitytoolkit.googleapis.com/admin/v2/projects/$PROJECT/config"
+          domains=$(curl -sS --fail-with-body -H "Authorization: Bearer $TOKEN" "$api" |
+            jq -c '.authorizedDomains // []')
+
+          keep=$(jq -c --argjson live "$live" --arg p "$PREFIX" \
+            '[.[] | select((startswith($p) | not) or (IN(.; $live[])))]' <<<"$domains")
+
+          if [ "$keep" = "$domains" ]; then
+            echo "::notice::Nothing to prune."
+            exit 0
+          fi
+
+          echo "Removing: $(jq -c --argjson keep "$keep" '. - $keep' <<<"$domains")"
+
+          curl -sS --fail-with-body -X PATCH \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'Content-Type: application/json' \
+            "$api?updateMask=authorizedDomains" \
+            -d "$(jq -c '{authorizedDomains: .}' <<<"$keep")" \
+            >/dev/null

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -84,14 +84,33 @@ jobs:
 
       # Closing the pull request is what makes its channel dead; without this
       # the reconciliation below would keep treating it as live until it expires.
+      #
+      # A channel that has already expired is the ordinary case, not a failure,
+      # and the delete has to tolerate it — but tolerating it by swallowing
+      # every non-zero exit swallows a 403, an expired token and a Hosting
+      # outage with it. The prune below would then read the channel as live,
+      # keep its authorized domain, and the run would go green having deleted
+      # nothing. So the list decides whether there is anything to delete, and
+      # the delete itself is allowed to fail the job, which makes it something
+      # a re-run can fix. `hosting:channel:list` is the same call the prune
+      # makes, so this costs one extra invocation and no new assumption about
+      # how the CLI words its errors.
       - name: Delete this pull request's channel
         if: steps.gate.outputs.configured == 'true' && github.event_name == 'pull_request'
         env:
           PR: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
+
+          channels=$(./node_modules/.bin/firebase hosting:channel:list --project dev --json)
+          if ! jq -e --arg c "pr-$PR" \
+            'any(.result.channels[]?; (.name | split("/") | last) == $c)' <<<"$channels" >/dev/null; then
+            echo "::notice::Channel pr-$PR has already expired or been deleted."
+            exit 0
+          fi
+
           ./node_modules/.bin/firebase hosting:channel:delete "pr-$PR" \
-            --project dev --force --non-interactive ||
-            echo "::notice::Channel pr-$PR was already gone."
+            --project dev --force --non-interactive
 
       - name: Prune authorized domains with no live channel
         if: steps.gate.outputs.configured == 'true'

--- a/README.md
+++ b/README.md
@@ -302,27 +302,31 @@ A preview channel is served from `goitei-dev--pr-<n>-<hash>.web.app`, and
 Firebase Auth refuses to complete a Google sign-in from an origin that is not on
 its authorized domain list. The hash is generated per channel, so every pull
 request lands on a hostname nobody has authorized, and the list accepts no
-wildcard. The `authorize` job in `deploy-dev.yml` adds the hostname through the
-Identity Toolkit admin API once the channel exists.
+wildcard.
 
-It adds every live channel's hostname and not only its own, because the job that
-should have added one can be cancelled before it ever runs. A concurrency group
-holds one running job and one pending job, and a third arrival evicts the
-pending one — `cancel-in-progress: false` protects the job that is running, not
-the one queued behind it. Three overlapping previews therefore lose the middle
-one's authorization outright, on a channel that is deployed, linked from its
-pull request and alive for a week. Reading the live channel list makes the next
-append repair it.
+`firebase hosting:channel:deploy` handles both halves of that on its own. It
+adds the new channel's hostname to the list, and it prunes every `goitei-dev--`
+hostname no live channel claims, unless it is asked not to with
+`--no-authorized-domains`. Nothing in this repository reimplements either.
 
-`preview-cleanup.yml` takes them off again. It prunes by reconciliation —
-every authorized domain starting `goitei-dev--` that no live channel claims —
-rather than by removing the one domain a closing pull request added, because a
-channel expires after seven days on its own and its hostname is then
-unrecoverable. It runs on pull-request close and nightly.
+**It needs `roles/firebaseauth.admin` to do it, and says almost nothing when it
+cannot.** Without the role the call fails, firebase-tools logs a warning and
+reports a successful deploy, and `--json` — which `deploy-dev.yml` passes to
+read the channel URL — suppresses the warning too. That is not a hypothetical:
+it is how preview sign-in came to be broken for weeks with every check green,
+and why reviewers were adding hostnames by hand.
 
-The list is project-wide and finite, which is why the removal matters as much as
-the addition: a stale entry is an origin that stays trusted for authentication
-after the site behind it is gone.
+So `deploy-dev.yml` ends with a step that reads the authorized domain list back
+and fails the job when the hostname it just deployed is missing. Two things
+cause that, and neither surfaces any other way: the role being revoked, and two
+channel deploys overlapping — the CLI reads the list, appends and writes it
+back, and the admin API has no etag between the read and the write, so the later
+writer drops the earlier one's hostname. A re-run of the job repairs both.
+
+`preview-cleanup.yml` deletes the channel when its pull request closes. It does
+not touch the domain list: with the channel gone, the next preview deploy prunes
+the hostname on its own. Without it the channel would linger its full seven
+days, and the hostname would stay trusted for authentication that whole time.
 
 Building previews with `yarn build:e2e` would sidestep all of this — the
 in-memory adapters sign a user in without Google — and it is the wrong trade.
@@ -342,9 +346,6 @@ rather than a build-time optimisation:
 - **`deploy`** holds the credentials and runs no code from the pull request. It
   checks out the base branch, installs `firebase-tools` from a lockfile that is
   already merged, and takes only `dist/` from the build job.
-- **`authorize`** holds a credential too, and checks out nothing whatsoever. It
-  needs a token, `curl` and `jq`; none of the three come from this repository,
-  so the cheapest thing it can run from the branch is nothing.
 
 A pull request is otherwise a code-execution primitive: `yarn install` runs
 whatever `postinstall` the branch's lockfile asks for, before any file in the

--- a/README.md
+++ b/README.md
@@ -275,6 +275,11 @@ hitting it:
   check needs `serviceusage.services.get`. Without it the deploy stops on
   `403 Permission denied to get service [firestore.googleapis.com]`, which reads
   like a Firestore problem and is not one.
+- The service account also needs **Firebase Authentication Admin**
+  (`roles/firebaseauth.admin`), for preview sign-in below. Without it the deploy
+  and the preview both still succeed and only Google sign-in fails, on a domain
+  that exists for a week — the failure that is easiest to mistake for a bug in
+  the branch under review.
 - The provider's attribute condition matches on `assertion.repository` and stops
   there, deliberately. Narrowing it further is the obvious-looking improvement
   that breaks previews — see the trust boundary below before changing it.
@@ -291,10 +296,35 @@ hitting it:
   attribute condition cannot reach production. The procedure is reusable; the
   resources are not.
 
+#### Preview sign-in
+
+A preview channel is served from `goitei-dev--pr-<n>-<hash>.web.app`, and
+Firebase Auth refuses to complete a Google sign-in from an origin that is not on
+its authorized domain list. The hash is generated per channel, so every pull
+request lands on a hostname nobody has authorized, and the list accepts no
+wildcard. The `authorize` job in `deploy-dev.yml` appends the hostname through
+the Identity Toolkit admin API once the channel exists.
+
+`preview-cleanup.yml` takes them off again. It prunes by reconciliation —
+every authorized domain starting `goitei-dev--` that no live channel claims —
+rather than by removing the one domain a closing pull request added, because a
+channel expires after seven days on its own and its hostname is then
+unrecoverable. It runs on pull-request close and nightly.
+
+The list is project-wide and finite, which is why the removal matters as much as
+the addition: a stale entry is an origin that stays trusted for authentication
+after the site behind it is gone.
+
+Building previews with `yarn build:e2e` would sidestep all of this — the
+in-memory adapters sign a user in without Google — and it is the wrong trade.
+The preview exists to show the branch against real `goitei-dev` data; a
+Firestore query, index or cursor defect is invisible against fakes, and that is
+the class of defect that has actually reached review here.
+
 #### Trust boundary
 
-The deploy workflow is split into two jobs, and the split is the security
-boundary rather than a build-time optimisation:
+The deploy workflow is split into jobs, and the split is the security boundary
+rather than a build-time optimisation:
 
 - **`build`** runs the pull request's own code. It has `contents: read` and
   nothing else — no `id-token` permission, so `ACTIONS_ID_TOKEN_REQUEST_TOKEN`
@@ -303,11 +333,14 @@ boundary rather than a build-time optimisation:
 - **`deploy`** holds the credentials and runs no code from the pull request. It
   checks out the base branch, installs `firebase-tools` from a lockfile that is
   already merged, and takes only `dist/` from the build job.
+- **`authorize`** holds a credential too, and checks out nothing whatsoever. It
+  needs a token, `curl` and `jq`; none of the three come from this repository,
+  so the cheapest thing it can run from the branch is nothing.
 
 A pull request is otherwise a code-execution primitive: `yarn install` runs
 whatever `postinstall` the branch's lockfile asks for, before any file in the
 diff has been read by a human. Keeping that away from the credential is what
-the two jobs buy.
+the split buys.
 
 The six `VITE_FIREBASE_*` values are the exception, and are scoped to the build
 step. They can already be read out of the deployed bundle by anyone, so a build

--- a/README.md
+++ b/README.md
@@ -323,10 +323,18 @@ channel deploys overlapping — the CLI reads the list, appends and writes it
 back, and the admin API has no etag between the read and the write, so the later
 writer drops the earlier one's hostname. A re-run of the job repairs both.
 
-`preview-cleanup.yml` deletes the channel when its pull request closes. It does
-not touch the domain list: with the channel gone, the next preview deploy prunes
-the hostname on its own. Without it the channel would linger its full seven
-days, and the hostname would stay trusted for authentication that whole time.
+`preview-cleanup.yml` deletes the channel when its pull request closes. The
+hostname goes with it — `hosting:channel:delete` removes it from the authorized
+domain list as part of deleting the channel — and without this the channel would
+linger its full seven days, with the hostname trusted for authentication that
+whole time.
+
+That removal fails the same quiet way the addition does, so the workflow reads
+the list back and fails when a hostname belonging to the closed pull request is
+still on it. It does not remove the hostname itself: a second writer on a list
+whose API has no etag is a way to lose a domain rather than a way to remove one.
+The next preview deploy prunes it, which is what makes a re-run of the job go
+green.
 
 Building previews with `yarn build:e2e` would sidestep all of this — the
 in-memory adapters sign a user in without Google — and it is the wrong trade.

--- a/README.md
+++ b/README.md
@@ -302,8 +302,17 @@ A preview channel is served from `goitei-dev--pr-<n>-<hash>.web.app`, and
 Firebase Auth refuses to complete a Google sign-in from an origin that is not on
 its authorized domain list. The hash is generated per channel, so every pull
 request lands on a hostname nobody has authorized, and the list accepts no
-wildcard. The `authorize` job in `deploy-dev.yml` appends the hostname through
-the Identity Toolkit admin API once the channel exists.
+wildcard. The `authorize` job in `deploy-dev.yml` adds the hostname through the
+Identity Toolkit admin API once the channel exists.
+
+It adds every live channel's hostname and not only its own, because the job that
+should have added one can be cancelled before it ever runs. A concurrency group
+holds one running job and one pending job, and a third arrival evicts the
+pending one — `cancel-in-progress: false` protects the job that is running, not
+the one queued behind it. Three overlapping previews therefore lose the middle
+one's authorization outright, on a channel that is deployed, linked from its
+pull request and alive for a week. Reading the live channel list makes the next
+append repair it.
 
 `preview-cleanup.yml` takes them off again. It prunes by reconciliation —
 every authorized domain starting `goitei-dev--` that no live channel claims —


### PR DESCRIPTION
## What

Google sign-in did not work on preview channels. A channel is served from
`goitei-dev--pr-<n>-<hash>.web.app`, Firebase Auth refuses a sign-in from an
origin that is not on its authorized domain list, the hash is generated per
channel, and the list takes no wildcard. Reviewers had been adding each hostname
by hand.

**It is already fixed, and not by the code in this pull request.**
`firebase hosting:channel:deploy` adds the hostname itself. The call needs
`roles/firebaseauth.admin`, the deploy service account did not have it, and
granting the role — which happened on this branch, while diagnosing something
else — repaired preview sign-in for every pull request. Two channels deployed
after the grant were already authorized before anything here ran.

What is left is why nobody noticed for weeks, which is the part worth merging:

- `deploy-dev.yml` reads the authorized domain list back after deploying and
  fails the job when the hostname it just deployed is missing.
- `preview-cleanup.yml` is new. It deletes the channel when its pull request
  closes, and reads the list back the same way to check the hostname went with
  it.

## Why this shape

**The failure this guards against is a silent one.** When `addAuthDomains`
inside the CLI fails, firebase-tools logs a warning and reports a successful
deploy — and the deploy step passes `--json` to read the channel URL, which
suppresses the warning as well. So the pull request went green, the comment
promised a working preview, and sign-in was broken on it for the seven days the
channel lived. Nothing in the run log said so. A check that reads the list back
is the smallest thing that turns that into a red job.

Two causes, and neither surfaces any other way:

- **The role is revoked.** Exactly the state this branch started in.
- **Two channel deploys overlap.** The CLI reads the domain list, appends and
  writes it back, and the admin API offers no etag between the read and the
  write, so the later writer drops the earlier one's hostname. A re-run of the
  job repairs it, which is the whole point of noticing.

The check runs after the step that comments the preview URL, so a reviewer still
gets the link on a run that then goes red — the preview is real and worth
opening, it just cannot sign in yet.

**The cleanup deletes a channel and writes no domains.** A channel lives seven
days past its last deploy, and its hostname is trusted for authentication that
whole time, on a site nobody is reading after the pull request closes. Deleting
the channel takes the hostname with it: `hosting:channel:delete` calls
`removeAuthDomain` once the channel is gone.

That removal fails the same quiet way the addition does — a warning, and a
successful delete — so the workflow reads the list back and fails when a
hostname belonging to the closed pull request is still on it. It runs whether or
not a channel was deleted this time, because a re-run after a failed removal
takes the already-expired branch, and a check gated on the delete would go green
having repaired nothing.

It does not remove the hostname itself. A second writer on a list whose API has
no etag is a way to lose a domain rather than a way to remove one; the next
preview deploy prunes it, since `hosting:channel:deploy` drops every
`goitei-dev--` hostname no live channel claims, and that is what turns a re-run
green.

**The delete is allowed to fail.** An already-expired channel is the ordinary
case rather than an error, but tolerating it by swallowing every non-zero exit
swallows a 403 and a Hosting outage with it, and the run then goes green having
deleted nothing. The channel list decides whether there is anything to delete,
and the delete itself fails the job, which makes it something a re-run can fix.
That also costs no assumption about how firebase-tools words its errors.

**The alternative that looks cheaper than it is.** Building previews with
`yarn build:e2e` would sidestep sign-in entirely — the in-memory adapters sign a
user in without Google. It trades away the thing a preview is for. The comment
on each pull request promises real `goitei-dev` data, and a query, index or
cursor defect is invisible against fakes; that is the class of defect that has
actually reached review here.

## How the redundancy was found, and how it was proved

The first version of this pull request added an `authorize` job that called the
Identity Toolkit admin API directly, and a reconciling prune to match. Both are
gone. What they were reimplementing is in `firebase-tools`:
`lib/commands/hosting-channel-deploy.js` calls `syncAuthState` unless
`--no-authorized-domains` is passed, and that adds the channel's hostname and
prunes the stale ones.

The proof is in the run this branch produced on 2026-08-19. The `authorize` job
logged every live channel and every hostname it added, and the two sets line up
exactly with when `roles/firebaseauth.admin` was granted — between 04:10 and
04:53 on 2026-08-18:

| channel  | last deployed    | already authorized? |
| -------- | ---------------- | ------------------- |
| `pr-59`  | 2026-08-18 02:00 | no                  |
| `pr-61`  | 2026-08-18 04:07 | no                  |
| `pr-66`  | 2026-08-18 08:20 | **yes**             |
| `pr-69`  | 2026-08-19 06:30 | **yes**             |

Twenty-four channels deployed before the grant, none of them authorized. Two
deployed after it, both authorized, with nothing from this branch involved —
other pull requests run `develop`'s workflow, which has no `authorize` job in
it. The evidence is circumstantial in form and unambiguous in content; a deploy
run with `--debug` would show `[hosting] added auth domain for urls` outright,
if anyone wants it in the log.

That same run is also why the `jq` here can trust the channel list: it held
nothing older than seven days, so the Hosting API drops expired channels on its
own.

## Testing

No automated tests. The Firebase Hosting deploy pipeline is on the
"deliberately not tested" list in `CLAUDE.md`, and this is that pipeline.

What was verified instead:

- `actionlint` (Docker, `rhysd/actionlint`) on both workflows — clean. It
  shellchecks the `run:` blocks as well as validating the workflow schema.
- `prettier --check` on all three changed files — clean.
- Both `run:` blocks were exercised against hand-built fixtures with `curl` and
  `firebase` stubbed. For the verification step: the hostname present, the
  hostname absent because the role was revoked, the hostname absent because
  another deploy clobbered it, a config carrying no `authorizedDomains` key at
  all, a 403 on the read, and a deploy that produced no URL. The first exits 0;
  the rest exit 1 with the annotation that names the cause, and none of the six
  writes to the API. For the channel delete: a live channel, an already-expired
  one, a 403 on the delete, and a failing channel list — deleting only in the
  first, exiting 0 with a notice in the second, and failing in the last two.

  For the check that no domain is left after cleanup: nothing left, the hostname
  still present, a config with no `authorizedDomains` key, a 403 on the read,
  and a hostname belonging to a different pull request whose number this one is
  a prefix of.

  The scripts under test are extracted from the workflow YAML rather than
  transcribed, so a fixture cannot pass against a copy that has drifted from
  what actually ships.

- Two assertions were proved by breaking what they guard. The delete step's
  earlier `|| echo "already gone"` form, given a live channel and a delete that
  exits non-zero with `HTTP Error: 403`, printed `Channel pr-60 was already
  gone.` and exited 0. And the trailing hyphen in the `goitei-dev--pr-<n>-`
  prefix is load-bearing: without it, cleanup for pull request #6 fails on pull
  request #60's live hostname.

### On the review that asked for a removal mechanism

The first version of `preview-cleanup.yml` said in three places — a header
comment, the README and this description — that deleting a channel leaves its
hostname authorized until the next preview deploy prunes it. That was wrong.
`lib/commands/hosting-channel-delete.js` calls `removeAuthDomain` immediately
after `deleteChannel`, so the hostname comes off at closure. The review was
right that the prose needed fixing, and right for the opposite reason to the one
it gave.

What survives of the concern is the failure path, which is why the check exists:
that removal is wrapped in a `try`/`catch` that logs a warning and reports a
successful delete. Unlike the addition on the deploy side it is at least visible,
since the delete step passes no `--json` — but a warning on a closed pull
request is not a thing anyone reads.

Still unproven against the real API: `preview-cleanup.yml`, which runs only when
a pull request closes. This one closing is its first exercise.

Google sign-in was checked by hand on the preview link below, and works.

## Before merging

The deploy service account needs **`roles/firebaseauth.admin`**, and already has
it. It is recorded here because the binding is the reason preview sign-in works
and nothing in the repository can assert it — a project that loses the role
fails the way this branch started, where the deploy and the preview both still
succeed and only sign-in breaks. The check added here is what makes that loud
rather than silent, and it is the only reason the repository has an opinion
about the role at all.

`roles/firebaseauth.admin` is broader than the CLI needs — it also carries full
user administration, on a service account that pull-request-triggered jobs use.
A custom role holding only `firebaseauth.configs.get` and
`firebaseauth.configs.update` would cover both the CLI's write and this check's
read. That belongs with the two service accounts split noted at the end of the
trust boundary section in the README, not here.

`token_format: access_token` on the deploy job calls
`iamcredentials.generateAccessToken`, which needs no new IAM binding (the
federation principal already has `roles/iam.workloadIdentityUser` on the service
account) but does need `iamcredentials.googleapis.com` enabled. It normally
already is, wherever impersonation is in use.
