### PR TITLE
chore(hosting): set Cache-Control, so a stale shell cannot outlive a deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,21 @@ out the pull request's base, so a preview channel runs the base branch's
 confirm them on `goitei-dev` after the merge:
 
 ```bash
-yarn build:e2e && yarn firebase emulators:start --only hosting --project demo-goitei
-curl -sI http://127.0.0.1:5000/ | grep -i cache-control
+yarn build:e2e
+yarn firebase emulators:exec --only hosting --project demo-goitei \
+  'curl -sI http://127.0.0.1:5010/ | grep -i cache-control &&
+   curl -sI "http://127.0.0.1:5010/$(cd dist && ls assets/*.js | head -1)" | grep -i cache-control'
 ```
+
+`emulators:exec` and not `emulators:start`: the latter runs in the foreground
+until it is interrupted, so anything written after it never runs. Check a file
+under `/assets/**` as well as `/` — that is the pair the ordering rule above
+decides, and checking only one of them would pass with the rules reversed.
+
+The port is pinned in `firebase.json` rather than left to default to 5000, which
+macOS hands to AirPlay Receiver; the emulator then shifts to another port and a
+hardcoded URL in a script fails for a reason that has nothing to do with what it
+is testing.
 
 ### Operator runbook
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,49 @@ password on the HTML protects the page, not the data.
 Rules deploy before anything that writes through them. A client briefly older
 than its rules fails closed; the other way round fails open.
 
+### Response headers
+
+`firebase.json` sets two things on every response: the security headers, and a
+caching rule. Two of Hosting's matching semantics decide how they have to be
+written, and both were measured against the Hosting emulator rather than read
+off the documentation.
+
+**Every matching entry applies, and for a repeated key the last one wins.** So
+the `**` block holding the security headers is not shadowed by the narrower
+entries after it — an asset still carries the full set — and `/assets/**` gets
+its `Cache-Control` only because it appears _after_ the `**` rule that sets
+`no-cache`. Move it above and the assets silently fall back to revalidating on
+every load.
+
+**A header rule matches the request path, not the rewritten one.** `**` →
+`/index.html` means `/` and `/browse` are served the index document, but a rule
+whose `source` is `/index.html` reaches neither of them; nobody navigates to
+`/index.html` by name. That is why the `no-cache` default is written against
+`**` rather than against the three files that actually need it.
+
+The result:
+
+| Path            | `Cache-Control`                       | Why                                                                                                                                                                                                            |
+| --------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/assets/**`    | `public, max-age=31536000, immutable` | Vite puts a content hash in the name, so a changed file is a changed URL and the old one is never requested again.                                                                                             |
+| everything else | `no-cache`                            | `index.html`, the manifest, the icons and a future `sw.js` keep their names across deploys, so the only safe answer is to revalidate. `no-cache` stores the response and revalidates it; it is not `no-store`. |
+
+`no-cache` as the default rather than a list of filenames is what makes this
+survive the service worker: `/sw.js` is covered before it exists. Hosting's
+default is `max-age=3600` on everything, which would otherwise pin a controlled
+client to an hour-old app shell — and the scripts a worker `importScripts` come
+from the HTTP cache even though the worker script itself does not.
+
+**A pull request cannot verify this on its own preview.** The deploy job checks
+out the pull request's base, so a preview channel runs the base branch's
+`firebase.json`. Check header changes against the Hosting emulator locally, and
+confirm them on `goitei-dev` after the merge:
+
+```bash
+yarn build:e2e && yarn firebase emulators:start --only hosting --project demo-goitei
+curl -sI http://127.0.0.1:5000/ | grep -i cache-control
+```
+
 ### Operator runbook
 
 Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -2,8 +2,9 @@
 
 Set in `firebase.json` under `hosting.headers`.
 
-The array now holds three entries: the security headers below on `**`, and two
-narrower `Cache-Control` rules described in
+The array now holds three entries: the security headers below on `**`, then a
+default `Cache-Control` rule — also on `**`, which is the point of it — and a
+narrower `/assets/**` override. Both are described in
 [README → Response headers](../README.md#response-headers). That matters here
 for one reason — **Hosting applies every matching entry, and only a repeated
 key is decided by the last one to match**. The security headers are therefore
@@ -39,7 +40,9 @@ The `connect-src` list is the minimum Firebase Auth and Firestore need.
 drop it if the avatar is ever rendered from initials only.
 
 `worker-src 'self'` and `manifest-src 'self'` are stated even though
-`default-src 'self'` already implies both. They buy nothing today; they exist so
-that narrowing `default-src` later cannot take the service worker or the web app
-manifest with it silently — and under Report-Only, silently is exactly how it
-would happen.
+`default-src 'self'` already implies both. They buy nothing today, and while the
+policy is Report-Only they would buy nothing if they were missing either: a
+`default-src` narrowed past them blocks no worker and no manifest, it only
+reports. The cost lands at promotion, along with everything else on this page —
+which is precisely when nobody wants to be discovering that one directive was
+doing two jobs.

--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -1,6 +1,14 @@
 # Security headers
 
-Set in `firebase.json` under `hosting.headers`, applied to every response.
+Set in `firebase.json` under `hosting.headers`.
+
+The array now holds three entries: the security headers below on `**`, and two
+narrower `Cache-Control` rules described in
+[README → Response headers](../README.md#response-headers). That matters here
+for one reason — **Hosting applies every matching entry, and only a repeated
+key is decided by the last one to match**. The security headers are therefore
+still on every response, including `/assets/**`, and a narrower entry added
+later will not shadow them unless it names the same header.
 
 ## Enforced
 
@@ -29,3 +37,9 @@ it enforces nothing**, so this is one of the things promotion turns on.
 The `connect-src` list is the minimum Firebase Auth and Firestore need.
 `https://lh3.googleusercontent.com` in `img-src` is the Google profile picture;
 drop it if the avatar is ever rendered from initials only.
+
+`worker-src 'self'` and `manifest-src 'self'` are stated even though
+`default-src 'self'` already implies both. They buy nothing today; they exist so
+that narrowing `default-src` later cannot take the service worker or the web app
+manifest with it silently — and under Report-Only, silently is exactly how it
+would happen.

--- a/firebase.json
+++ b/firebase.json
@@ -33,9 +33,17 @@
           },
           {
             "key": "Content-Security-Policy-Report-Only",
-            "value": "default-src 'self'; script-src 'self' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com; frame-src https://*.firebaseapp.com https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
+            "value": "default-src 'self'; script-src 'self' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://lh3.googleusercontent.com; font-src 'self' data:; worker-src 'self'; manifest-src 'self'; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://securetoken.googleapis.com; frame-src https://*.firebaseapp.com https://accounts.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'"
           }
         ]
+      },
+      {
+        "source": "**",
+        "headers": [{ "key": "Cache-Control", "value": "no-cache" }]
+      },
+      {
+        "source": "/assets/**",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
       }
     ]
   }

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,7 @@
   },
   "emulators": {
     "firestore": { "port": 8080 },
+    "hosting": { "port": 5010 },
     "ui": { "enabled": false },
     "singleProjectMode": true
   },

--- a/tests/unit/cacheHeaders.test.ts
+++ b/tests/unit/cacheHeaders.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * What `Cache-Control` a request actually resolves to, given the rules in
+ * `firebase.json`.
+ *
+ * This reads as a test of a config file, and it is not: the two Hosting
+ * semantics it depends on both make a wrong config look right, and neither is
+ * visible in a diff.
+ *
+ * 1. **Every matching entry applies, and a repeated key is decided by the last
+ *    match** — not the first, and not the most specific. So `/assets/**` gets
+ *    its long lifetime only because it is listed *after* the `**` rule that
+ *    sets `no-cache`. Move it above and every hashed asset silently goes back
+ *    to revalidating on each load: nothing fails, nothing logs, the app is just
+ *    slower forever.
+ * 2. **A rule matches the request path, not the rewritten one.** `**` →
+ *    `/index.html` means `/` and `/browse` are served the index document, but a
+ *    rule whose `source` is `/index.html` reaches neither. Writing the
+ *    `no-cache` default against `**` is what covers a real navigation — and
+ *    what will cover `/sw.js` before it exists.
+ *
+ * Both were measured against the Firebase Hosting emulator, using an unrelated
+ * header as a probe, rather than read off the documentation. `resolve` below is
+ * a model of that measured behaviour; the assertions pin the committed config
+ * against it.
+ */
+
+interface Header {
+  key: string;
+  value: string;
+}
+
+const config = JSON.parse(
+  readFileSync(new URL('../../firebase.json', import.meta.url), 'utf8'),
+) as { hosting?: { headers?: { source: string; headers: Header[] }[] } };
+
+const rules = config.hosting?.headers ?? [];
+
+/**
+ * The shapes a `source` can take here: everything, one exact path, or a prefix.
+ * The exact-path case is modelled even though the config uses none, because a
+ * rule written that way is the mistake this file exists to catch — it looks
+ * like it covers the document and covers only its literal name.
+ */
+const matches = (source: string, path: string): boolean =>
+  source === '**' ||
+  source === path ||
+  (source.endsWith('/**') && path.startsWith(source.slice(0, -2)));
+
+/** Last match wins, which is the half of the semantics that bites. */
+const resolve = (path: string, key: string): string | undefined =>
+  rules
+    .filter((rule) => matches(rule.source, path))
+    .flatMap((rule) => rule.headers)
+    .filter((header) => header.key === key)
+    .at(-1)?.value;
+
+describe('Cache-Control that a request resolves to', () => {
+  // Passing by iterating over nothing is the exact shape of the bug below.
+  it('has rules to resolve against at all', () => {
+    expect(rules.length).toBeGreaterThan(0);
+  });
+
+  it.each(['/', '/browse', '/practice', '/index.html', '/manifest.webmanifest', '/sw.js'])(
+    'revalidates %s, whose name does not change when the build does',
+    (path) => {
+      expect(resolve(path, 'Cache-Control')).toBe('no-cache');
+    },
+  );
+
+  it.each(['/assets/index-CXo-DkYT.js', '/assets/index-BRZ7eUL-.css'])(
+    'lets the browser keep %s forever, since Vite puts the content hash in the name',
+    (path) => {
+      expect(resolve(path, 'Cache-Control')).toBe('public, max-age=31536000, immutable');
+    },
+  );
+
+  // The narrower entries must not cost an asset its security headers. They do
+  // not, because matching entries merge rather than shadow — but that is the
+  // other half of semantic 1, and this is what would notice it changing.
+  it.each([
+    'Strict-Transport-Security',
+    'X-Content-Type-Options',
+    'X-Frame-Options',
+    'Referrer-Policy',
+    'Permissions-Policy',
+    'Cross-Origin-Opener-Policy',
+    'Content-Security-Policy-Report-Only',
+  ])('still sends %s on a hashed asset, not only on the document', (key) => {
+    expect(resolve('/assets/index-CXo-DkYT.js', key)).toBeDefined();
+  });
+});


### PR DESCRIPTION
### Summary

Firebase Hosting sets no `Cache-Control` in `firebase.json`, so everything falls
to its default of `max-age=3600`. This sets the two rules the app actually
needs, before #67 makes the current behaviour permanent rather than transient.

Closes #62.

### The default, measured

Against the live preview channel for #66, every file — the document, the
manifest, the icons, the hashed assets — came back the same way:

```
$ curl -sI https://goitei-dev--pr-66-2ea3k9jd.web.app/ | grep -i cache-control
cache-control: max-age=3600
```

That is fine while a reload always reaches the network. It stops being fine
under a service worker: `index.html` decides what a navigation resolves to, and
the scripts Workbox `importScripts` **do** come from the HTTP cache, even though
the worker script itself does not. A worker rebuilt correctly on top of cached
imports is a worker serving the previous build — and reloading, the thing
everybody tries, is then the action that does not help.

### Two Hosting semantics, measured rather than assumed

Both were established against the Hosting emulator with `X-Frame-Options` as a
probe, because getting either wrong is silent.

**1. Every matching entry applies; a repeated key is decided by the last match.**
Not first-match-wins. If it were, adding a narrow `/assets/**` entry would have
dropped HSTS, CSP and the rest from every asset. It does not — assets still
carry all seven security headers. But position does decide `Cache-Control`:
with `/assets/**` listed *before* `**`, a fresh emulator served the asset the
`**` value instead. So `/assets/**` is last in the array on purpose.

**2. A rule matches the request path, not the rewritten one.** This is the one
that changes the fix. The issue proposes `no-cache` on `/index.html`, but with
`**` → `/index.html` rewriting every route:

| Request | `source: "/index.html"` matches? |
| --- | --- |
| `/index.html` | yes |
| `/` | **no** |
| `/browse` | **no** |

Nobody navigates to `/index.html` by name, so that rule would have left every
real navigation on `max-age=3600` while looking correct. `no-cache` is therefore
the default on `**`, and only `/assets/**` overrides it.

Writing it as a default rather than a list of filenames also means `/sw.js` is
covered before it exists, which is what #67 needs.

### Result

Verified locally against `vite build --mode e2e` output, with the manifest and a
placeholder `sw.js` dropped into `dist/` to stand in for the files #66 and #67
bring:

| Path | `Cache-Control` | Security headers |
| --- | --- | --- |
| `/`, `/browse`, `/practice`, `/index.html` | `no-cache` | 7/7 |
| `/sw.js`, `/manifest.webmanifest`, `/favicon.svg` | `no-cache` | 7/7 |
| `/assets/*.js`, `/assets/*.css` | `public, max-age=31536000, immutable` | 7/7 |

`no-cache` stores the response and revalidates it — it is not `no-store`, and a
304 is what the common case costs.

### Also

`worker-src 'self'` and `manifest-src 'self'` are now stated in the CSP.
`default-src 'self'` already implies both, so this changes no behaviour; it
stops a later narrowing of `default-src` from taking the service worker or the
manifest with it. Under Report-Only, silently is exactly how that would happen.

### Testing

**Layer: unit** (`tests/unit/cacheHeaders.test.ts`), which is the cheapest layer
that can see this defect.

That needs justifying, because the claim looks like an HTTP one. It is not: the
defect is which rule a path *resolves to*, and both semantics above are pure
functions of the committed config. `tests/unit/csp.test.ts` already reads
`firebase.json` in a unit test for the same class of problem — a policy that
silently stops attesting — so this follows an existing precedent rather than
setting one. Neither the emulator nor an e2e run is needed to see any of the
three failures below, and the e2e suite could not see them anyway: it runs
against Vite's preview server, which never reads `firebase.json`.

The test resolves a path through the rules the way the emulator was measured to
— every matching entry, last match wins — and asserts the resulting header. It
asserts an outcome per path, not the array's indices.

**Proved red three ways before being claimed green**, restoring the config each
time:

| Defect injected | Went red | Stayed green |
| --- | --- | --- |
| `/assets/**` moved above `**` | the 2 asset assertions | everything else |
| No `Cache-Control` at all — the pre-#62 config | 8 of 16 | the security-header assertions, and the guard against an empty rule list |
| `no-cache` on `/index.html`, as #62 literally asks | `/`, `/browse`, `/practice`, `/manifest.webmanifest`, `/sw.js` | **`/index.html` itself** |

The third is the one worth reading twice. The literal rule passes for the
filename it names and fails for every path a person actually visits — so
checking `/index.html` by hand would have confirmed a fix that does nothing.
That asymmetry is why the `no-cache` default is written against `**`.

One note on the model: it handles an exact-path `source` even though the config
uses none. Without that, the third case would have gone red because the resolver
ignored the rule entirely, rather than because the rule does not match — right
answer, wrong reason.

Also run by hand, since the unit test models Hosting rather than being Hosting:

- Hosting emulator against a real `vite build` output, all nine paths, with the
  manifest and a placeholder `sw.js` dropped into `dist/` to stand in for what
  #66 and #67 bring
- Both semantics reproduced in isolation with `X-Frame-Options` as the probe,
  including the reordered arrangement that breaks `/assets/**`
- `yarn typecheck`, `yarn lint` (0 errors, 17 pre-existing warnings),
  `yarn format:check`, `yarn test:unit` — 685 passed

#65 still owns the manifest's required fields and an actual offline navigation.
What this PR removes from its scope is the header resolution itself.

### One thing a reviewer cannot check here

**This PR's own preview channel will not show these headers.** The deploy job
checks out the pull request's *base*, so a preview runs `develop`'s
`firebase.json` — as documented in `deploy-dev.yml`. Confirm on `goitei-dev`
after merge:

```bash
curl -sI https://goitei-dev.web.app/ | grep -i cache-control
curl -sI https://goitei-dev.web.app/assets/<hashed>.js | grep -i cache-control
```

### Docs

- `README.md` gains a **Response headers** section: both semantics, the
  resulting table, and the preview-channel caveat.
- `docs/security-headers.md` notes that the array is no longer a single `**`
  entry, and why the narrower ones cannot shadow the security headers.

### Unrelated, spotted while editing

`docs/security-headers.md` says "`frame-ancestors 'none'` is the reason there is
no `X-Frame-Options`" — but `firebase.json` has carried
`X-Frame-Options: DENY` all along, and the Enforced table omits it. Left alone
here rather than folded into a caching change; happy to file it.
