### PR TITLE
fix(forms): keep iOS from zooming in on a focused control

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,11 +118,17 @@ body {
  * are deliberately sized down for density with text-sm and text-xs, which is
  * right on a pointer device and is exactly what trips the zoom on a phone, so
  * on a coarse pointer the threshold wins instead.
+ *
+ * Matching those two utilities by name, rather than every control, is what
+ * keeps this a floor instead of a fixed size: they are the only sizes in use
+ * below the threshold, so a control that asks for more — the dictation answer
+ * field at text-lg — is never selected and keeps what it asked for. Naming
+ * them couples this rule to Tailwind's scale, which is the trade: a control
+ * added with some other small size would go uncovered and zoom, where the
+ * unscoped rule would instead have silently shrunk the next large one.
  */
 @media (pointer: coarse) {
-  input,
-  textarea,
-  select {
+  :is(input, textarea, select):is(.text-xs, .text-sm) {
     font-size: 16px;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -110,6 +110,23 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/*
+ * iOS Safari zooms the page in whenever a focused form control computes to a
+ * font-size under 16px, and does not reliably zoom back out on blur: the
+ * keyboard changes the layout mid-gesture and the visual viewport keeps the
+ * scale, leaving the page stuck magnified with no API to reset it. The controls
+ * are deliberately sized down for density with text-sm and text-xs, which is
+ * right on a pointer device and is exactly what trips the zoom on a phone, so
+ * on a coarse pointer the threshold wins instead.
+ */
+@media (pointer: coarse) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
 /* Japanese and Cantonese prose needs the extra leading for furigana and wrapping. */
 .prose-cjk {
   font-family: var(--font-cjk);


### PR DESCRIPTION
### Summary

Focusing any text field on iOS zooms the page in and it never zooms back
out, leaving the app stuck magnified for the rest of the session.

Safari zooms whenever a focused form control computes to a font-size under
16px. Every control here is below that: `inputClass` in
`src/components/entry-form/fields.tsx` is `text-sm` (14px), and the
`selectClass` in `FilterPanel.tsx` and `PracticeSetup.tsx` is `text-xs`
(12px). Safari is supposed to restore the scale on blur, but the keyboard
resizes the layout mid-gesture and the visual viewport keeps the scale —
there is no API to put it back.

### What changed

One rule in `src/index.css`, raising the controls that sit below the
threshold to 16px behind `@media (pointer: coarse)`. The sizes are
deliberate on a pointer device, so the override is scoped to touch and
desktop is untouched.

```css
@media (pointer: coarse) {
  :is(input, textarea, select):is(.text-xs, .text-sm) {
    font-size: 16px;
  }
}
```

Selecting the two sub-16px utilities by name, rather than every control,
is what keeps this a floor instead of a fixed size: a control that asks
for more than 16px — the dictation answer field at `text-lg` — is never
matched and keeps what it asked for. The trade is that this couples the
rule to Tailwind's scale, so a control added at some other small size
would go uncovered and zoom. That failure is visible and recoverable; the
alternative, silently shrinking the next control that deliberately asks
for more, is not.

The rule sits outside any cascade layer. Tailwind v4 emits its utilities
inside `@layer utilities`, and unlayered CSS wins over layered CSS
regardless of specificity, so it overrides `text-sm` and `text-xs`
without `!important`. Verified against the compiled stylesheet: the rule
has zero enclosing `@layer` blocks.

The viewport meta was left alone. `maximum-scale=1` is ignored by
Safari since iOS 10 and would cost pinch-to-zoom (WCAG 1.4.4) if it
worked.

### How to verify

Measured against the `e2e` build in a touch-enabled 390px context and
again at 1280 without touch. No textual control resolves below 16px on
touch, no page scrolls sideways
(`scrollWidth === clientWidth === 390`), and every control keeps its
original size on desktop.

| Route | Controls | Under 16px on touch | Overflow |
| --- | --- | --- | --- |
| `/vocabulary` | 8 | none | none |
| `/practice/dictation`, `/practice/flashcards` | 5 each | none | none |
| `/settings` | 4 | none | none |
| `/wordsets` | 1 | none | none |
| Add-vocabulary modal | 5 | none | none |
| Dictation session | 1 (`text-lg`, 18px) | none | none |

The dictation session has to be started, not just its setup screen
rendered, for the answer field to exist — the first round of measurement
here missed it, and the review caught the resulting regression.

`/vocabulary` was the one at risk for layout — its selects jump 12px to
16px — and the screenshot shows them still filling their full-width pills
with the label rows and chips intact.

Desktop is unchanged: at 1280 in Desktop Chrome, `pointer: coarse` is
false and the controls still measure 14px and 12px.

**Tests:** `yarn test:unit` — 648 passing, 44 files.

### No test added

Deliberate, and the repository asks for it to be stated. `CLAUDE.md` lists
Tailwind class combinations as not tested unless layout carries meaning,
which here it does not — this is a font-size threshold, not the furigana
or heatmap geometry the screenshots exist for.

There is also no layer that could see it. jsdom does not evaluate CSS, so
a component test cannot; and `playwright.config.ts` runs a single
`Desktop Chrome` project with no touch, where the media query never
matches. Covering it durably means adding a touch project and a new
baseline. Happy to do that in a follow-up if it is wanted.

### Screenshot baselines

Untouched, and cannot move: the only Playwright project is `Desktop
Chrome`, and the phone test at `tests/e2e/visual.spec.ts:120` only calls
`setViewportSize(375)` without `hasTouch`, so `pointer: coarse` stays
false there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DByP7Ge7Yun9BeonDN5STc
