### PR TITLE
test(integration): stop three ordering tests depending on the emulator's clock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,20 @@ blob, because the sanitiser is itself under test.
 the day it was written is worse than no test. The Playwright specs freeze time
 in `tests/e2e/fixtures.ts`; a dashboard baseline would otherwise change nightly.
 
+The same applies to the server's clock, which a test cannot pass as an argument
+and must therefore not depend on the resolution of. Three integration tests
+asserted an order that `serverTimestamp()` was trusted to establish, and all
+three flaked: measured against the emulator, it resolves to the **millisecond**
+— every value it returned across 180 documents was a whole number of them —
+while two awaited creates are about one millisecond apart. Three sequential
+writes tied in 3 seedings out of 60, and once they tie the query falls through
+to `orderBy(documentId(), 'desc')`, where an auto-id is random. Under a forced
+tie the assertion held 6 times in 30.
+
+So a test about ordering writes the timestamps itself: create through the
+adapter, so the document shape is real, then set `createdAt` directly. The
+claim is that the query orders by the field, and that is what stays under test.
+
 ### Do not generate tests in bulk
 
 No boilerplate test per component. A new test corresponds to a real behaviour,

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -198,7 +198,7 @@ describe('list — pagination', () => {
    * `createdAt` descending, and that is exactly what is still exercised; the
    * resolution of somebody else's clock never was the claim.
    */
-  it('orders newest first', async () => {
+  it('orders newest first, so a word added today is not on the last page', async () => {
     const uid = `it-order-${randomUUID()}`;
     const repo = createEntryRepository(db, uid);
     const ids = await seed(repo, ['一番目', '二番目', '三番目']);

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -175,9 +175,43 @@ describe('list — pagination', () => {
     expect((await repo.list({ limit: 2, cursor: null })).cursor).toBeNull();
   });
 
+  /**
+   * **The timestamps are written here rather than inherited from the clock,
+   * and that is the fix for a flake this test used to produce.**
+   *
+   * Seeding through `create` and trusting the order the writes arrived in was
+   * wrong, and the measurement says why. The emulator resolves
+   * `serverTimestamp()` to the millisecond — across 180 documents every value
+   * it returned was a whole number of milliseconds — while two awaited creates
+   * are roughly one millisecond apart: over 120 consecutive pairs the median
+   * gap was 999,936ns and the minimum was zero. Three documents seeded this way
+   * therefore shared a `createdAt` in 3 rounds out of 60.
+   *
+   * A tie is not a defect and the query already answers it: it falls through to
+   * `documentId() desc`, and an auto-id is random, so the tied pair comes back
+   * in an order unrelated to when it was written. What was broken was this
+   * test, which reported an ordering bug that was not there — and reported it
+   * rarely enough to read as noise.
+   *
+   * Written through the adapter first so the document shape is real, then given
+   * distinct timestamps directly. The claim is that the query orders by
+   * `createdAt` descending, and that is exactly what is still exercised; the
+   * resolution of somebody else's clock never was the claim.
+   */
   it('orders newest first', async () => {
-    const repo = freshRepo();
-    await seed(repo, ['一番目', '二番目', '三番目']);
+    const uid = `it-order-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+    const ids = await seed(repo, ['一番目', '二番目', '三番目']);
+
+    // A minute apart, which no clock resolution can tie.
+    for (const [minute, id] of ids.entries()) {
+      await setDoc(
+        doc(db, 'users', uid, 'entries', id),
+        { createdAt: Timestamp.fromDate(new Date(Date.UTC(2026, 5, 24, 9, minute))) },
+        { merge: true },
+      );
+    }
+
     const page = await repo.list({ limit: 10, cursor: null });
     expect(page.items.map((entry) => entry.headword)).toEqual(['三番目', '二番目', '一番目']);
   });
@@ -195,7 +229,11 @@ describe('list — pagination', () => {
     const tied = createEntryRepository(db, uid);
 
     // Written through the adapter first so the shape is real, then given an
-    // identical createdAt directly — serverTimestamp() cannot be made to collide.
+    // identical createdAt directly. Not because serverTimestamp() cannot
+    // collide — measured against this emulator it collides about one seeding in
+    // twenty, which is what the ordering test above had to be rewritten for —
+    // but because a tie that happens sometimes proves nothing on the runs where
+    // it does not.
     const ids = await seed(tied, ['甲', '乙', '丙', '丁', '戊']);
     for (const id of ids) {
       await setDoc(doc(db, 'users', uid, 'entries', id), { createdAt: shared }, { merge: true });

--- a/tests/integration/progressRepo.test.ts
+++ b/tests/integration/progressRepo.test.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { deleteApp, initializeApp } from 'firebase/app';
 import type { FirebaseApp } from 'firebase/app';
-import { connectFirestoreEmulator, doc, getDoc, getFirestore, Timestamp } from 'firebase/firestore';
+import {
+  connectFirestoreEmulator,
+  doc,
+  getDoc,
+  getFirestore,
+  setDoc,
+  Timestamp,
+} from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { ProgressRepository } from '@/domain/ports';
@@ -167,10 +174,28 @@ describe('recording a session', () => {
 });
 
 describe('paging through 履歴', () => {
+  /**
+   * `finishedAt` is written here rather than left to the clock, for the reason
+   * recorded at length on `entryRepo`'s ordering test: the emulator resolves
+   * `serverTimestamp()` to the millisecond and three sequential writes land
+   * inside one often enough to tie. `listSessions` then falls through to its
+   * second key, `documentId() desc`, where an auto-id is random — so this
+   * assertion failed on roughly one run in six with nothing wrong in the query.
+   */
   it('returns sessions newest first', async () => {
-    const { repo } = freshRepo();
+    const { repo, uid } = freshRepo();
+    const ids: string[] = [];
     for (const label of ['一', '二', '三']) {
-      await repo.recordSession(session({ filterLabel: label }), []);
+      ids.push(await repo.recordSession(session({ filterLabel: label }), []));
+    }
+
+    // A minute apart, which no clock resolution can tie.
+    for (const [minute, id] of ids.entries()) {
+      await setDoc(
+        doc(db, 'users', uid, 'practiceSessions', id),
+        { finishedAt: Timestamp.fromDate(new Date(Date.UTC(2026, 5, 24, 9, minute))) },
+        { merge: true },
+      );
     }
 
     const page = await repo.listSessions({ limit: 5, cursor: null });

--- a/tests/integration/progressRepo.test.ts
+++ b/tests/integration/progressRepo.test.ts
@@ -182,7 +182,7 @@ describe('paging through 履歴', () => {
    * second key, `documentId() desc`, where an auto-id is random — so this
    * assertion failed on roughly one run in six with nothing wrong in the query.
    */
-  it('returns sessions newest first', async () => {
+  it('orders newest first, so the last practice run is the first row of 履歴', async () => {
     const { repo, uid } = freshRepo();
     const ids: string[] = [];
     for (const label of ['一', '二', '三']) {

--- a/tests/integration/wordSetRepo.test.ts
+++ b/tests/integration/wordSetRepo.test.ts
@@ -1,7 +1,14 @@
 import { randomUUID } from 'node:crypto';
 import { deleteApp, initializeApp } from 'firebase/app';
 import type { FirebaseApp } from 'firebase/app';
-import { connectFirestoreEmulator, doc, getDoc, getFirestore } from 'firebase/firestore';
+import {
+  connectFirestoreEmulator,
+  doc,
+  getDoc,
+  getFirestore,
+  setDoc,
+  Timestamp,
+} from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { WordSetRepository } from '@/domain/ports';
@@ -117,9 +124,27 @@ describe('deleting a set', () => {
 });
 
 describe('listing', () => {
+  /**
+   * The timestamps are written rather than taken from the clock, for the reason
+   * recorded at length on `entryRepo`'s copy of this test: the emulator
+   * resolves `serverTimestamp()` to the millisecond and two awaited creates are
+   * about a millisecond apart, so three of them tie often enough to fail this
+   * assertion by chance — the query then orders the tied pair by document id,
+   * which is random.
+   */
   it('returns sets newest first', async () => {
-    const { repo } = freshRepo();
-    for (const name of ['一', '二', '三']) await repo.create(draft({ name }));
+    const { repo, uid } = freshRepo();
+    const ids: string[] = [];
+    for (const name of ['一', '二', '三']) ids.push(await repo.create(draft({ name })));
+
+    // A minute apart, which no clock resolution can tie.
+    for (const [minute, id] of ids.entries()) {
+      await setDoc(
+        doc(db, 'users', uid, 'wordSets', id),
+        { createdAt: Timestamp.fromDate(new Date(Date.UTC(2026, 5, 24, 9, minute))) },
+        { merge: true },
+      );
+    }
 
     const page = await repo.list({ limit: 10, cursor: null });
     expect(page.items.map((item) => item.name)).toEqual(['三', '二', '一']);

--- a/tests/integration/wordSetRepo.test.ts
+++ b/tests/integration/wordSetRepo.test.ts
@@ -132,7 +132,7 @@ describe('listing', () => {
    * assertion by chance — the query then orders the tied pair by document id,
    * which is random.
    */
-  it('returns sets newest first', async () => {
+  it('orders newest first, so a set made today is not on the last page', async () => {
     const { repo, uid } = freshRepo();
     const ids: string[] = [];
     for (const name of ['一', '二', '三']) ids.push(await repo.create(draft({ name })));


### PR DESCRIPTION
Three integration tests flaked. This is the fix, and the measurement that found it.

## What was failing

`entryRepo > orders newest first`, `wordSetRepo > returns sets newest first` and
`progressRepo > returns sessions newest first`. Each seeded three documents
through the adapter and asserted they came back newest first, trusting the order
the writes arrived in.

## Why, measured rather than assumed

| Measurement | Result |
| --- | --- |
| `serverTimestamp()` resolution in the emulator | **milliseconds** — every nanosecond value returned across 180 documents was a whole number of them |
| Gap between two awaited creates | median 999,936ns, minimum **0**, over 120 consecutive pairs |
| Three sequential creates sharing a `createdAt` | 3 seedings in 60 |
| The old assertion holding under a forced tie | **6 in 30** — which is 1 in 6, the chance a random permutation of three items is the expected one |

A tie is not a defect, and the query already answers it: it falls through to
`orderBy(documentId(), 'desc')`, and an auto-id is random. So a tied pair comes
back in an order unrelated to when it was written, and the suite reported an
ordering bug that was not there.

## The change

Each test creates through the adapter, so the document shape is real, then
writes timestamps a minute apart directly — the pattern the neighbouring
`pages consistently through documents that share a createdAt` already used for
the opposite case. The claim under test is that the query orders by the field,
and that is exactly what still runs. The resolution of somebody else's clock
never was the claim.

Two things beyond the three tests:

- `entryRepo.test.ts` carried a comment saying `serverTimestamp()` cannot be
  made to collide. It collides in about one seeding in twenty. Corrected.
- The measurement is recorded in `CLAUDE.md`, beside the existing rule about
  clocks. The same defect in three files is a rule, not an incident.

## Layer

`tests/integration`, unchanged — the claim is about a query and its index
ordering, which is the row in the table that names the emulator. Nothing moved
layer; what changed is that the assertion no longer depends on a property of the
emulator that was never being asserted.

## Verification

The emulator suite **twenty times, all green**. Before the change it went red
2 times in 10 and 3 times in 12.

`progressRepo` was not in the original diagnosis and only surfaced because the
suite was run ten times after the first two were fixed. That is the reason the
verification here is twenty runs rather than one: a defect that appears in 5% of
runs is invisible to a single green run.

Also: typecheck (three tsconfigs), ESLint 0 errors / 17 warnings (unchanged from
`develop`), `prettier --check .`, unit + component 669. Run after
`yarn install --frozen-lockfile`, since `develop` has moved to TypeScript 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DByP7Ge7Yun9BeonDN5STc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration test reliability for newest-first ordering across entries, progress sessions, and word sets.
  - Tests now use explicit timestamps to verify ordering consistently, including deterministic handling of timestamp ties.
  - Reduced susceptibility to emulator timing variations and unpredictable document ID ordering.

- **Documentation**
  - Added guidance for writing reliable tests involving server-generated timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->