### PR TITLE
fix(import): accept a note whose quotes a phone app substituted

### DIFF
--- a/src/lib/jsonImport.ts
+++ b/src/lib/jsonImport.ts
@@ -119,22 +119,68 @@ function parseTolerantly(text: string): unknown {
 }
 
 /**
- * Rewrite only the curly quotes standing where JSON expects a delimiter: an
- * opening one after `{`, `[`, `,` or `:`, and a closing one before `:`, `,`,
- * `}` or `]`.
+ * Rewrite the quotes delimiting each value, leaving the ones inside it alone.
  *
- * A curly quote inside a value is left as it is, because it is already legal
- * there. Rewriting every one of them instead would end a string early — a
- * definition that quotes a word would parse as something other than what was
- * written, or stop parsing at all, which is worse than the refusal this is
- * trying to avoid.
+ * Which is which cannot be decided from the neighbouring punctuation, because
+ * that does not say what opened the value being read. A straight-quoted value
+ * holding a ” is the case it gets wrong: read as a delimiter, the note parses,
+ * imports, and is missing a character the user wrote — a silent edit, which is
+ * worse than the refusal this is trying to avoid. So the scan tracks the quote
+ * that opened the value it is standing in.
  *
- * A closing quote inside a value that happens to sit before an ASCII comma is
- * the case this reads wrongly. That paste fails today too, so it is left
- * failing rather than guessed at.
+ * A straight-quoted value ends where JSON says it ends. A curly-quoted one ends
+ * at a ” standing where a delimiter can stand, which keeps a curly quote used
+ * as punctuation mid-sentence inside the sentence.
+ *
+ * That last rule is a reading, not a proof: a ” inside a value that happens to
+ * sit before a `:` `,` `}` or `]` still closes it early. What follows then reads
+ * as structure and the parse fails, which is the refusal the caller reports —
+ * but nothing here guarantees it fails for every such note, only that the two
+ * shapes covered in the tests do.
  */
 function straightenDelimiters(text: string): string {
-  return text.replace(/(?<=[{[,:]\s*)\u201C/g, '"').replace(/\u201D(?=\s*[:,}\]])/g, '"');
+  const out: string[] = [];
+  let opener: '"' | '“' | undefined;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text.charAt(i);
+
+    if (opener === undefined) {
+      if (ch === '"' || ch === '“') {
+        opener = ch;
+        out.push('"');
+      } else {
+        out.push(ch);
+      }
+      continue;
+    }
+
+    // An escape takes the character after it with it, so a quote the assistant
+    // escaped never reads as the end of the value.
+    if (ch === '\\') {
+      out.push(ch, text.charAt(i + 1));
+      i += 1;
+      continue;
+    }
+
+    const ends = opener === '"' ? ch === '"' : ch === '”' && delimiterMayStandAt(text, i + 1);
+    if (ends) {
+      opener = undefined;
+      out.push('"');
+      continue;
+    }
+
+    out.push(ch);
+  }
+
+  return out.join('');
+}
+
+/** Whether the next thing after `from`, ignoring whitespace, follows a value. */
+function delimiterMayStandAt(text: string, from: number): boolean {
+  let i = from;
+  while (i < text.length && /\s/.test(text.charAt(i))) i += 1;
+  return i === text.length || ':,}]'.includes(text.charAt(i));
 }
 
 /**

--- a/src/lib/jsonImport.ts
+++ b/src/lib/jsonImport.ts
@@ -72,7 +72,7 @@ export function buildPrompt(word: string, language: string, context: PromptConte
     ? `- "source" には「${source}」をそのまま入れてください。`
     : `- "source" は空のままにしてください。`;
 
-  return `「${word}」という日本語の単語について、次のJSONスキーマだけを出力してください。説明文やコードフェンスは不要です。
+  return `「${word}」という日本語の単語について、次のJSONスキーマだけを出力してください。説明文は不要で、JSON全体を \`\`\`json のコードブロックに入れてください。
 ${contextLines}
 
 - "definitionSub" と各 "translation" は${language}で書いてください。
@@ -91,6 +91,53 @@ ${SCHEMA}`;
 }
 
 /**
+ * Copying an assistant's reply out of a phone app is not a byte-for-byte
+ * transfer. The same answer copied from a browser arrives with U+0022 and
+ * copied from an iOS app arrives with U+201C and U+201D, because what the app
+ * puts on the clipboard is the typographically substituted prose rather than
+ * the source it rendered. `JSON.parse` accepts only U+0022, so the note is
+ * refused for a reason that has nothing to do with the note.
+ *
+ * Asking for a code fence — which `buildPrompt` now does — is the better half
+ * of the fix, because a fenced reply is copied verbatim. This is the other
+ * half, for the paste that arrives substituted anyway.
+ */
+function parseTolerantly(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Falls through to the repair. Anything that parsed as written is returned
+    // above untouched, so the rewrite below only ever sees input that is
+    // already broken and cannot make a good note worse.
+  }
+
+  try {
+    return JSON.parse(straightenDelimiters(text));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Rewrite only the curly quotes standing where JSON expects a delimiter: an
+ * opening one after `{`, `[`, `,` or `:`, and a closing one before `:`, `,`,
+ * `}` or `]`.
+ *
+ * A curly quote inside a value is left as it is, because it is already legal
+ * there. Rewriting every one of them instead would end a string early — a
+ * definition that quotes a word would parse as something other than what was
+ * written, or stop parsing at all, which is worse than the refusal this is
+ * trying to avoid.
+ *
+ * A closing quote inside a value that happens to sit before an ASCII comma is
+ * the case this reads wrongly. That paste fails today too, so it is left
+ * failing rather than guessed at.
+ */
+function straightenDelimiters(text: string): string {
+  return text.replace(/(?<=[{[,:]\s*)\u201C/g, '"').replace(/\u201D(?=\s*[:,}\]])/g, '"');
+}
+
+/**
  * Import a note written by an assistant elsewhere. Only headword and
  * definition are required; every other field falls back to the blank draft,
  * so a partial answer still saves.
@@ -103,19 +150,16 @@ export function jsonToDraft(
   raw: string,
   context: PromptContext = {},
 ): { draft?: EntryDraft; error?: string } {
-  let parsed: Record<string, unknown>;
-  try {
-    // Tolerate a ```json fence, which assistants add even when told not to.
-    // The shape is validated by the guards below; JSON.parse's `any` stops here.
-    parsed = JSON.parse(
-      raw
-        .replace(/^\s*```(?:json)?/, '')
-        .replace(/```\s*$/, '')
-        .trim(),
-    ) as Record<string, unknown>;
-  } catch {
-    return { error: 'JSON として解析できませんでした。' };
-  }
+  // Tolerate a ```json fence. The prompt now asks for one, and assistants used
+  // to add it even when told not to, so both eras of pasted note arrive here.
+  const unfenced = raw
+    .replace(/^\s*```(?:json)?/, '')
+    .replace(/```\s*$/, '')
+    .trim();
+
+  // The shape is validated by the guards below; JSON.parse's `any` stops here.
+  const parsed = parseTolerantly(unfenced) as Record<string, unknown> | undefined;
+  if (parsed === undefined) return { error: 'JSON として解析できませんでした。' };
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return { error: 'JSON オブジェクトではありません。' };
   }

--- a/tests/unit/jsonImport.test.ts
+++ b/tests/unit/jsonImport.test.ts
@@ -3,9 +3,9 @@ import { buildPrompt, jsonToDraft, promptLanguageName, SCHEMA } from '@/lib/json
 
 /**
  * The import box takes JSON an assistant wrote somewhere else and a human
- * pasted in. Neither step is reliable: assistants wrap output in a code fence
- * they were told not to add, invent enum values, and paraphrase the sentence
- * they were handed. All of that has to become either a saveable draft or a
+ * pasted in. Neither step is reliable: assistants fence or unfence the output
+ * whatever the prompt asks, invent enum values, paraphrase the sentence they
+ * were handed, and reach the box through a clipboard that rewrites its quotes. All of that has to become either a saveable draft or a
  * message the user can act on — never a thrown error inside the form.
  */
 
@@ -25,7 +25,7 @@ describe('jsonToDraft — parsing', () => {
       'fence with surrounding blank lines',
       '\n\n```json\n{"headword":"兆候","definition":"前ぶれ"}\n```\n\n',
     ],
-  ])('strips a %s that the assistant added anyway', (_case, raw) => {
+  ])('strips a %s, which the prompt asks for and an assistant may omit', (_case, raw) => {
     expect(jsonToDraft(raw).draft?.headword).toBe('兆候');
   });
 
@@ -52,6 +52,68 @@ describe('jsonToDraft — parsing', () => {
  * Coercion happens in `sanitizeDraft`; what this checks is that the import path
  * reaches it at all, rather than dropping a field the prompt now asks for.
  */
+/**
+ * Copying an assistant's answer out of a phone app is not a byte-for-byte
+ * transfer. The same reply copied from a browser arrives with U+0022, and
+ * copied from an iOS app arrives with U+201C and U+201D, because the app hands
+ * over the typographically substituted prose rather than the source. `JSON.parse`
+ * accepts only U+0022, so the paste is refused for a reason that has nothing to
+ * do with whether the note is any good — and the user has no way to see why.
+ */
+describe('jsonToDraft — quotes an iOS app substituted on the way to the clipboard', () => {
+  it('parses a note whose delimiters are curly quotes, which is what an iOS copy produces', () => {
+    const raw = `{
+“headword”: “最終日”,
+“reading”: “さいしゅうび”,
+“pos”: [“名詞”],
+“definition”: “ある期間・行事・予定などの最後にあたる日。”
+}`;
+
+    const { draft, error } = jsonToDraft(raw);
+
+    expect(error).toBeUndefined();
+    expect(draft?.headword).toBe('最終日');
+    expect(draft?.reading).toBe('さいしゅうび');
+    expect(draft?.pos).toEqual(['名詞']);
+  });
+
+  /**
+   * Only the quotes acting as delimiters are rewritten. A curly quote inside a
+   * value is already legal JSON, and rewriting it would end the string early —
+   * turning a note that merely failed to parse into one that parses as
+   * something else, or splits a definition in half.
+   */
+  it('leaves curly quotes inside a value alone while repairing the delimiters', () => {
+    const raw = '{“headword”:“兆候”,“definition”:“いわゆる“前ぶれ”のこと。”}';
+
+    const { draft, error } = jsonToDraft(raw);
+
+    expect(error).toBeUndefined();
+    expect(draft?.definition).toBe('いわゆる“前ぶれ”のこと。');
+  });
+
+  it('parses a curly-quoted note still wrapped in the code fence the prompt asks for', () => {
+    const raw = '```json\n{“headword”:“兆候”,“definition”:“前ぶれ”}\n```';
+
+    expect(jsonToDraft(raw).draft?.headword).toBe('兆候');
+  });
+
+  /**
+   * The repair runs only after an ordinary parse has already failed, so input
+   * that was valid to begin with never reaches it. A definition quoting
+   * dialogue keeps the punctuation the assistant chose.
+   */
+  it('does not touch a well-formed note whose value contains curly quotes', () => {
+    const raw = JSON.stringify({ ...minimal, definition: '“やばい”という語の説明。' });
+
+    expect(jsonToDraft(raw).draft?.definition).toBe('“やばい”という語の説明。');
+  });
+
+  it('still reports input that curly quotes were not the problem with', () => {
+    expect(jsonToDraft('{“headword”: }').error).toBe('JSON として解析できませんでした。');
+  });
+});
+
 describe('jsonToDraft — the pitch accent', () => {
   const note = (pitchAccent: string) =>
     jsonToDraft(`{"headword":"卵","definition":"たまご","reading":"たまご",${pitchAccent}}`).draft;
@@ -191,6 +253,19 @@ describe('buildPrompt', () => {
     const without = buildPrompt('兆候', '廣東話');
     expect(without).toContain('出会った文がないため');
     expect(without).not.toContain('"context.original"');
+  });
+
+  /**
+   * The prompt used to end with 「コードフェンスは不要です」. A fenced reply is the one
+   * an iOS app will copy verbatim — plain prose comes back with its quotes
+   * typographically substituted, which `JSON.parse` then refuses. Asking for
+   * the fence costs nothing, because the parser has always stripped one.
+   */
+  it('asks for a code fence rather than forbidding it, so an iOS copy stays verbatim', () => {
+    const prompt = buildPrompt('兆候', '廣東話');
+
+    expect(prompt).not.toContain('コードフェンスは不要です');
+    expect(prompt).toContain('```json');
   });
 
   it('passes a source through, and asks for it to be left blank otherwise', () => {

--- a/tests/unit/jsonImport.test.ts
+++ b/tests/unit/jsonImport.test.ts
@@ -109,6 +109,51 @@ describe('jsonToDraft — quotes an iOS app substituted on the way to the clipbo
     expect(jsonToDraft(raw).draft?.definition).toBe('“やばい”という語の説明。');
   });
 
+  /**
+   * The repair must know which quote opened the string it is standing in. This
+   * value is delimited by straight quotes, so the ” inside it is ordinary text.
+   * Reading it as a delimiter does not fail the parse — it succeeds, drops the
+   * character, and imports a definition the user never wrote. A refusal the
+   * user can see is the only acceptable outcome; a silent edit is not.
+   */
+  it('refuses a straight-quoted value holding a curly quote, rather than importing it with the quote deleted', () => {
+    const raw = '{"headword":"兆候","definition":"末尾の引用 ”, "source":"x"}';
+
+    const { draft, error } = jsonToDraft(raw);
+
+    expect(draft).toBeUndefined();
+    expect(error).toBe('JSON として解析できませんでした。');
+  });
+
+  /**
+   * Nested curly quotes that could close the value in more than one place are
+   * not guessable. Splitting the value at the wrong one would move half of a
+   * definition into a field of its own, which sanitisation then discards — an
+   * import that looks like it worked and is missing the second half.
+   */
+  it('refuses nested curly quotes it cannot place, rather than splitting the value into another field', () => {
+    const raw = '{“headword”:“x”,“definition”:“A, “B”: “C””}';
+
+    const { draft, error } = jsonToDraft(raw);
+
+    expect(draft).toBeUndefined();
+    expect(error).toBe('JSON として解析できませんでした。');
+  });
+
+  /**
+   * An escaped quote is content, not the end of the string. Treating it as a
+   * delimiter would put the repair back outside the value halfway through it,
+   * where the rest of the sentence reads as structure.
+   */
+  it('does not end a value at an escaped quote, which would resume repairing inside the sentence', () => {
+    const raw = '{“headword”:“兆候”,“definition”:“\\"前ぶれ\\" のこと。”}';
+
+    const { draft, error } = jsonToDraft(raw);
+
+    expect(error).toBeUndefined();
+    expect(draft?.definition).toBe('"前ぶれ" のこと。');
+  });
+
   it('still reports input that curly quotes were not the problem with', () => {
     expect(jsonToDraft('{“headword”: }').error).toBe('JSON として解析できませんでした。');
   });


### PR DESCRIPTION
## The defect

Pasting an assistant's answer into the import box failed with `JSON として解析できませんでした。` when the answer had been copied out of a phone app, and succeeded when the same answer was copied out of a browser.

It looked like a difference between assistants. It is not. The reply is identical; the clipboard is not:

| Copied from | Quote character |
| --- | --- |
| Browser | `"` U+0022 |
| iOS app | `“` U+201C / `”` U+201D |

What an iOS app puts on the clipboard for rendered prose is the typographically substituted text, not the source it rendered from. `JSON.parse` accepts only U+0022, so the note was refused for a reason that had nothing to do with the note — and the message gave the user no way to tell that the quotes were the problem.

## The prompt was steering into it

`buildPrompt` ended with 「説明文やコードフェンスは不要です」 — it asked for exactly the unfenced prose that gets substituted. It now asks for a fenced `json` block instead. A fenced reply is copied verbatim, and the parser has stripped a fence since it was written, so asking for one costs nothing on the parsing side.

That is the better half of the fix, because it stops the substitution happening at all. It is not the whole fix: prompt compliance was never reliable in either direction — the parser tolerated a fence precisely because assistants added one when told not to — and a user who selects the text by hand rather than using the copy-code control still gets substituted quotes.

## The parser half

`jsonToDraft` now parses in two phases:

1. Parse as written. **If this succeeds nothing else runs**, so input that was already valid is never rewritten.
2. Only on failure, straighten the delimiters and parse again.
3. Still failing returns the same error as before. The message is unchanged and the worst case is today's behaviour.

The repair is positional, not a global replace. Only curly quotes standing where JSON expects a delimiter are rewritten — an opening one after `{`, `[`, `,` or `:`, a closing one before `:`, `,`, `}` or `]`. A curly quote inside a value is left alone, because it is already legal there:

```
{“definition”:“いわゆる“前ぶれ”のこと。”}   →   {"definition":"いわゆる“前ぶれ”のこと。"}
```

A global replace would produce `"いわゆる"前ぶれ"のこと。"` — it would end the string early and turn a note that merely failed to parse into one that parses as something else. That is worse than the refusal this is trying to avoid.

### What the repair will not do

It will not decide, from the punctuation around a quote, what opened the value that quote sits in. That was the first attempt and it was wrong: a straight-quoted value holding a `”` parsed, imported, and lost the character, which review caught. The scan is stateful for that reason — a `”` inside a straight-quoted value is always content.

For a value opened by `“`, the closing `”` must also stand where a delimiter can stand. That condition is a reading, not a proof. A `”` inside such a value that happens to sit before `:` `,` `}` or `]` still closes it early; what follows then reads as structure and the parse fails, which is the refusal the caller reports. Nothing here guarantees that outcome for every note — only for the shapes the tests pin.

## Test layer

`tests/unit`. Both changes are pure functions of their inputs — one builds a string, the other turns a string into a draft — which is the default layer in the repository's table. Nothing here touches a query, the DOM, or a route.

## Proving the tests red

Four tests were written first and confirmed failing against the unfixed code — `4 failed | 37 passed` in the file:

- `parses a note whose delimiters are curly quotes, which is what an iOS copy produces`
- `leaves curly quotes inside a value alone while repairing the delimiters`
- `parses a curly-quoted note still wrapped in the code fence the prompt asks for`
- `asks for a code fence rather than forbidding it, so an iOS copy stays verbatim`

Two further tests were written to stay green, and did, because they assert the guarantees rather than the fix: `does not touch a well-formed note whose value contains curly quotes` and `still reports input that curly quotes were not the problem with`.

Review then found a case the positional repair imported instead of refusing — a straight-quoted value holding a curly quote. That is fixed in 497e063, with `refuses a straight-quoted value holding a curly quote, rather than importing it with the quote deleted` confirmed red beforehand and the only test that was.

After both changes: 44 files / 645 tests pass, all three `tsconfig` passes clean, ESLint clean, Prettier clean. The exact paste from the bug report was also run through `jsonToDraft` directly and imports with every field intact — headword, reading, pitch accent, JLPT level, part of speech, both senses and examples arrays, related words, and the 「」 punctuation inside `usage.caution`.

## Not verified here

The mechanism behind the iOS clipboard substitution is inferred from the browser-versus-app comparison above, not measured — there is no iOS device in the loop. The prompt change should be confirmed by running the flow on a phone. The parser change does not depend on that inference holding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON import reliability for responses wrapped in code fences.
  * Added support for JSON using iOS-style curly quotation marks while preserving curly quotes within text values.
  * Maintained clear validation and error handling for invalid JSON input.

* **Tests**
  * Expanded coverage for fenced JSON, curly-quote repair, clipboard input, and invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
