### PR TITLE
feat(pwa): precache the app shell, and offer the build that replaces it

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,59 @@ macOS hands to AirPlay Receiver; the emulator then shifts to another port and a
 hardcoded URL in a script fails for a reason that has nothing to do with what it
 is testing.
 
+### The service worker
+
+`vite-plugin-pwa` precaches the built output — the shell, the CSS, the icons,
+the manifest and **every route chunk**. The chunks are not an optimisation here:
+every route in `src/router.tsx` is a `lazy: () => import(...)`, so a shell
+without them reaches no screen at all. `navigateFallback` is `/index.html`,
+matching the rewrite in `firebase.json`; `/__/*` is denied, because Firebase
+serves `signInWithPopup`'s handler from there and answering it with the index
+document would break sign-in with nothing naming the cause.
+
+Settings live in `pwa-config.ts` rather than inline in `vite.config.ts`, so
+`tests/unit/pwaConfig.test.ts` can read them back. Every failure they guard is
+silent — a build succeeds either way.
+
+**It is off under `mode === 'e2e'`.** A worker that precached the previous build
+serves it to Playwright, and the suite then passes against code that is not the
+code under test. That is the one failure here that would make every other test
+in this repository green and meaningless.
+
+#### What it changes about deploying
+
+Before the worker, a client running a stale build fixed itself: the next load
+fetched a new `index.html` and the new chunk names came with it. It does not any
+more. A controlled client keeps being served the precached build until it is
+told to take a new one — so **reloading is no longer the fix**, and a support
+reply that says "try reloading" is now advice that cannot work.
+
+What ends it is the prompt. `skipWaiting` and `clientsClaim` are both off, so a
+new build installs and waits rather than replacing the assets under a running
+session — which would hand a page mid-practice a chunk from a bundle its loaded
+code was never compiled against. `UpdatePrompt` offers the swap and the reader
+takes it, or does not. A reader who keeps choosing "Later" stays on the old
+build, deliberately: old and working beats new and halfway.
+
+The consequence for a release is that **the deployed commit and the running
+commit are now different questions**. The footer's build line answers the second
+one, which is the one a bug report is actually about.
+
+#### Checking it
+
+The end-to-end suite cannot: it builds `--mode e2e`, where there is no worker.
+Against a production-mode build served locally, in a real browser:
+
+- the worker must reach `activated`, and must **not** control the first page —
+  that is `clientsClaim: false` behaving correctly, not a failure;
+- it takes control from the second navigation onwards;
+- with the network off, `/` and a deep route such as `/vocabulary` must both
+  render, and no same-origin request may fail.
+
+Installability is Chrome DevTools → Application → Manifest on a deployed build.
+Headless Chromium does not fire `beforeinstallprompt`, so that half needs a real
+browser against the dev site or a preview channel.
+
 ### Operator runbook
 
 Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1",
+    "vite-plugin-pwa": "^1.3.0",
     "vitest": "^3.2.4"
   }
 }

--- a/pwa-config.ts
+++ b/pwa-config.ts
@@ -49,8 +49,11 @@ export const pwaOptions = (mode: string): Partial<VitePWAOptions> => ({
    * has to be wired to the same `registerSW` call that learns a new build is
    * waiting. An injected script would register a second time and own the
    * callback this app needs.
+   *
+   * `false` and not `null`: both mean "inject nothing", and the plugin's own
+   * type marks `null` deprecated in favour of `false`.
    */
-  injectRegister: null,
+  injectRegister: false,
 
   workbox: {
     /**

--- a/pwa-config.ts
+++ b/pwa-config.ts
@@ -1,0 +1,115 @@
+import type { VitePWAOptions } from 'vite-plugin-pwa';
+
+/**
+ * The service worker's configuration, as a function of the build mode.
+ *
+ * Extracted from `vite.config.ts` for the same reason `build-info.ts` is: the
+ * interesting part is a value, and a value can be read back and asserted on. A
+ * plugin instance cannot — `VitePWA(options)` returns plugin objects that do
+ * not carry the options anywhere a test can reach — so inlining this would put
+ * every decision below beyond the reach of anything but a full build.
+ *
+ * `tests/unit/pwaConfig.test.ts` is what reads it.
+ */
+export const pwaOptions = (mode: string): Partial<VitePWAOptions> => ({
+  /**
+   * **`prompt`, not `autoUpdate`.** The reader decides when the new build is
+   * taken; see `src/lib/appUpdate.tsx` for what that costs and why it is still
+   * the right side of the trade.
+   */
+  registerType: 'prompt',
+
+  /**
+   * **Off for the end-to-end build, and this is not a tidiness measure.** A
+   * worker that precached the previous build serves it to Playwright, and the
+   * suite then passes against code that is not the code under test — green for
+   * a build nobody shipped. `vite.config.ts` already branches on this mode for
+   * the backend alias, so the seam is one the architecture had rather than one
+   * added for this.
+   */
+  disable: mode === 'e2e',
+
+  /**
+   * Off by default. A worker in `yarn dev` caches modules Vite expects to serve
+   * fresh, and the resulting staleness reads as a bug in whatever is being
+   * edited. Flip it here when the thing being debugged *is* the worker.
+   */
+  devOptions: { enabled: false },
+
+  /**
+   * The manifest is `public/manifest.webmanifest`, written by hand in #66 and
+   * linked from `index.html`. Letting the plugin emit one too would put two
+   * manifests in `dist/` and leave which of them a browser reads to the order
+   * of the tags.
+   */
+  manifest: false,
+
+  /**
+   * Registration happens in `src/infra/pwa/updatePort.ts`, because the prompt
+   * has to be wired to the same `registerSW` call that learns a new build is
+   * waiting. An injected script would register a second time and own the
+   * callback this app needs.
+   */
+  injectRegister: null,
+
+  workbox: {
+    /**
+     * Every route in `src/router.tsx` is a `lazy: () => import(...)`, so the
+     * chunks are the app. Precaching the shell without them is what #67
+     * describes: a cache full of words behind a shell that cannot reach the
+     * screen the reader asked for.
+     *
+     * `webmanifest` is here because the default pattern list does not include
+     * it, and an installed window that cannot read its own manifest offline is
+     * the case this whole change is for.
+     */
+    globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
+
+    /**
+     * Matches the `rewrites` block in `firebase.json`. Without it an offline
+     * navigation to `/vocabulary` asks the cache for a document that was never
+     * a file.
+     */
+    navigateFallback: '/index.html',
+
+    /**
+     * **Firebase reserves `/__/*`, and sign-in is served from it.**
+     * `signInWithPopup` opens `/__/auth/handler` on the configured auth domain.
+     * That is a different origin while the auth domain is the
+     * `*.firebaseapp.com` default — but pointing it at the hosting domain is a
+     * documented way to avoid third-party cookie problems, and the day someone
+     * does that, a navigation fallback would answer the auth handler with
+     * `index.html` and sign-in would break with no error naming the cause.
+     * Denying the prefix costs nothing today and is the difference between that
+     * being a non-event and an outage.
+     */
+    navigateFallbackDenylist: [/^\/__\//],
+
+    /**
+     * **`skipWaiting` and `clientsClaim` both stay off**, which is the decision
+     * #68 asks to have written down.
+     *
+     * Claiming immediately swaps the precached assets under a session that is
+     * already running. The reader mid-dictation does not get a new build so
+     * much as a different one halfway through: the chunk their next interaction
+     * lazily imports comes from a bundle the loaded code was not compiled
+     * against. That is a worse failure than the staleness it fixes, because it
+     * is not reproducible and it lands on whoever was busiest.
+     *
+     * The cost of the other side is real and is not being waved away: a waiting
+     * worker waits for every tab on the origin to close, which for an installed
+     * app can be days. That is exactly why this cannot ship without the prompt
+     * in #68 — the prompt is what ends the wait, on the reader's word rather
+     * than the browser's.
+     */
+    skipWaiting: false,
+    clientsClaim: false,
+
+    /**
+     * Precaches are keyed by revision, so a superseded entry is dead weight in
+     * storage a phone may later reclaim under pressure — taking the live cache
+     * with it.
+     */
+    cleanupOutdatedCaches: true,
+  },
+});

--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useI18n } from '@/i18n/context';
+import { useAppUpdate } from '@/lib/appUpdateContext';
+
+/**
+ * Offers the waiting build, and stays out of the way until there is one.
+ *
+ * **A banner and not a modal.** The reader is mid-something whenever this
+ * arrives — that is the only time it can arrive — and a dialog that takes focus
+ * would interrupt a dictation answer to talk about deployment. `role="status"`
+ * with the default polite live region announces it at the next pause rather
+ * than cutting in, which is the same decision expressed for screen readers.
+ *
+ * **Dismissal is per session, not remembered.** "Later" means later: the
+ * banner returns on the next load, because `onWaiting` replays a build that is
+ * still waiting rather than only reporting the transition. A dismissal that
+ * persisted would leave a reader on an old build with nothing left to tell
+ * them so, which is the state #68 exists to end.
+ */
+export function UpdatePrompt() {
+  const { t } = useI18n();
+  const { updateReady, activate } = useAppUpdate();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!updateReady || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      // Bottom centre, above the add button rather than beside it: on a phone
+      // the two would otherwise overlap, and the one that loses is the button
+      // the reader was reaching for.
+      //
+      // The bottom offset does not yet read `env(safe-area-inset-bottom)`, so
+      // on an installed iOS window this sits nearer the home indicator than it
+      // should. That is #64, which covers every fixed element here at once —
+      // this one and the add button already beside it.
+      className="fixed inset-x-4 bottom-24 z-40 mx-auto max-w-md rounded-panel border border-line bg-card p-4 shadow-panel nav:bottom-5"
+    >
+      <p className="text-sm font-semibold text-ink">{t('update.available')}</p>
+      <p className="prose-cjk mt-1 text-xs text-muted">{t('update.hint')}</p>
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          className="min-h-10 rounded-pill bg-bg-alt px-4 text-sm font-semibold text-ink"
+        >
+          {t('update.later')}
+        </button>
+        <button
+          type="button"
+          onClick={activate}
+          className="min-h-10 rounded-pill bg-accent px-4 text-sm font-semibold text-on-accent"
+        >
+          {t('update.action')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -199,3 +199,31 @@ export interface SearchPort {
   /** False means the UI hides that tab rather than showing an empty state. */
   supports(scope: SearchQuery['scope']): boolean;
 }
+
+/**
+ * A new build is waiting to replace the one that is running.
+ *
+ * A port rather than a direct call into Workbox, for the same reason the
+ * repositories above are: the mechanism is a service worker on the web and the
+ * decision it drives — "offer the reader the new version" — is not about
+ * service workers at all. The `e2e` build supplies an implementation that never
+ * reports one, because that build has no worker to report it.
+ */
+export interface AppUpdatePort {
+  /**
+   * Calls `onWaiting` when a build has installed and is waiting for the running
+   * one to step aside. Returns an unsubscribe function, like `AuthPort.onChange`.
+   *
+   * It may never fire. That is the ordinary case, not an error: most sessions
+   * start and end on the same build.
+   */
+  onWaiting(fn: () => void): () => void;
+  /**
+   * Hand the session over to the waiting build.
+   *
+   * Resolves only in the sense that the request was made — the page is expected
+   * to be replaced out from under the caller, so nothing should be sequenced
+   * after this.
+   */
+  activate(): Promise<void>;
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -59,6 +59,10 @@ const en = {
   'settings.saved': 'Saved.',
   'settings.unsaved': 'You have unsaved changes.',
   'settings.unsavedLeave': 'Leave without saving your settings?',
+  'update.available': 'A new version is available',
+  'update.hint': 'Updating reloads the app, so finish anything you are typing first.',
+  'update.action': 'Update now',
+  'update.later': 'Later',
 } as const;
 
 type BaseMessageKey = keyof typeof en;
@@ -118,6 +122,10 @@ const ja: Messages = {
   'settings.saved': '保存しました。',
   'settings.unsaved': '保存していない変更があります。',
   'settings.unsavedLeave': '設定を保存せずに移動しますか？',
+  'update.available': '新しいバージョンがあります',
+  'update.hint': '更新するとアプリを読み込み直します。入力中の内容は先に保存してください。',
+  'update.action': '今すぐ更新',
+  'update.later': 'あとで',
 };
 
 const zhHant: Messages = {
@@ -173,6 +181,10 @@ const zhHant: Messages = {
   'settings.saved': '已儲存。',
   'settings.unsaved': '有尚未儲存的變更。',
   'settings.unsavedLeave': '設定尚未儲存，確定要離開嗎？',
+  'update.available': '有新版本可以使用',
+  'update.hint': '更新會重新載入應用程式，請先完成正在輸入的內容。',
+  'update.action': '立即更新',
+  'update.later': '稍後',
 };
 
 const ko: Messages = {
@@ -229,6 +241,10 @@ const ko: Messages = {
   'settings.saved': '저장했습니다.',
   'settings.unsaved': '저장하지 않은 변경 사항이 있습니다.',
   'settings.unsavedLeave': '설정을 저장하지 않고 나갈까요?',
+  'update.available': '새 버전이 있습니다',
+  'update.hint': '업데이트하면 앱을 다시 불러옵니다. 입력 중인 내용을 먼저 저장하세요.',
+  'update.action': '지금 업데이트',
+  'update.later': '나중에',
 };
 
 const es: Messages = {
@@ -285,6 +301,10 @@ const es: Messages = {
   'settings.saved': 'Guardado.',
   'settings.unsaved': 'Tienes cambios sin guardar.',
   'settings.unsavedLeave': '¿Salir sin guardar la configuración?',
+  'update.available': 'Hay una versión nueva disponible',
+  'update.hint': 'Al actualizar se recarga la aplicación. Termina antes lo que estés escribiendo.',
+  'update.action': 'Actualizar ahora',
+  'update.later': 'Más tarde',
 };
 
 const allMessages = {

--- a/src/infra/pwa/updatePort.ts
+++ b/src/infra/pwa/updatePort.ts
@@ -1,0 +1,45 @@
+import { registerSW } from 'virtual:pwa-register';
+import type { AppUpdatePort } from '@/domain/ports';
+
+/**
+ * `AppUpdatePort` over the worker `vite-plugin-pwa` generates.
+ *
+ * `registerSW` is called once, at module load, and its return value is the only
+ * way to move the waiting worker along. Registering a second time elsewhere
+ * would produce a second updater whose `onNeedRefresh` fires into nothing,
+ * which is why `injectRegister` is `null` in `vite.config.ts`.
+ */
+
+/**
+ * Set before `registerSW` runs, because `onNeedRefresh` can fire during
+ * registration when a worker is already waiting from a previous visit — the
+ * reader who closed the tab yesterday and opened it today. A subscriber that
+ * arrives after that would otherwise never hear about the build it is there to
+ * announce.
+ */
+let waiting = false;
+const listeners = new Set<() => void>();
+
+const updateSW = registerSW({
+  onNeedRefresh() {
+    waiting = true;
+    for (const listener of listeners) listener();
+  },
+});
+
+export const swUpdatePort: AppUpdatePort = {
+  onWaiting(fn) {
+    listeners.add(fn);
+    // Replays the state rather than only reporting transitions, for the case
+    // above: by the time React has mounted, the event may already have passed.
+    if (waiting) fn();
+    return () => listeners.delete(fn);
+  },
+  /**
+   * `true` is `reloadPage`. The worker calls `skipWaiting()` and the page is
+   * reloaded once it has taken control, which is what makes the reload land on
+   * the new build rather than re-serving the old one and looking like the
+   * button did nothing.
+   */
+  activate: () => updateSW(true),
+};

--- a/src/infra/pwa/updatePort.ts
+++ b/src/infra/pwa/updatePort.ts
@@ -7,7 +7,7 @@ import type { AppUpdatePort } from '@/domain/ports';
  * `registerSW` is called once, at module load, and its return value is the only
  * way to move the waiting worker along. Registering a second time elsewhere
  * would produce a second updater whose `onNeedRefresh` fires into nothing,
- * which is why `injectRegister` is `null` in `vite.config.ts`.
+ * which is why `injectRegister` is `false` in `pwa-config.ts`.
  */
 
 /**
@@ -36,10 +36,18 @@ export const swUpdatePort: AppUpdatePort = {
     return () => listeners.delete(fn);
   },
   /**
-   * `true` is `reloadPage`. The worker calls `skipWaiting()` and the page is
-   * reloaded once it has taken control, which is what makes the reload land on
-   * the new build rather than re-serving the old one and looking like the
-   * button did nothing.
+   * Called bare. The plugin's own signature names the parameter `_reloadPage`
+   * and its type says it "is not used anymore" from 0.13.2 on — all
+   * `updateServiceWorker` does is post `skipWaiting` to the waiting worker, so
+   * passing `true` would have been a decoration that read like a control.
+   *
+   * The reload is real but it is not this call's, and not ours. When
+   * `onNeedRefresh` fires, the plugin attaches a `controlling` listener; no
+   * `onNeedReload` is passed above, so its default branch runs
+   * `window.location.reload()` once the new worker takes control. Supplying
+   * `onNeedReload` here would replace that default and leave the page on the
+   * old build with a new worker underneath it — which is the stale state this
+   * whole file exists to end.
    */
-  activate: () => updateSW(true),
+  activate: () => updateSW(),
 };

--- a/src/lib/appUpdate.tsx
+++ b/src/lib/appUpdate.tsx
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import type { AppUpdatePort } from '@/domain/ports';
+import { AppUpdateContext } from './appUpdateContext';
+
+/**
+ * Whether a newer build is waiting, and the one action that takes it.
+ *
+ * **Why a prompt exists at all.** Before a service worker, a stale chunk fixed
+ * itself: the next load fetched a new `index.html` and the new chunk names came
+ * with it. Under a worker it does not. A controlled client keeps being served
+ * the precached build until every tab on the origin has closed — so reloading,
+ * the thing a reader will try and the thing a support reply would tell them,
+ * is precisely the action that does not help. The worker cannot ship without
+ * the thing that ends its own version.
+ *
+ * **Why the reader decides and not the app.** Activating on arrival would swap
+ * the precached assets under a session already running, and the next lazily
+ * imported route would come from a bundle the loaded code was not compiled
+ * against. Mid-dictation that is a worse failure than the staleness it fixes:
+ * it is unreproducible and it lands on whoever was busiest. The trade is that a
+ * reader who ignores the prompt stays on the old build, which is the outcome
+ * this is choosing on purpose — old and working beats new and halfway.
+ *
+ * The port is injected rather than imported so this module never names a
+ * service worker. That is what lets a component test drive it with a real
+ * implementation instead of a stub of ours.
+ */
+export function AppUpdateProvider({
+  port,
+  children,
+}: {
+  port: AppUpdatePort;
+  children: ReactNode;
+}) {
+  const [updateReady, setUpdateReady] = useState(false);
+
+  useEffect(() => {
+    // `onWaiting` replays a build that was already waiting when this mounted,
+    // so nothing is missed by subscribing after registration.
+    return port.onWaiting(() => setUpdateReady(true));
+  }, [port]);
+
+  const activate = useCallback(() => {
+    void port.activate();
+  }, [port]);
+
+  return (
+    <AppUpdateContext.Provider value={{ updateReady, activate }}>
+      {children}
+    </AppUpdateContext.Provider>
+  );
+}

--- a/src/lib/appUpdateContext.ts
+++ b/src/lib/appUpdateContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Split from `appUpdate.tsx` for the reason `userSettingsContext.ts` is split
+ * from `userSettings.tsx`: a module that exports both a component and a hook
+ * loses fast refresh for everything that imports it.
+ */
+export interface AppUpdateValue {
+  /** A build has installed and is waiting for this session to step aside. */
+  updateReady: boolean;
+  /** Hand over to it. The page is replaced, so nothing follows this. */
+  activate: () => void;
+}
+
+export const AppUpdateContext = createContext<AppUpdateValue | null>(null);
+
+export function useAppUpdate(): AppUpdateValue {
+  const value = useContext(AppUpdateContext);
+  if (!value) throw new Error('useAppUpdate must be used inside <AppUpdateProvider>');
+  return value;
+}

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -1,5 +1,6 @@
 import type { Entry, EntryDraft } from '@/domain/entry';
 import type {
+  AppUpdatePort,
   AuthPort,
   AuthUser,
   EntryRepository,
@@ -113,6 +114,17 @@ const listeners = new Set<(user: AuthUser | null) => void>();
 const notify = () => {
   save('user', currentUser);
   for (const listener of listeners) listener(currentUser);
+};
+
+/**
+ * There is no worker in this build — `VitePWA` is disabled under `mode === 'e2e'`
+ * — so there is nothing that could ever be waiting. This is the honest
+ * implementation of that, not a stub standing in for one: a build with no
+ * service worker genuinely never has a new build installed behind it.
+ */
+export const appUpdatePort: AppUpdatePort = {
+  onWaiting: () => () => {},
+  activate: () => Promise.resolve(),
 };
 
 export const authPort: AuthPort = {

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -1,4 +1,5 @@
 import type {
+  AppUpdatePort,
   AuthPort,
   EntryRepository,
   ProgressRepository,
@@ -11,6 +12,7 @@ import { createEntryRepository } from '@/infra/firebase/entryRepo';
 import { createProgressRepository } from '@/infra/firebase/progressRepo';
 import { createUserRepository } from '@/infra/firebase/userRepo';
 import { createWordSetRepository } from '@/infra/firebase/wordSetRepo';
+import { swUpdatePort } from '@/infra/pwa/updatePort';
 
 /**
  * The single point where the app names its adapters.
@@ -25,6 +27,8 @@ import { createWordSetRepository } from '@/infra/firebase/wordSetRepo';
  */
 
 export const authPort: AuthPort = firebaseAuth;
+
+export const appUpdatePort: AppUpdatePort = swUpdatePort;
 
 export const entryRepositoryFor = (uid: string): EntryRepository => createEntryRepository(db, uid);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,14 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
+// `@/lib/backend`, not `./lib/backend`. The end-to-end alias matches the
+// absolute specifier only, so the relative form resolves straight to the real
+// module and quietly takes Firebase and the service worker into a build that is
+// supposed to have neither.
+import { appUpdatePort } from '@/lib/backend';
+import { UpdatePrompt } from './components/UpdatePrompt';
 import { I18nProvider } from './i18n/I18nProvider';
+import { AppUpdateProvider } from './lib/appUpdate';
 import { AuthProvider } from './lib/auth';
 import { router } from './router';
 import './index.css';
@@ -9,9 +16,24 @@ import './index.css';
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
-      <I18nProvider>
-        <RouterProvider router={router} />
-      </I18nProvider>
+      <AppUpdateProvider port={appUpdatePort}>
+        <I18nProvider>
+          {/*
+            Outside the router, because a waiting build is a fact about the tab
+            and not about the route: a reader sitting on /login or /privacy is
+            just as stuck on the old build as one mid-practice.
+
+            The cost of that placement is the locale. This reads the browser's
+            language, while a signed-in reader's pages read the one saved in
+            their profile — so someone whose device is English and whose app is
+            set to 日本語 gets an English banner. Moving it inside the
+            authenticated tree would fix that and lose the public routes, which
+            is the worse half of the trade for four short strings.
+          */}
+          <UpdatePrompt />
+          <RouterProvider router={router} />
+        </I18nProvider>
+      </AppUpdateProvider>
     </AuthProvider>
   </StrictMode>,
 );

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 interface ImportMetaEnv {
   readonly VITE_FIREBASE_API_KEY: string;

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -46,6 +46,10 @@ describe('UpdatePrompt', () => {
     const { port } = testPort();
     mount(port);
 
+    // Absence is the whole assertion. A banner with no waiting build offers the
+    // reader an update to the build they are already running — and the only
+    // thing the button could do is reload them onto the same code, which reads
+    // as the app being broken rather than as nothing having happened.
     expect(screen.queryByText('新しいバージョンがあります')).not.toBeInTheDocument();
   });
 
@@ -75,6 +79,9 @@ describe('UpdatePrompt', () => {
 
     act(() => screen.getByRole('button', { name: 'あとで' }).click());
 
+    // Absence again, and it is what makes "Later" mean anything. A banner that
+    // stayed up would leave the reader no way to defer: the only control that
+    // cleared it would be the one that reloads them mid-practice.
     expect(screen.queryByText('新しいバージョンがあります')).not.toBeInTheDocument();
     // Zero, and counted rather than inferred from the banner going away. A
     // "Later" that dismissed *and* handed over would look identical on screen

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -69,6 +69,9 @@ describe('UpdatePrompt', () => {
 
     act(() => updateButton().click());
 
+    // Counted at the port, because the screen cannot tell the difference: a
+    // button that dismissed instead of handing over looks identical, and the
+    // reader only finds out when the build they asked for is still not there.
     expect(worker.activations()).toBe(1);
   });
 
@@ -101,6 +104,11 @@ describe('UpdatePrompt', () => {
     mount(worker.port);
     worker.announceWaitingBuild();
 
+    // Queried by role rather than by text, and that is the assertion. `status`
+    // is a polite live region: a screen reader announces it at the next pause.
+    // Lose the role and the banner is either silent to a screen reader, or —
+    // if someone reaches for `alert` — cuts into the dictation answer being
+    // typed, which is the one moment this can arrive.
     expect(screen.getByRole('status')).toHaveTextContent('新しいバージョンがあります');
   });
 });

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -76,6 +76,10 @@ describe('UpdatePrompt', () => {
     act(() => screen.getByRole('button', { name: 'あとで' }).click());
 
     expect(screen.queryByText('新しいバージョンがあります')).not.toBeInTheDocument();
+    // Zero, and counted rather than inferred from the banner going away. A
+    // "Later" that dismissed *and* handed over would look identical on screen
+    // for the moment before the page reloaded underneath the reader — which is
+    // the swap they just declined, arriving anyway.
     expect(worker.activations()).toBe(0);
   });
 

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -1,0 +1,95 @@
+import { act, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UpdatePrompt } from '@/components/UpdatePrompt';
+import type { AppUpdatePort } from '@/domain/ports';
+import { AppUpdateProvider } from '@/lib/appUpdate';
+import { renderWithI18n as render } from '../helpers/renderWithI18n';
+
+/**
+ * The port is implemented here rather than substituted for. `AppUpdatePort` is
+ * a seam the architecture already has — `src/lib/backend.e2e.ts` implements the
+ * same one for the end-to-end build — so this is standing in for a service
+ * worker, not stubbing out `src/lib` or `src/components`.
+ */
+function testPort() {
+  const listeners = new Set<() => void>();
+  let activations = 0;
+  const port: AppUpdatePort = {
+    onWaiting(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    activate() {
+      activations += 1;
+      return Promise.resolve();
+    },
+  };
+  return {
+    port,
+    /** What the worker does when a new build has installed and is waiting. */
+    announceWaitingBuild: () => act(() => listeners.forEach((fn) => fn())),
+    activations: () => activations,
+  };
+}
+
+const mount = (port: AppUpdatePort) =>
+  render(
+    <AppUpdateProvider port={port}>
+      <UpdatePrompt />
+    </AppUpdateProvider>,
+  );
+
+const updateButton = () => screen.getByRole('button', { name: '今すぐ更新' });
+
+describe('UpdatePrompt', () => {
+  it('says nothing until a build is actually waiting, so nobody is offered the build they are already on', () => {
+    const { port } = testPort();
+    mount(port);
+
+    expect(screen.queryByText('新しいバージョンがあります')).not.toBeInTheDocument();
+  });
+
+  it('appears once a build is waiting, which is the only signal a controlled client ever gets', () => {
+    const worker = testPort();
+    mount(worker.port);
+
+    worker.announceWaitingBuild();
+
+    expect(screen.getByText('新しいバージョンがあります')).toBeInTheDocument();
+  });
+
+  it('hands over to the waiting build, because reloading re-serves the precached one instead', () => {
+    const worker = testPort();
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    act(() => updateButton().click());
+
+    expect(worker.activations()).toBe(1);
+  });
+
+  it('takes Later without activating, since the swap costs a reader mid-practice their session', () => {
+    const worker = testPort();
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    act(() => screen.getByRole('button', { name: 'あとで' }).click());
+
+    expect(screen.queryByText('新しいバージョンがあります')).not.toBeInTheDocument();
+    expect(worker.activations()).toBe(0);
+  });
+
+  /**
+   * Not a styling assertion. The banner arrives while the reader is mid-task —
+   * that is the only moment it can arrive — and an assertive live region would
+   * cut into a dictation answer to talk about deployment. `role="status"` is
+   * polite by default, so it is announced at the next pause instead.
+   */
+  it('announces politely rather than interrupting, because it always arrives mid-task', () => {
+    const worker = testPort();
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    expect(screen.getByRole('status')).toHaveTextContent('新しいバージョンがあります');
+  });
+});

--- a/tests/unit/backendSeam.test.ts
+++ b/tests/unit/backendSeam.test.ts
@@ -28,6 +28,21 @@ import { describe, expect, it } from 'vitest';
 
 const srcDir = fileURLToPath(new URL('../../src', import.meta.url));
 
+/**
+ * Every specifier in `source` that resolves to the backend module.
+ *
+ * Both spellings that reach a module have to be covered, and a first version of
+ * this missed one. `import('…')` carries no `from`, so a detector written
+ * around `from '…'` sees nothing — and a dynamic import is not hypothetical
+ * here: every route in `src/router.tsx` is written as one, so it is the form a
+ * lazily loaded consumer would most naturally reach for. Quote style is
+ * normalised by Prettier and checked in CI, but costs nothing to accept.
+ */
+export const backendSpecifiers = (source: string): string[] =>
+  [...source.matchAll(/(?:from\s+|import\s*\(\s*)['"]([^'"]*\bbackend)['"]/g)].map(
+    (match) => match[1]!,
+  );
+
 function sourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((name) => {
     const path = join(dir, name);
@@ -36,29 +51,57 @@ function sourceFiles(dir: string): string[] {
   });
 }
 
-/** Any import whose specifier ends at the backend module, however it is spelled. */
-const BACKEND_IMPORT = /from\s+'([^']*\bbackend)'/g;
-
 const offenders = sourceFiles(srcDir)
   .filter((path) => !path.endsWith('backend.e2e.ts'))
-  .flatMap((path) => {
-    const source = readFileSync(path, 'utf8');
-    return [...source.matchAll(BACKEND_IMPORT)]
-      .map((match) => match[1])
+  .flatMap((path) =>
+    backendSpecifiers(readFileSync(path, 'utf8'))
       .filter((specifier) => specifier !== '@/lib/backend')
-      .map((specifier) => `${path.slice(srcDir.length + 1)} imports '${specifier}'`);
+      .map((specifier) => `${path.slice(srcDir.length + 1)} imports '${specifier}'`),
+  );
+
+/**
+ * The detector, before anything is concluded from it. A scan that silently
+ * matches nothing reports a clean tree and a broken seam identically, and that
+ * is the failure this whole file is about — so the regular expression is held
+ * to the same standard as the code it polices.
+ */
+describe('the detector sees every way a module is named', () => {
+  it.each([
+    ['a static import', "import { authPort } from './lib/backend';", './lib/backend'],
+    ['a double-quoted import', 'import { authPort } from "./lib/backend";', './lib/backend'],
+    // A sibling inside src/lib reaches it as './backend', which is the shortest
+    // spelling and the one least likely to look wrong to a reader.
+    ['a re-export', "export { authPort } from './backend';", './backend'],
+    ['a dynamic import', "const m = await import('./lib/backend');", './lib/backend'],
+    ['a double-quoted dynamic import', 'const m = await import("./lib/backend");', './lib/backend'],
+    ['a lazy route-style import', "lazy: () => import('./backend')", './backend'],
+  ])('finds the specifier in %s', (_form, source, expected) => {
+    expect(backendSpecifiers(source)).toEqual([expected]);
   });
 
+  it('reads the aliased spelling as itself, so the allowed form is not reported', () => {
+    expect(backendSpecifiers("import { authPort } from '@/lib/backend';")).toEqual([
+      '@/lib/backend',
+    ]);
+  });
+
+  it.each([
+    ['an unrelated module', "import { thing } from './backendish-helper';"],
+    ['a word inside an identifier', 'const backendCount = 1;'],
+  ])('does not invent a specifier from %s', (_form, source) => {
+    expect(backendSpecifiers(source)).toEqual([]);
+  });
+});
+
 describe('the end-to-end backend seam', () => {
-  // Passing by iterating over nothing is the exact shape of the bug below, so
-  // the fixture is asserted before anything is concluded from it.
+  // Passing by iterating over nothing is the exact shape of the bug below.
   it('can see the source tree it is scanning', () => {
     expect(sourceFiles(srcDir).length).toBeGreaterThan(20);
   });
 
   it('finds the real backend module, so a rename cannot make this pass by matching nothing', () => {
-    const importers = sourceFiles(srcDir).filter((path) =>
-      /from\s+'[^']*\bbackend'/.test(readFileSync(path, 'utf8')),
+    const importers = sourceFiles(srcDir).filter(
+      (path) => backendSpecifiers(readFileSync(path, 'utf8')).length > 0,
     );
     expect(importers.length).toBeGreaterThan(0);
   });

--- a/tests/unit/backendSeam.test.ts
+++ b/tests/unit/backendSeam.test.ts
@@ -1,0 +1,69 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The end-to-end build swaps the datasource by aliasing one specifier:
+ *
+ * ```ts
+ * { find: /^@\/lib\/backend$/, replacement: src('lib/backend.e2e.ts') }
+ * ```
+ *
+ * A regular expression anchored on `@/lib/backend` matches the absolute
+ * specifier and nothing else, so `./lib/backend` from `src/main.tsx` — or
+ * `./backend` from a sibling in `src/lib` — resolves straight past it to the
+ * real module. Vite reports no error, the build succeeds, and the bundle
+ * Playwright runs against quietly contains the Firebase SDK and the service
+ * worker registration that `mode === 'e2e'` exists to keep out.
+ *
+ * Nothing about that is visible in a diff: a relative import next to other
+ * relative imports is what the file already looks like. It happened once while
+ * this test's own feature was being written.
+ *
+ * The layer is unit because the defect is a property of the source text. Seeing
+ * it in a build would mean asserting on bundle contents, which is slower and
+ * says less about why.
+ */
+
+const srcDir = fileURLToPath(new URL('../../src', import.meta.url));
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) return sourceFiles(path);
+    return /\.tsx?$/.test(name) ? [path] : [];
+  });
+}
+
+/** Any import whose specifier ends at the backend module, however it is spelled. */
+const BACKEND_IMPORT = /from\s+'([^']*\bbackend)'/g;
+
+const offenders = sourceFiles(srcDir)
+  .filter((path) => !path.endsWith('backend.e2e.ts'))
+  .flatMap((path) => {
+    const source = readFileSync(path, 'utf8');
+    return [...source.matchAll(BACKEND_IMPORT)]
+      .map((match) => match[1])
+      .filter((specifier) => specifier !== '@/lib/backend')
+      .map((specifier) => `${path.slice(srcDir.length + 1)} imports '${specifier}'`);
+  });
+
+describe('the end-to-end backend seam', () => {
+  // Passing by iterating over nothing is the exact shape of the bug below, so
+  // the fixture is asserted before anything is concluded from it.
+  it('can see the source tree it is scanning', () => {
+    expect(sourceFiles(srcDir).length).toBeGreaterThan(20);
+  });
+
+  it('finds the real backend module, so a rename cannot make this pass by matching nothing', () => {
+    const importers = sourceFiles(srcDir).filter((path) =>
+      /from\s+'[^']*\bbackend'/.test(readFileSync(path, 'utf8')),
+    );
+    expect(importers.length).toBeGreaterThan(0);
+  });
+
+  it('names the backend as @/lib/backend everywhere, since a relative specifier resolves past the e2e alias', () => {
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -6,7 +6,9 @@ import { pwaOptions } from '../../pwa-config';
  *
  * Every failure guarded here is silent. Nothing throws, nothing goes red on its
  * own, and the build succeeds either way — which is the whole reason these are
- * assertions rather than a comment asking the next person to be careful.
+ * assertions rather than a comment asking the next person to be careful. Each
+ * one carries its consequence immediately above it, because a reason written
+ * above `it(...)` cannot say which of several assertions it belongs to.
  *
  * What this deliberately does **not** cover is whether the app actually loads
  * with the network off. That needs a production-mode build in a real browser,
@@ -23,42 +25,29 @@ const workboxOf = (mode: string) => {
 };
 
 describe('the service worker is absent from the end-to-end build', () => {
-  /**
-   * The one that matters most, and the one that fails quietest. A worker in the
-   * `e2e` build precaches a bundle and then serves it to the next Playwright
-   * run, so the suite passes against a build that is not the one under test.
-   * Every other test in this repository would still be green while proving
-   * nothing.
-   */
   it('is disabled under e2e, so Playwright cannot be served a previous build', () => {
+    // The one that matters most, and the one that fails quietest. A worker here
+    // precaches a bundle and serves it to the next Playwright run, so the suite
+    // passes against a build that is not the one under test — every other test
+    // in this repository still green while proving nothing.
     expect(pwaOptions('e2e').disable).toBe(true);
   });
 
-  /**
-   * `development` is not decoration in this list. `disable` governs the build;
-   * `devOptions.enabled` governs `yarn dev`, and it is off — so nothing runs a
-   * worker while editing either way. What this holds up is the by-hand dev
-   * deploy the README documents, `yarn vite build --mode development` followed
-   * by a Hosting deploy. Disabling on this mode would ship `goitei-dev` an app
-   * that silently has no worker, which is a thing nobody would notice until
-   * they were offline and expecting one.
-   */
   it.each(['production', 'development'])(
     'is enabled under %s, since disabling it everywhere would silently drop the feature',
     (mode) => {
+      // `development` is not padding beside `production`. `disable` governs the
+      // build while `devOptions.enabled` governs `yarn dev`, and that is off —
+      // so nothing runs a worker while editing either way. What this holds up
+      // is the by-hand dev deploy the README documents, `yarn vite build --mode
+      // development`, which would otherwise ship `goitei-dev` an app with no
+      // worker at all, unnoticed until someone went offline expecting one.
       expect(pwaOptions(mode).disable).toBe(false);
     },
   );
 });
 
 describe('the update handover', () => {
-  /**
-   * `autoUpdate` would swap the precached assets under a running session, so
-   * the next lazily imported route arrives from a bundle the loaded code was
-   * not compiled against. `prompt` is what makes the reader the one who
-   * chooses, and `src/components/UpdatePrompt.tsx` only has anything to do
-   * while this holds.
-   */
   it('waits to be asked rather than updating underneath a running session', () => {
     // `autoUpdate` reloads the reader without asking, mid-sentence in a
     // dictation answer if that is where they are.
@@ -72,46 +61,45 @@ describe('the update handover', () => {
     expect(workboxOf('production').clientsClaim).toBe(false);
   });
 
-  /**
-   * Two registrations means two updaters, and the second one's `onNeedRefresh`
-   * fires into nothing. The prompt would then never appear, while everything
-   * about the worker still looked correct.
-   */
   it('leaves registration to the adapter, so the prompt is wired to the live updater', () => {
+    // An injected registration is a second updater, and the second one's
+    // `onNeedRefresh` fires into nothing. The prompt then never appears while
+    // everything about the worker still looks correct — a stale build with no
+    // way left to report itself.
     expect(pwaOptions('production').injectRegister).toBe(false);
   });
 });
 
 describe('what an offline navigation can reach', () => {
-  /**
-   * Every route in `src/router.tsx` is a lazy import. A pattern list that
-   * stopped matching `.js` would precache the shell and none of the screens —
-   * the exact state #67 describes, and one that looks fine until the network
-   * goes away.
-   */
   it('precaches the route chunks, which are the app rather than an optimisation', () => {
     const patterns = workboxOf('production').globPatterns ?? [];
+    // Every route in `src/router.tsx` is a lazy import, so dropping `js` here
+    // precaches the shell and none of the screens: the app opens offline and
+    // reaches nothing, which is the exact state #67 describes.
     expect(patterns.some((pattern) => pattern.includes('js'))).toBe(true);
+    // Without the manifest an installed window cannot read its own identity
+    // offline, which is the case this whole change exists for.
     expect(patterns.some((pattern) => pattern.includes('webmanifest'))).toBe(true);
   });
 
   it('answers a deep navigation with the index document, matching the hosting rewrite', () => {
+    // Without it, an offline visit to `/vocabulary` asks the cache for a
+    // document that was never a file, and the reader gets the browser's
+    // offline error instead of the app they installed.
     expect(workboxOf('production').navigateFallback).toBe('/index.html');
   });
 
-  /**
-   * `signInWithPopup` opens `/__/auth/handler`. If the auth domain is ever
-   * pointed at the hosting domain, that becomes same-origin and in scope — and
-   * a navigation fallback would answer it with `index.html`, breaking sign-in
-   * with nothing naming the cause.
-   *
-   * Asserted as behaviour over paths rather than by comparing the pattern to
-   * itself, which would pass for any regular expression at all.
-   */
   it.each(['/__/auth/handler', '/__/auth/iframe', '/__/firebase/init.json'])(
     'keeps %s away from the navigation fallback, since Firebase serves sign-in from there',
     (path) => {
       const denied = workboxOf('production').navigateFallbackDenylist ?? [];
+      // `signInWithPopup` opens `/__/auth/handler`. Should the auth domain ever
+      // point at the hosting domain, that path becomes same-origin and in
+      // scope — and a fallback would answer it with `index.html`, breaking
+      // sign-in with no error naming the cause.
+      //
+      // Asserted over paths rather than by comparing the pattern to itself,
+      // which would pass for any regular expression at all.
       expect(denied.some((pattern) => pattern.test(path))).toBe(true);
     },
   );
@@ -120,6 +108,9 @@ describe('what an offline navigation can reach', () => {
     'still lets %s fall back, which is what makes it reachable offline',
     (path) => {
       const denied = workboxOf('production').navigateFallbackDenylist ?? [];
+      // The other half of the denylist, and the half a too-broad pattern
+      // breaks: deny these and every route stops resolving offline, which is
+      // the feature rather than a corner of it.
       expect(denied.some((pattern) => pattern.test(path))).toBe(false);
     },
   );

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -34,6 +34,15 @@ describe('the service worker is absent from the end-to-end build', () => {
     expect(pwaOptions('e2e').disable).toBe(true);
   });
 
+  /**
+   * `development` is not decoration in this list. `disable` governs the build;
+   * `devOptions.enabled` governs `yarn dev`, and it is off — so nothing runs a
+   * worker while editing either way. What this holds up is the by-hand dev
+   * deploy the README documents, `yarn vite build --mode development` followed
+   * by a Hosting deploy. Disabling on this mode would ship `goitei-dev` an app
+   * that silently has no worker, which is a thing nobody would notice until
+   * they were offline and expecting one.
+   */
   it.each(['production', 'development'])(
     'is enabled under %s, since disabling it everywhere would silently drop the feature',
     (mode) => {

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -62,7 +62,7 @@ describe('the update handover', () => {
    * about the worker still looked correct.
    */
   it('leaves registration to the adapter, so the prompt is wired to the live updater', () => {
-    expect(pwaOptions('production').injectRegister).toBeNull();
+    expect(pwaOptions('production').injectRegister).toBe(false);
   });
 });
 

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { pwaOptions } from '../../pwa-config';
+
+/**
+ * The worker's settings, at the layer that can see them without a build.
+ *
+ * Every failure guarded here is silent. Nothing throws, nothing goes red on its
+ * own, and the build succeeds either way — which is the whole reason these are
+ * assertions rather than a comment asking the next person to be careful.
+ *
+ * What this deliberately does **not** cover is whether the app actually loads
+ * with the network off. That needs a production-mode build in a real browser,
+ * and the Playwright harness builds `--mode e2e`, where the worker does not
+ * exist by design. #65 owns that and names the layer it needs. The offline
+ * behaviour was verified by hand for this change instead: 37/37 precached, `/`
+ * and `/vocabulary` both rendering offline, the manifest still served.
+ */
+
+const workboxOf = (mode: string) => {
+  const workbox = pwaOptions(mode).workbox;
+  if (!workbox) throw new Error(`no workbox config for mode ${mode}`);
+  return workbox;
+};
+
+describe('the service worker is absent from the end-to-end build', () => {
+  /**
+   * The one that matters most, and the one that fails quietest. A worker in the
+   * `e2e` build precaches a bundle and then serves it to the next Playwright
+   * run, so the suite passes against a build that is not the one under test.
+   * Every other test in this repository would still be green while proving
+   * nothing.
+   */
+  it('is disabled under e2e, so Playwright cannot be served a previous build', () => {
+    expect(pwaOptions('e2e').disable).toBe(true);
+  });
+
+  it.each(['production', 'development'])(
+    'is enabled under %s, since disabling it everywhere would silently drop the feature',
+    (mode) => {
+      expect(pwaOptions(mode).disable).toBe(false);
+    },
+  );
+});
+
+describe('the update handover', () => {
+  /**
+   * `autoUpdate` would swap the precached assets under a running session, so
+   * the next lazily imported route arrives from a bundle the loaded code was
+   * not compiled against. `prompt` is what makes the reader the one who
+   * chooses, and `src/components/UpdatePrompt.tsx` only has anything to do
+   * while this holds.
+   */
+  it('waits to be asked rather than updating underneath a running session', () => {
+    expect(pwaOptions('production').registerType).toBe('prompt');
+    expect(workboxOf('production').skipWaiting).toBe(false);
+    expect(workboxOf('production').clientsClaim).toBe(false);
+  });
+
+  /**
+   * Two registrations means two updaters, and the second one's `onNeedRefresh`
+   * fires into nothing. The prompt would then never appear, while everything
+   * about the worker still looked correct.
+   */
+  it('leaves registration to the adapter, so the prompt is wired to the live updater', () => {
+    expect(pwaOptions('production').injectRegister).toBeNull();
+  });
+});
+
+describe('what an offline navigation can reach', () => {
+  /**
+   * Every route in `src/router.tsx` is a lazy import. A pattern list that
+   * stopped matching `.js` would precache the shell and none of the screens —
+   * the exact state #67 describes, and one that looks fine until the network
+   * goes away.
+   */
+  it('precaches the route chunks, which are the app rather than an optimisation', () => {
+    const patterns = workboxOf('production').globPatterns ?? [];
+    expect(patterns.some((pattern) => pattern.includes('js'))).toBe(true);
+    expect(patterns.some((pattern) => pattern.includes('webmanifest'))).toBe(true);
+  });
+
+  it('answers a deep navigation with the index document, matching the hosting rewrite', () => {
+    expect(workboxOf('production').navigateFallback).toBe('/index.html');
+  });
+
+  /**
+   * `signInWithPopup` opens `/__/auth/handler`. If the auth domain is ever
+   * pointed at the hosting domain, that becomes same-origin and in scope — and
+   * a navigation fallback would answer it with `index.html`, breaking sign-in
+   * with nothing naming the cause.
+   *
+   * Asserted as behaviour over paths rather than by comparing the pattern to
+   * itself, which would pass for any regular expression at all.
+   */
+  it.each(['/__/auth/handler', '/__/auth/iframe', '/__/firebase/init.json'])(
+    'keeps %s away from the navigation fallback, since Firebase serves sign-in from there',
+    (path) => {
+      const denied = workboxOf('production').navigateFallbackDenylist ?? [];
+      expect(denied.some((pattern) => pattern.test(path))).toBe(true);
+    },
+  );
+
+  it.each(['/', '/vocabulary', '/practice/dictation', '/wordsets/abc'])(
+    'still lets %s fall back, which is what makes it reachable offline',
+    (path) => {
+      const denied = workboxOf('production').navigateFallbackDenylist ?? [];
+      expect(denied.some((pattern) => pattern.test(path))).toBe(false);
+    },
+  );
+});

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -60,8 +60,15 @@ describe('the update handover', () => {
    * while this holds.
    */
   it('waits to be asked rather than updating underneath a running session', () => {
+    // `autoUpdate` reloads the reader without asking, mid-sentence in a
+    // dictation answer if that is where they are.
     expect(pwaOptions('production').registerType).toBe('prompt');
+    // Skipping the wait replaces the precached assets while the page is still
+    // running on the old ones, so the next lazily imported route arrives from
+    // a bundle the loaded code was never compiled against.
     expect(workboxOf('production').skipWaiting).toBe(false);
+    // Claiming does the same to any *other* open tab, which is worse: nobody
+    // there pressed anything.
     expect(workboxOf('production').clientsClaim).toBe(false);
   });
 

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -22,6 +22,12 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
+    // Config files import each other by explicit `.ts` path. Vite's coming
+    // native config loader does not resolve an extensionless specifier, and
+    // says so as a warning on every build today. Safe here because this
+    // project only ever typechecks — `noEmit` above is the option's own
+    // precondition.
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true
   },
   "include": [

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -24,5 +24,11 @@
     "noEmit": true,
     "skipLibCheck": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts", "playwright.config.ts", "build-info.ts"]
+  "include": [
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "build-info.ts",
+    "pwa-config.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,120 @@ import { fileURLToPath, URL } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { VitePWA } from 'vite-plugin-pwa';
 import { buildInfo } from './build-info';
 
 const src = (path: string) => fileURLToPath(new URL(`./src/${path}`, import.meta.url));
 
 export default defineConfig(({ mode }) => ({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    VitePWA({
+      /**
+       * **`prompt`, not `autoUpdate`.** The reader decides when the new build
+       * is taken; see `src/lib/appUpdate.tsx` for what that costs and why it is
+       * still the right side of the trade.
+       */
+      registerType: 'prompt',
+
+      /**
+       * **Off for the end-to-end build, and this is not a tidiness measure.**
+       * A worker that precached the previous build serves it to Playwright,
+       * and the suite then passes against code that is not the code under
+       * test — green for a build nobody shipped. `vite.config.ts` already
+       * branches on this mode for the backend alias, so the seam is one the
+       * architecture had rather than one added for this.
+       */
+      disable: mode === 'e2e',
+
+      /**
+       * Off by default. A worker in `yarn dev` caches modules Vite expects to
+       * serve fresh, and the resulting staleness reads as a bug in whatever is
+       * being edited. Flip it here when the thing being debugged *is* the
+       * worker.
+       */
+      devOptions: { enabled: false },
+
+      /**
+       * The manifest is `public/manifest.webmanifest`, written by hand in #66
+       * and linked from `index.html`. Letting the plugin emit one too would put
+       * two manifests in `dist/` and leave which of them a browser reads to the
+       * order of the tags.
+       */
+      manifest: false,
+
+      /**
+       * Registration happens in `src/infra/pwa/updatePort.ts`, because the
+       * prompt has to be wired to the same `registerSW` call that learns a new
+       * build is waiting. An injected script would register a second time and
+       * own the callback this app needs.
+       */
+      injectRegister: null,
+
+      workbox: {
+        /**
+         * Every route in `src/router.tsx` is a `lazy: () => import(...)`, so
+         * the chunks are the app. Precaching the shell without them is what
+         * #67 describes: a cache full of words behind a shell that cannot
+         * reach the screen the reader asked for.
+         *
+         * `webmanifest` is here because the default pattern list does not
+         * include it, and an installed window that cannot read its own
+         * manifest offline is the case this whole change is for.
+         */
+        globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
+
+        /**
+         * Matches the `rewrites` block in `firebase.json`. Without it an
+         * offline navigation to `/vocabulary` asks the cache for a document
+         * that was never a file.
+         */
+        navigateFallback: '/index.html',
+
+        /**
+         * **Firebase reserves `/__/*`, and sign-in is served from it.**
+         * `signInWithPopup` opens `/__/auth/handler` on the configured auth
+         * domain. That is a different origin while the auth domain is the
+         * `*.firebaseapp.com` default — but pointing it at the hosting domain
+         * is a documented way to avoid third-party cookie problems, and the
+         * day someone does that, a navigation fallback would answer the auth
+         * handler with `index.html` and sign-in would break with no error
+         * naming the cause. Denying the prefix costs nothing today and is the
+         * difference between that being a non-event and an outage.
+         */
+        navigateFallbackDenylist: [/^\/__\//],
+
+        /**
+         * **`skipWaiting` and `clientsClaim` both stay off**, which is the
+         * decision #68 asks to have written down.
+         *
+         * Claiming immediately swaps the precached assets under a session that
+         * is already running. The reader mid-dictation does not get a new
+         * build so much as a different one halfway through: the chunk their
+         * next interaction lazily imports comes from a bundle the loaded code
+         * was not compiled against. That is a worse failure than the staleness
+         * it fixes, because it is not reproducible and it lands on whoever was
+         * busiest.
+         *
+         * The cost of the other side is real and is not being waved away: a
+         * waiting worker waits for every tab on the origin to close, which for
+         * an installed app can be days. That is exactly why this cannot ship
+         * without the prompt in #68 — the prompt is what ends the wait, on the
+         * reader's word rather than the browser's.
+         */
+        skipWaiting: false,
+        clientsClaim: false,
+
+        /**
+         * Precaches are keyed by revision, so a superseded entry is dead
+         * weight in storage a phone may later reclaim under pressure — taking
+         * the live cache with it.
+         */
+        cleanupOutdatedCaches: true,
+      },
+    }),
+  ],
   define: buildInfo(mode),
   resolve: {
     // Array form, because the e2e override has to be matched before the bare

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
-import { buildInfo } from './build-info';
-import { pwaOptions } from './pwa-config';
+import { buildInfo } from './build-info.ts';
+import { pwaOptions } from './pwa-config.ts';
 
 const src = (path: string) => fileURLToPath(new URL(`./src/${path}`, import.meta.url));
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,118 +4,14 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
 import { buildInfo } from './build-info';
+import { pwaOptions } from './pwa-config';
 
 const src = (path: string) => fileURLToPath(new URL(`./src/${path}`, import.meta.url));
 
 export default defineConfig(({ mode }) => ({
-  plugins: [
-    react(),
-    tailwindcss(),
-    VitePWA({
-      /**
-       * **`prompt`, not `autoUpdate`.** The reader decides when the new build
-       * is taken; see `src/lib/appUpdate.tsx` for what that costs and why it is
-       * still the right side of the trade.
-       */
-      registerType: 'prompt',
-
-      /**
-       * **Off for the end-to-end build, and this is not a tidiness measure.**
-       * A worker that precached the previous build serves it to Playwright,
-       * and the suite then passes against code that is not the code under
-       * test — green for a build nobody shipped. `vite.config.ts` already
-       * branches on this mode for the backend alias, so the seam is one the
-       * architecture had rather than one added for this.
-       */
-      disable: mode === 'e2e',
-
-      /**
-       * Off by default. A worker in `yarn dev` caches modules Vite expects to
-       * serve fresh, and the resulting staleness reads as a bug in whatever is
-       * being edited. Flip it here when the thing being debugged *is* the
-       * worker.
-       */
-      devOptions: { enabled: false },
-
-      /**
-       * The manifest is `public/manifest.webmanifest`, written by hand in #66
-       * and linked from `index.html`. Letting the plugin emit one too would put
-       * two manifests in `dist/` and leave which of them a browser reads to the
-       * order of the tags.
-       */
-      manifest: false,
-
-      /**
-       * Registration happens in `src/infra/pwa/updatePort.ts`, because the
-       * prompt has to be wired to the same `registerSW` call that learns a new
-       * build is waiting. An injected script would register a second time and
-       * own the callback this app needs.
-       */
-      injectRegister: null,
-
-      workbox: {
-        /**
-         * Every route in `src/router.tsx` is a `lazy: () => import(...)`, so
-         * the chunks are the app. Precaching the shell without them is what
-         * #67 describes: a cache full of words behind a shell that cannot
-         * reach the screen the reader asked for.
-         *
-         * `webmanifest` is here because the default pattern list does not
-         * include it, and an installed window that cannot read its own
-         * manifest offline is the case this whole change is for.
-         */
-        globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
-
-        /**
-         * Matches the `rewrites` block in `firebase.json`. Without it an
-         * offline navigation to `/vocabulary` asks the cache for a document
-         * that was never a file.
-         */
-        navigateFallback: '/index.html',
-
-        /**
-         * **Firebase reserves `/__/*`, and sign-in is served from it.**
-         * `signInWithPopup` opens `/__/auth/handler` on the configured auth
-         * domain. That is a different origin while the auth domain is the
-         * `*.firebaseapp.com` default — but pointing it at the hosting domain
-         * is a documented way to avoid third-party cookie problems, and the
-         * day someone does that, a navigation fallback would answer the auth
-         * handler with `index.html` and sign-in would break with no error
-         * naming the cause. Denying the prefix costs nothing today and is the
-         * difference between that being a non-event and an outage.
-         */
-        navigateFallbackDenylist: [/^\/__\//],
-
-        /**
-         * **`skipWaiting` and `clientsClaim` both stay off**, which is the
-         * decision #68 asks to have written down.
-         *
-         * Claiming immediately swaps the precached assets under a session that
-         * is already running. The reader mid-dictation does not get a new
-         * build so much as a different one halfway through: the chunk their
-         * next interaction lazily imports comes from a bundle the loaded code
-         * was not compiled against. That is a worse failure than the staleness
-         * it fixes, because it is not reproducible and it lands on whoever was
-         * busiest.
-         *
-         * The cost of the other side is real and is not being waved away: a
-         * waiting worker waits for every tab on the origin to close, which for
-         * an installed app can be days. That is exactly why this cannot ship
-         * without the prompt in #68 — the prompt is what ends the wait, on the
-         * reader's word rather than the browser's.
-         */
-        skipWaiting: false,
-        clientsClaim: false,
-
-        /**
-         * Precaches are keyed by revision, so a superseded entry is dead
-         * weight in storage a phone may later reclaim under pressure — taking
-         * the live cache with it.
-         */
-        cleanupOutdatedCaches: true,
-      },
-    }),
-  ],
+  // The worker's settings live in pwa-config.ts, where a test can read them
+  // back — see the comment at the top of that file.
+  plugins: [react(), tailwindcss(), VitePWA(pwaOptions(mode))],
   define: buildInfo(mode),
   resolve: {
     // Array form, because the e2e override has to be matched before the bare

--- a/yarn.lock
+++ b/yarn.lock
@@ -8971,7 +8971,7 @@ vite-node@3.2.4:
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
 
-vite-plugin-pwa@1.3.0:
+vite-plugin-pwa@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz#98f06224027479c541dafb1fd474d907a12039bd"
   integrity sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,6 +15,14 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@apideck/better-ajv-errors@^0.3.1":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz#89238f689d81a644139a47e0ebc2e236bca1ff2c"
+  integrity sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==
+  dependencies:
+    jsonpointer "^5.0.1"
+    leven "^3.1.0"
+
 "@apidevtools/json-schema-ref-parser@^9.0.3":
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz#8ff5386b365d4c9faa7c8b566ff16a46a577d9b8"
@@ -60,7 +68,7 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
-"@babel/compat-data@^7.29.7":
+"@babel/compat-data@^7.28.6", "@babel/compat-data@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
   integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
@@ -97,7 +105,14 @@
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
 
-"@babel/helper-compilation-targets@^7.29.7":
+"@babel/helper-annotate-as-pure@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz#c70fe3c6ecbdc3fd2dd1b0f498428b88b82ce47f"
+  integrity sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-compilation-targets@^7.28.6", "@babel/helper-compilation-targets@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz#7a1def704302401c47f64fa85589e974ae217042"
   integrity sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==
@@ -108,12 +123,53 @@
     lru-cache "^5.1.1"
     semver "^6.3.1"
 
+"@babel/helper-create-class-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz#6eddf286f2ec418f740c91d60a83347c55838ddd"
+  integrity sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    semver "^6.3.1"
+
+"@babel/helper-create-regexp-features-plugin@^7.18.6", "@babel/helper-create-regexp-features-plugin@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.29.7.tgz#5d4c3f928f315cf6c4184ea2fc3b5b38745b2430"
+  integrity sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    regexpu-core "^6.3.1"
+    semver "^6.3.1"
+
+"@babel/helper-define-polyfill-provider@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz#cf1e4462b613f2b54c41e6ff758d5dfcaa2c85d1"
+  integrity sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+    debug "^4.4.3"
+    lodash.debounce "^4.0.8"
+    resolve "^1.22.11"
+
 "@babel/helper-globals@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-7.29.7.tgz#f04a96fbd8473241b1079243f5b3f03a3010ab7b"
   integrity sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==
 
-"@babel/helper-module-imports@^7.29.7":
+"@babel/helper-member-expression-to-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz#8dbdb3ce0b5c487e1aec10e13c9a43a500814df8"
+  integrity sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz#ef25048a518e828d7393fac5882ddd73921d7396"
   integrity sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==
@@ -130,6 +186,44 @@
     "@babel/helper-validator-identifier" "^7.29.7"
     "@babel/traverse" "^7.29.7"
 
+"@babel/helper-optimise-call-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz#77b0b5b94f1997fa9d6e3125f445227b1faf9d85"
+  integrity sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==
+  dependencies:
+    "@babel/types" "^7.29.7"
+
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.28.6", "@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
+
+"@babel/helper-remap-async-to-generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.29.7.tgz#34b1f68dd75b86d31df781a29c3ff2df88da82e6"
+  integrity sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-wrap-function" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-replace-supers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz#bc3c3964329043c79112e513c1b198f16589ac21"
+  integrity sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.29.7"
+    "@babel/helper-optimise-call-expression" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/helper-skip-transparent-expression-wrappers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz#50c95c7e4c4f54936cfa0116428edc559862d551"
+  integrity sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==
+  dependencies:
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
+
 "@babel/helper-string-parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz#7f0871d99824d23137d60f86fcf6130fd5a1b51f"
@@ -144,6 +238,15 @@
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz#cf315be940213b354eb4abcc0bd01ebe3f73bc2a"
   integrity sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==
+
+"@babel/helper-wrap-function@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.29.7.tgz#eec72163044548a0935e9d182bf2d547ec5ff483"
+  integrity sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==
+  dependencies:
+    "@babel/template" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+    "@babel/types" "^7.29.7"
 
 "@babel/helpers@^7.29.7":
   version "7.29.7"
@@ -160,7 +263,564 @@
   dependencies:
     "@babel/types" "^7.29.8"
 
-"@babel/runtime@^7.12.5":
+"@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.29.7.tgz#2b535896d933a85aa92377eaa3d51a437d54a4e3"
+  integrity sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-bugfix-safari-class-field-initializer-scope@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.29.7.tgz#b00711a9e52bf4fe55ef7e54b2ef4a881bf804c8"
+  integrity sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.29.7.tgz#2375328852026a3cf6bc0bcf2de7d236f2d5e701"
+  integrity sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.7.tgz#759a857c46c4d2a6199685cf71070d81ae5f743a"
+  integrity sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
+"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.29.7.tgz#86de98dd8e03836178231ea96c27dab26016a705"
+  integrity sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+    "@babel/plugin-transform-optional-chaining" "^7.29.7"
+
+"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.29.7.tgz#f5d892681dbf4b08753436a5e55000d5ba728d6d"
+  integrity sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+  version "7.21.0-placeholder-for-preset-env.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
+  integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-syntax-import-assertions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz#c5cd868505269126cc18882e1f01f7b0e0e24b4e"
+  integrity sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-import-attributes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz#6115264516e95ead0f35a41710906612e447f605"
+  integrity sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-syntax-unicode-sets-regex@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz#d49a3b3e6b52e5be6740022317580234a6a47357"
+  integrity sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-transform-arrow-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.29.7.tgz#d651343f562c03f47951bd1802195d0e10605f27"
+  integrity sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-async-generator-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.7.tgz#a5365617921d82a1fee33124a1102bb38a1e677d"
+  integrity sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-remap-async-to-generator" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-async-to-generator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.29.7.tgz#3b5e8f1fb58133cf701bcf0baaf6f01bfd1a8889"
+  integrity sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-remap-async-to-generator" "^7.29.7"
+
+"@babel/plugin-transform-block-scoped-functions@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.29.7.tgz#96d292634434082d6687bcdb81139affedf77e8c"
+  integrity sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-block-scoping@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.29.7.tgz#baa376691ae16244cd14335422fca6900f54e17d"
+  integrity sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-class-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.29.7.tgz#034897b8a21beec163332fac2de235b14409abdf"
+  integrity sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-class-static-block@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.29.7.tgz#fed8efd19f3dd3e1114ee390707c70912778fd7c"
+  integrity sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-classes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.29.7.tgz#61d3e5aaae0c838acc3204d9db7c8dc05c25815b"
+  integrity sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-globals" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-computed-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.29.7.tgz#95028787ca31901b9a20b5c6d9605c32346f55ad"
+  integrity sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/template" "^7.29.7"
+
+"@babel/plugin-transform-destructuring@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz#5781ec6947852e27b64c1165f0db431f408090e4"
+  integrity sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-dotall-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.29.7.tgz#b203de9740e4c7ff6b55ce436ed5313b88d70af8"
+  integrity sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-duplicate-keys@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.29.7.tgz#8f3fe721835cb7a433420841dae90afc962ea7ae"
+  integrity sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-duplicate-named-capturing-groups-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.7.tgz#dc6c405e55c01b7657e1827a25332c4ac17e9cac"
+  integrity sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-dynamic-import@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.29.7.tgz#a83a6faec5bab5b619adf9d0eac6c1c270123c2a"
+  integrity sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-explicit-resource-management@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz#65c8b9f76ec915b02a0e1df703125a0fca58abaa"
+  integrity sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+
+"@babel/plugin-transform-exponentiation-operator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.29.7.tgz#00bf002fde8794356171f5d4df200f6bc0d5a303"
+  integrity sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-export-namespace-from@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.29.7.tgz#d6014f45cec61d7691335c6c9804204bee801d51"
+  integrity sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-for-of@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.29.7.tgz#c65a678592117717aacdb10c1b73a9cb85e830be"
+  integrity sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
+"@babel/plugin-transform-function-name@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.29.7.tgz#8b87f8a7504dbcd96135167e3fc4f61126a7bd86"
+  integrity sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-json-strings@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.29.7.tgz#f57d63dcc05b4481c281acedcd8fc4e3e439a1d4"
+  integrity sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.29.7.tgz#b90bd47463326c2a9d779e1bd5e1f88b9f421921"
+  integrity sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-logical-assignment-operators@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.29.7.tgz#9b29425adf5c794967aabe4b046a046a167bac2f"
+  integrity sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-member-expression-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.29.7.tgz#1281689fa2fefc17b110d21ebafd0fe9402d5309"
+  integrity sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-modules-amd@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.29.7.tgz#f05ca662c8a1dc4be2f337af9c7e80369c942d6c"
+  integrity sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-modules-commonjs@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz#70e6835abf2663dafbe94b8ef1f51de7351ef135"
+  integrity sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-modules-systemjs@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz#e60a6a42ac63a3095f9cc7264f698a100c8fe05d"
+  integrity sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-identifier" "^7.29.7"
+    "@babel/traverse" "^7.29.8"
+
+"@babel/plugin-transform-modules-umd@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.29.7.tgz#391d1c0215aca6307257f2f608598dfe55feb6cf"
+  integrity sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-named-capturing-groups-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.7.tgz#21e75d847b31189842fa7a77703722ed4b43d27d"
+  integrity sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-new-target@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.29.7.tgz#714147ce7947e1b49cbd84137ca2e75e92b2a067"
+  integrity sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-nullish-coalescing-operator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.29.7.tgz#8a54cdf88c3f50433a6173117a286195b67714cc"
+  integrity sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-numeric-separator@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.29.7.tgz#0266d5cd42ab87ec40fee45a4e36483cfdcbc66a"
+  integrity sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-object-rest-spread@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.29.7.tgz#e0d5060241803922c545676613cc8acbbda0d266"
+  integrity sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+    "@babel/plugin-transform-parameters" "^7.29.7"
+    "@babel/traverse" "^7.29.7"
+
+"@babel/plugin-transform-object-super@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.29.7.tgz#e89283d14fa3c35817d4493ffc6bc649aa10e4eb"
+  integrity sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-replace-supers" "^7.29.7"
+
+"@babel/plugin-transform-optional-catch-binding@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.29.7.tgz#729664f79985be504eba112c51de9f71d009030b"
+  integrity sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-optional-chaining@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.29.7.tgz#b84a1b574b3c73001023092567e16c492b720e51"
+  integrity sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
+"@babel/plugin-transform-parameters@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.29.7.tgz#a5ddc3b9bfb534814cb8334cbeba47d9cf9db090"
+  integrity sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-private-methods@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.29.7.tgz#cea8bd3ab99533892897a02999d5b752584ad145"
+  integrity sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-private-property-in-object@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.29.7.tgz#4a2f6be5aba47be7afbdb4cd7903c46edf3a7661"
+  integrity sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.29.7"
+    "@babel/helper-create-class-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-property-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz#d45817cd72f9e134ab1f7fbb79264cfcb85cf636"
+  integrity sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-regenerator@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz#3a4a4dd7214af9d524f0503bb97c99af5f4abf26"
+  integrity sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-regexp-modifiers@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.29.7.tgz#68311c0c10af2198212528863f8542843e424025"
+  integrity sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-reserved-words@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.29.7.tgz#a6feeb179b36a5f1fc6e3154c1eb727bdbe35876"
+  integrity sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-shorthand-properties@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.29.7.tgz#25c0436b98f4bd9ca4b98e1fbd662743bbaab9bf"
+  integrity sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-spread@^7.29.7":
+  version "7.29.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz#c894cff38556a5dafeb412e13fc012b6df4b95a2"
+  integrity sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.29.7"
+
+"@babel/plugin-transform-sticky-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.29.7.tgz#a42c0fd1fa42f7e98e1e0c7757f72a1bbca3a015"
+  integrity sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-template-literals@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.29.7.tgz#ada97d8e0832bca8edb315888aa654b1570f3835"
+  integrity sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-typeof-symbol@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.29.7.tgz#d848a4677c1ee3485ab017f4018f04597798911c"
+  integrity sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-unicode-escapes@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.29.7.tgz#1e99554b0cddfd650d649a9f2b996049893e5720"
+  integrity sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-unicode-property-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.29.7.tgz#44444afc73768c2190fac4d95f7716817b7f204a"
+  integrity sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-unicode-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.29.7.tgz#c3064b293ff7f1794b71f7650eec8db9896d3e59"
+  integrity sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/plugin-transform-unicode-sets-regex@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.29.7.tgz#b03ac9f27326f6197e8e574add83bbf33fc34ecd"
+  integrity sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==
+  dependencies:
+    "@babel/helper-create-regexp-features-plugin" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+
+"@babel/preset-env@^7.11.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.29.7.tgz#5e2ab5e764b493fdefc99c43aeaa70a9533a37fd"
+  integrity sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==
+  dependencies:
+    "@babel/compat-data" "^7.29.7"
+    "@babel/helper-compilation-targets" "^7.29.7"
+    "@babel/helper-plugin-utils" "^7.29.7"
+    "@babel/helper-validator-option" "^7.29.7"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.29.7"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.29.7"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression" "^7.29.7"
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array" "^7.29.7"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining" "^7.29.7"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly" "^7.29.7"
+    "@babel/plugin-proposal-private-property-in-object" "7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-syntax-import-assertions" "^7.29.7"
+    "@babel/plugin-syntax-import-attributes" "^7.29.7"
+    "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
+    "@babel/plugin-transform-arrow-functions" "^7.29.7"
+    "@babel/plugin-transform-async-generator-functions" "^7.29.7"
+    "@babel/plugin-transform-async-to-generator" "^7.29.7"
+    "@babel/plugin-transform-block-scoped-functions" "^7.29.7"
+    "@babel/plugin-transform-block-scoping" "^7.29.7"
+    "@babel/plugin-transform-class-properties" "^7.29.7"
+    "@babel/plugin-transform-class-static-block" "^7.29.7"
+    "@babel/plugin-transform-classes" "^7.29.7"
+    "@babel/plugin-transform-computed-properties" "^7.29.7"
+    "@babel/plugin-transform-destructuring" "^7.29.7"
+    "@babel/plugin-transform-dotall-regex" "^7.29.7"
+    "@babel/plugin-transform-duplicate-keys" "^7.29.7"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.29.7"
+    "@babel/plugin-transform-dynamic-import" "^7.29.7"
+    "@babel/plugin-transform-explicit-resource-management" "^7.29.7"
+    "@babel/plugin-transform-exponentiation-operator" "^7.29.7"
+    "@babel/plugin-transform-export-namespace-from" "^7.29.7"
+    "@babel/plugin-transform-for-of" "^7.29.7"
+    "@babel/plugin-transform-function-name" "^7.29.7"
+    "@babel/plugin-transform-json-strings" "^7.29.7"
+    "@babel/plugin-transform-literals" "^7.29.7"
+    "@babel/plugin-transform-logical-assignment-operators" "^7.29.7"
+    "@babel/plugin-transform-member-expression-literals" "^7.29.7"
+    "@babel/plugin-transform-modules-amd" "^7.29.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.29.7"
+    "@babel/plugin-transform-modules-systemjs" "^7.29.7"
+    "@babel/plugin-transform-modules-umd" "^7.29.7"
+    "@babel/plugin-transform-named-capturing-groups-regex" "^7.29.7"
+    "@babel/plugin-transform-new-target" "^7.29.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.29.7"
+    "@babel/plugin-transform-numeric-separator" "^7.29.7"
+    "@babel/plugin-transform-object-rest-spread" "^7.29.7"
+    "@babel/plugin-transform-object-super" "^7.29.7"
+    "@babel/plugin-transform-optional-catch-binding" "^7.29.7"
+    "@babel/plugin-transform-optional-chaining" "^7.29.7"
+    "@babel/plugin-transform-parameters" "^7.29.7"
+    "@babel/plugin-transform-private-methods" "^7.29.7"
+    "@babel/plugin-transform-private-property-in-object" "^7.29.7"
+    "@babel/plugin-transform-property-literals" "^7.29.7"
+    "@babel/plugin-transform-regenerator" "^7.29.7"
+    "@babel/plugin-transform-regexp-modifiers" "^7.29.7"
+    "@babel/plugin-transform-reserved-words" "^7.29.7"
+    "@babel/plugin-transform-shorthand-properties" "^7.29.7"
+    "@babel/plugin-transform-spread" "^7.29.7"
+    "@babel/plugin-transform-sticky-regex" "^7.29.7"
+    "@babel/plugin-transform-template-literals" "^7.29.7"
+    "@babel/plugin-transform-typeof-symbol" "^7.29.7"
+    "@babel/plugin-transform-unicode-escapes" "^7.29.7"
+    "@babel/plugin-transform-unicode-property-regex" "^7.29.7"
+    "@babel/plugin-transform-unicode-regex" "^7.29.7"
+    "@babel/plugin-transform-unicode-sets-regex" "^7.29.7"
+    "@babel/preset-modules" "0.1.6-no-external-plugins"
+    babel-plugin-polyfill-corejs2 "^0.4.15"
+    babel-plugin-polyfill-corejs3 "^0.14.0"
+    babel-plugin-polyfill-regenerator "^0.6.6"
+    core-js-compat "^3.48.0"
+    semver "^6.3.1"
+
+"@babel/preset-modules@0.1.6-no-external-plugins":
+  version "0.1.6-no-external-plugins"
+  resolved "https://registry.yarnpkg.com/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz#ccb88a2c49c817236861fee7826080573b8a923a"
+  integrity sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/types" "^7.4.4"
+    esutils "^2.0.2"
+
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -174,7 +834,7 @@
     "@babel/parser" "^7.29.7"
     "@babel/types" "^7.29.7"
 
-"@babel/traverse@^7.29.7":
+"@babel/traverse@^7.29.7", "@babel/traverse@^7.29.8":
   version "7.29.8"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.8.tgz#4111014cdc71a0f95d9471907590baa0b8a6b28a"
   integrity sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==
@@ -187,7 +847,7 @@
     "@babel/types" "^7.29.8"
     debug "^4.3.1"
 
-"@babel/types@^7.25.4", "@babel/types@^7.29.7", "@babel/types@^7.29.8":
+"@babel/types@^7.25.4", "@babel/types@^7.29.7", "@babel/types@^7.29.8", "@babel/types@^7.4.4":
   version "7.29.8"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.8.tgz#1229eef31d85156d70fa3f4cd859376d0eaf6863"
   integrity sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==
@@ -1223,6 +1883,11 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@isaacs/cliui@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
+  integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
+
 "@isaacs/fs-minipass@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
@@ -1256,12 +1921,20 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
+"@jridgewell/source-map@^0.3.3":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.11.tgz#b21835cbd36db656b857c2ad02ebd413cc13a9ba"
+  integrity sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+
 "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
+"@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28", "@jridgewell/trace-mapping@^0.3.31":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -1501,130 +2174,300 @@
   resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
   integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
 
+"@rollup/plugin-babel@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-6.1.0.tgz#5766913722057f28a56365bb6c1ca61306c7e527"
+  integrity sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.18.6"
+    "@rollup/pluginutils" "^5.0.1"
+
+"@rollup/plugin-node-resolve@^16.0.3":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz#0988e6f2cbb13316b0f5e7213f757bc9ed44928f"
+  integrity sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    "@types/resolve" "1.20.2"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.22.1"
+
+"@rollup/plugin-replace@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz#0f82e41d81f6586ab0f81a1b48bd7fd92fcfb9a2"
+  integrity sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
+"@rollup/plugin-terser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz#dabbc4414d127aa7d43fc5e7ea8699b9c3bc59e5"
+  integrity sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==
+  dependencies:
+    serialize-javascript "^7.0.3"
+    smob "^1.0.0"
+    terser "^5.17.4"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.4.0.tgz#ac23a29ced0247060a210815fca39c17de4d2f26"
+  integrity sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^4.0.2"
+
 "@rollup/rollup-android-arm-eabi@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz#2b86c8fff13a065845ddb65f64d814499ace020f"
   integrity sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==
+
+"@rollup/rollup-android-arm-eabi@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.5.tgz#ea71e1a350caefa1bb4c530b3bf785e7b1c17e21"
+  integrity sha512-jfkGfTwhQpsiSckPF8r9bU3pn3vyd72NlWaO+TgEO6WPSDnUhXzrNYCHBMOYj0ACaUgjm6eERLF+XV9a6RstoA==
 
 "@rollup/rollup-android-arm64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz#af217357ecc06ae5e4f54ef34ee72b1e37f8dbc3"
   integrity sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==
 
+"@rollup/rollup-android-arm64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.5.tgz#fe52450ae863d44741982e88f383ce4b16cb0bc3"
+  integrity sha512-oGVqyQlxnrz9/ty89oHpU857VUHEl5/Xu4R2lS+aivCTrNnSsbiENzTnNaBsjxH0CNWGPhzHArOLFwo+oKXveA==
+
 "@rollup/rollup-darwin-arm64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz#e9d0adba06e39b632fc8e880100ff06547eda80b"
   integrity sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==
+
+"@rollup/rollup-darwin-arm64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.5.tgz#ed49492a7714ae0195eccb552a361da827095ca0"
+  integrity sha512-bW7B8xMEq8n99Q3ieEcPRGuphurdZAaFzQc9Efyyw3FL6DZO6pMy9xhdN+kBoD7Sy05xNXSr4OyPPnpkYriS/A==
 
 "@rollup/rollup-darwin-x64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz#eff983a29db7d8ea7f733f1ce430fc64e159a5e6"
   integrity sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==
 
+"@rollup/rollup-darwin-x64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.5.tgz#b45c8cdd49dca779fed95035a9d76c8ba84ef335"
+  integrity sha512-YSwBS86QeHOGlrxJ1PSOIZSkzRL/JmKeunhc+lV6M1a6En8QuVCD/T/qIA0J4Gd2Y86RIOBYrLcOUtqGh9+/1w==
+
 "@rollup/rollup-freebsd-arm64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz#abe1399a70e819034f492d05dbcc97964310bb57"
   integrity sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==
+
+"@rollup/rollup-freebsd-arm64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.5.tgz#498aa15854533cb2f79e247a3c7733430d8bade2"
+  integrity sha512-2fST8lILgl7cKbme/1KDdPCmbXbG+gqoV3bHp19L0ypX/3akYMBVdOunPleRCwonoLnXOZ/0F+Mt/v8POFmfcQ==
 
 "@rollup/rollup-freebsd-x64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz#b2e0f8c24a362ac7112be3d5549c6940597e0168"
   integrity sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==
 
+"@rollup/rollup-freebsd-x64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.5.tgz#4dbaefae93fb22020ebfd7d60c4fcdb84780ee69"
+  integrity sha512-cpIxQCP9J+EVad0a6LO1kY3ZGODlk80VlI+2I96B8xMcdHZ4pLVhfQ49JFpYqjPF91FFkQWftf57YlDcTiw9yQ==
+
 "@rollup/rollup-linux-arm-gnueabihf@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz#a5f2a7e7eb719254a6800db18e9f369d3c623439"
   integrity sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.5.tgz#d6ff261df871a4acc4a26f05910c832ceff7aa0d"
+  integrity sha512-r9fGh3eFs3e/udWh5ZjXQtxiYK/xoFxQaYR/cELxac/Udkl5Th+IsFm0CX3Kl9hmUH/we7EoMpjJgeQNnE0+IA==
 
 "@rollup/rollup-linux-arm-musleabihf@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz#390c86c797695af87c38d6f005222d920b5bfa22"
   integrity sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==
 
+"@rollup/rollup-linux-arm-musleabihf@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.5.tgz#d44c1f6407b6194624952e423d0040853e6a29ad"
+  integrity sha512-xdvFdp7OM6KLJviJT2g/YuRSUjnZgGHk4RNgwIbN7X6cPugOucV60DdHXWzsBVCUdrGb6qSXnJQrrAKMmQuj3Q==
+
 "@rollup/rollup-linux-arm64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz#1fea78609a15813cda98d93fe8d987c87017f572"
   integrity sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==
+
+"@rollup/rollup-linux-arm64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.5.tgz#5ccabe0fd8b61ccedaa743698b977433af2b13c9"
+  integrity sha512-rRqILAndyzHzP7T9NFQrq+4HFWNhqkqkKur7eiBpfLmz01PO0JKx5Vchu3YllE4YXI/Ftgq/szrDWg5GJ0mI8g==
 
 "@rollup/rollup-linux-arm64-musl@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz#3b50031c9916517576098f6e11b38a13147dc463"
   integrity sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==
 
+"@rollup/rollup-linux-arm64-musl@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.5.tgz#516f74f164c137bf6de6a13f910163a5923f6f55"
+  integrity sha512-Gf4X3qVMucayUvux6aXXPgXovocSFUC0rrffDuPI/S2nHhNMhjcZxsrAFYCOF350PRreW1XwzFj3CT/3bKsWCw==
+
 "@rollup/rollup-linux-loong64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz#b403255546099a4300b17d976ee1776224c090e5"
   integrity sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==
+
+"@rollup/rollup-linux-loong64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.5.tgz#0d8bf9dc4f3ce87767e062f8b9651a9e3b434920"
+  integrity sha512-+s5qA0TNM0qm8PK/a5gt/1Hpx+NV08uSuCncvhziIlQzT6AEV2fnUQo7eBtFTFO0nA9scauvoR2HusfXmQnO4w==
 
 "@rollup/rollup-linux-loong64-musl@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz#5900610e59c66ee594539c6590566dbfda7082b1"
   integrity sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==
 
+"@rollup/rollup-linux-loong64-musl@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.5.tgz#b3a39a390689a798f61403c779b79351229125cb"
+  integrity sha512-ybb6QvWwWJCbBWqERpc8K3pYVGIrXlG8MEQ8IIuJY6Y9KdHQxoFoNyfkAOtKn1VHu3KuLidXvwrvGR1mEjeWCw==
+
 "@rollup/rollup-linux-ppc64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz#a892cc8b8414bc8ae0b267816b5e384e5d321ff2"
   integrity sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==
+
+"@rollup/rollup-linux-ppc64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.5.tgz#a90aa5865030a7aa0784467bb8de99774a6d45be"
+  integrity sha512-nZb1DtnOyhCmYvsC8A2CwOkopVg+IS1+fPUa7rMOAXtNw5+lLCLLPqd6XAiNrGtoQKsbvIBOwsHnBH/3wnb4HQ==
 
 "@rollup/rollup-linux-ppc64-musl@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz#d9e60d568b7db4df2196fb2411b0c6918b2360cc"
   integrity sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==
 
+"@rollup/rollup-linux-ppc64-musl@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.5.tgz#0263313b98dd553abee2b96870d0a5b642417d68"
+  integrity sha512-yMbj63Sp89ryrXLWyz+sy+fYD2HpOnMCLGbe4Oa1smclFSUukdtD/BgdiHaAetJNb74URD8U4hM+qG5KVzMEkg==
+
 "@rollup/rollup-linux-riscv64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz#5b3141ab43afbd9e50f639e562e94ed256d201cf"
   integrity sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==
+
+"@rollup/rollup-linux-riscv64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.5.tgz#cb85a44dc8a49605cf5d22cb9e6331f241d4443f"
+  integrity sha512-mhoan3OJw2kYV/e1jtIdmvUZgyBFeA6zGWsOswmR0Tg19TQbowZuR+JMLID6spbbBN7Zee2ejrgmy3+FxGrIdA==
 
 "@rollup/rollup-linux-riscv64-musl@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz#b0fe751015bc3822f9004884eaba5e5cdfde7aa6"
   integrity sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==
 
+"@rollup/rollup-linux-riscv64-musl@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.5.tgz#62cdc451b5fd20a17fa1a16ce5da8d3a55d1d692"
+  integrity sha512-5ZTLmjWbb1VZdjuyhe83K/8QO0/h11midQCBP+X5OYn32ra7eOBoM0ZqtaY4nkgNsYgmdVhMYPoyVPTjUpHf3w==
+
 "@rollup/rollup-linux-s390x-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz#0cb323e850509e1b9bf6d241328a98b0e12e2916"
   integrity sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==
+
+"@rollup/rollup-linux-s390x-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.5.tgz#3e9396f0c3b6b15e124ca2da5d91e4e4b587401e"
+  integrity sha512-m53kG+br6PGxOTmgBEM2DHSDs9RVjsyEbUwjJPJGTFm1grWOG8EKJggDCTb60unD4Tjby8fi7/m9XfkEWasVWg==
 
 "@rollup/rollup-linux-x64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz#1e7470123e7a8ba8c160a7a043447472d5549542"
   integrity sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==
 
+"@rollup/rollup-linux-x64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.5.tgz#0b4d2727b1be49bf950cab56053dbffbc8dbe22e"
+  integrity sha512-6RHPJR1g/uvdYU8uXBnfq3nlqyZCP82Fr6NHgfGoaIeSh0YEqnX/x6uA9MmJJbnSH7swqX4F+CkGdUF+6doiQA==
+
 "@rollup/rollup-linux-x64-musl@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz#19df9a17d20ff3c17bd8e9cc2553563ae0aa0580"
   integrity sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==
+
+"@rollup/rollup-linux-x64-musl@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.5.tgz#fa4968b9d2cfa2543196868d4b1397c1d50412ec"
+  integrity sha512-xs+OXQtEXgpXT0DmA5+U3qnRZHdCST/5HRQxS8wSPZTUZN/EMWeHuSIod32LQklTBZBV9DyfncKBQ8n5V3eFdw==
 
 "@rollup/rollup-openbsd-x64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz#31c3ca1bd00e80f309a1d0cb8da4bdf59cb2dfa3"
   integrity sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==
 
+"@rollup/rollup-openbsd-x64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.5.tgz#8ef82314abc777c02523b2cd3f94deaba73c059d"
+  integrity sha512-e7hD+sl3s+mcLQDZ8pbudBVsdG6r5yN4w3LqG2TJ8sQHDpblWj5lrJs/3m01Cvlxbt4x13zu5thLjgypgtkYzw==
+
 "@rollup/rollup-openharmony-arm64@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz#84561a14381caecb7652e158d10551a5edc0a6fc"
   integrity sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==
+
+"@rollup/rollup-openharmony-arm64@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.5.tgz#0dba708f7951d805d15d9d8eb589ab4c107d5c00"
+  integrity sha512-GiyJaCf+WpMub/17aPcKk27QMl5W6f+KhdPTjlFOn5akH5Wa/DCM9Stdx5cDfmasyKB08MqpVQ1uJE2RkkpbXg==
 
 "@rollup/rollup-win32-arm64-msvc@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz#bc532edb20cd39c0b53eee2dfae43b52c2e3be1e"
   integrity sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==
 
+"@rollup/rollup-win32-arm64-msvc@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.5.tgz#97da586a5feab756b3a4d2e70a8c221b38a23744"
+  integrity sha512-+OQ8U2DdoEfXl8T4Fb18AjmEwbXMerKDKCL8yCPAYhKCEEKoul7rkbeGCBFCbAlaGaa7pmtRTpkAJM2LE/i5FA==
+
 "@rollup/rollup-win32-ia32-msvc@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz#a6f51492976c9fc19801be298df2f76a3cbebf7a"
   integrity sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.5.tgz#b220871a747c2c517ceafb9a427a029c7f6b1467"
+  integrity sha512-KanvAZrPKbDBFwrgiU9yEVpQoox9QPV1WZOXX7HudJQY+eSlu82CtWxDU8WtuRRvtN5EGkLczkd6Y6DTcvm9wA==
 
 "@rollup/rollup-win32-x64-gnu@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz#ae60710b0868b2fe731d9f7c341fa49cbf8e8629"
   integrity sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==
 
+"@rollup/rollup-win32-x64-gnu@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.5.tgz#5b685285cfcbe0a041d67d67f118727bb8ce8650"
+  integrity sha512-1aC3UEWTtRl3RK3VpDJ/Tqk1XI4SLTmXIthAq6wRWo8XiSXJNd+VprJM4/1P4+i6HIaFEFlVi9sTTziniD2tOQ==
+
 "@rollup/rollup-win32-x64-msvc@4.62.4":
   version "4.62.4"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz#c3a265fe0f9af4fb63bad86d3829386bc5da0026"
   integrity sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==
+
+"@rollup/rollup-win32-x64-msvc@4.62.5":
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.5.tgz#441b89b848ba51cbf259621c6f554e268d169b6a"
+  integrity sha512-/gDJaRs4gl0NPIwqCz+6PkpmhhjRAD2j6P4rSNHBzUkO3naEx2mIU0pRle1vUNRQ7mE/+8OOeXLTv/J56FKiQg==
 
 "@sindresorhus/is@^4.6.0":
   version "4.6.0"
@@ -1789,6 +2632,16 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
+"@trickfilm400/rollup-plugin-off-main-thread@^3.0.0-pre1":
+  version "3.0.0-pre1"
+  resolved "https://registry.yarnpkg.com/@trickfilm400/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-3.0.0-pre1.tgz#1ffeab04d8972063de4ad1a948b3e550e11dc745"
+  integrity sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==
+  dependencies:
+    ejs "^3.1.10"
+    json5 "^2.2.3"
+    magic-string "^0.30.21"
+    string.prototype.matchall "^4.0.12"
+
 "@tybys/wasm-util@^0.10.2", "@tybys/wasm-util@^0.10.3":
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
@@ -1876,6 +2729,11 @@
     "@types/tough-cookie" "*"
     form-data "^2.5.5"
 
+"@types/resolve@1.20.2":
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
+  integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
+
 "@types/tough-cookie@*":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
@@ -1885,6 +2743,11 @@
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.5.tgz#74fef9ffbaa198eb8b588be029f38b00299caa2c"
   integrity sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==
+
+"@types/trusted-types@^2.0.2":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
 "@typescript-eslint/eslint-plugin@8.67.0":
   version "8.67.0"
@@ -2102,7 +2965,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.16.0:
+acorn@^8.15.0, acorn@^8.16.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
   integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
@@ -2143,7 +3006,7 @@ ajv@^6.14.0:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.17.1, ajv@^8.3.0:
+ajv@^8.0.0, ajv@^8.17.1, ajv@^8.3.0, ajv@^8.6.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
   integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
@@ -2255,10 +3118,31 @@ aria-query@^5.0.0:
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.2.tgz#93f81a43480e33a338f19163a3d10a50c01dcd59"
   integrity sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==
 
+array-buffer-byte-length@^1.0.1, array-buffer-byte-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz#384d12a37295aec3769ab022ad323a18a51ccf8b"
+  integrity sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==
+  dependencies:
+    call-bound "^1.0.3"
+    is-array-buffer "^3.0.5"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+arraybuffer.prototype.slice@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz#9d760d84dbdd06d0cbf92c8849615a1a7ab3183c"
+  integrity sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==
+  dependencies:
+    array-buffer-byte-length "^1.0.1"
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.5"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    is-array-buffer "^3.0.4"
 
 arrify@^2.0.0:
   version "2.0.1"
@@ -2291,6 +3175,11 @@ ast-v8-to-istanbul@^0.3.3:
     estree-walker "^3.0.3"
     js-tokens "^10.0.0"
 
+async-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
+  integrity sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==
+
 async-lock@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/async-lock/-/async-lock-1.4.1.tgz#56b8718915a9b68b10fce2f2a9a3dddf765ef53f"
@@ -2313,10 +3202,46 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+available-typed-arrays@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
+  integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
+  dependencies:
+    possible-typed-array-names "^1.0.0"
+
 b4a@^1.6.4, b4a@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.8.1.tgz#7f16334ca80127aeb26064a28841acbf174840a4"
   integrity sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==
+
+babel-plugin-polyfill-corejs2@^0.4.15:
+  version "0.4.17"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz#198f970f1c99a856b466d1187e88ce30bd199d91"
+  integrity sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==
+  dependencies:
+    "@babel/compat-data" "^7.28.6"
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
+    semver "^6.3.1"
+
+babel-plugin-polyfill-corejs3@^0.14.0:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz#6ac08d2f312affb70c4c69c0fbba4cb417ee5587"
+  integrity sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
+    core-js-compat "^3.48.0"
+
+babel-plugin-polyfill-regenerator@^0.6.6:
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz#8a6bfd5dd54239362b3d06ce47ac52b2d95d7721"
+  integrity sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==
+  dependencies:
+    "@babel/helper-define-polyfill-provider" "^0.6.8"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -2374,6 +3299,11 @@ baseline-browser-mapping@^2.10.44:
   version "2.11.12"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz#42ac48770bf73d292f60ce8ba4dc5e7ebb242ec3"
   integrity sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==
+
+baseline-browser-mapping@^2.11.12:
+  version "2.11.16"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.16.tgz#0fa19a4ece2e34439ecaa3fdca8a59acfbd287fb"
+  integrity sha512-H/bNPUFHewJHyCTdjn1n3Pit5+2GmWT6mmeHImPX+8MA9NA6b67jO4gYmi4jTbCJb2otq34KMZnovndDPqJwhQ==
 
 basic-auth-connect@^1.1.0:
   version "1.1.0"
@@ -2507,6 +3437,17 @@ browserslist@^4.24.0:
     node-releases "^2.0.51"
     update-browserslist-db "^1.2.3"
 
+browserslist@^4.28.7:
+  version "4.28.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.8.tgz#a3c79ceb70028527e5da7dafc887f3200b5168c0"
+  integrity sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==
+  dependencies:
+    baseline-browser-mapping "^2.11.12"
+    caniuse-lite "^1.0.30001809"
+    electron-to-chromium "^1.5.402"
+    node-releases "^2.0.53"
+    update-browserslist-db "^1.3.0"
+
 buffer-crc32@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz#a10993b9055081d55304bd9feb4a072de179f405"
@@ -2516,6 +3457,11 @@ buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -2551,7 +3497,17 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bound@^1.0.2:
+call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
+  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    get-intrinsic "^1.3.0"
+    set-function-length "^1.2.2"
+
+call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
   integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
@@ -2573,6 +3529,11 @@ caniuse-lite@^1.0.30001806:
   version "1.0.30001806"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz#1bc8e502b723fa393455dfbedd5ccec0c29bb74e"
   integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
+
+caniuse-lite@^1.0.30001809:
+  version "1.0.30001809"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz#e6cf71f14ddfe008f114dd2a846923be3c03a07b"
+  integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
 
 chai@^5.2.0:
   version "5.3.3"
@@ -2767,7 +3728,7 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
-commander@^2.19.0:
+commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2776,6 +3737,11 @@ commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+common-tags@^1.8.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 compress-commons@^6.0.2:
   version "6.0.2"
@@ -2890,6 +3856,13 @@ cookie@^1.0.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
+core-js-compat@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.50.0.tgz#d5922c2a692ab1cba6078c920e7c5567421ae08e"
+  integrity sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==
+  dependencies:
+    browserslist "^4.28.7"
+
 core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -2978,6 +3951,33 @@ data-urls@^7.0.0:
     whatwg-mimetype "^5.0.0"
     whatwg-url "^16.0.0"
 
+data-view-buffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.2.tgz#211a03ba95ecaf7798a8c7198d79536211f88570"
+  integrity sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.2"
+
+data-view-byte-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz#9e80f7ca52453ce3e93d25a35318767ea7704735"
+  integrity sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.2"
+
+data-view-byte-offset@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz#068307f9b71ab76dbbe10291389e020856606191"
+  integrity sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-data-view "^1.0.1"
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -3024,12 +4024,35 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
 defaults@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.4.tgz#b0b02062c1e2aa62ff5d9528f0f98baa90978d7a"
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+define-data-property@^1.0.1, define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
+define-properties@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.1.tgz#10781cc616eb951a80a034bafcaa7377f6af2b6c"
+  integrity sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==
+  dependencies:
+    define-data-property "^1.0.1"
+    has-property-descriptors "^1.0.0"
+    object-keys "^1.1.1"
 
 degenerator@^5.0.0:
   version "5.0.1"
@@ -3087,7 +4110,7 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dunder-proto@^1.0.1:
+dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
   integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
@@ -3123,10 +4146,22 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
+ejs@^3.1.10:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
+  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
+  dependencies:
+    jake "^10.8.5"
+
 electron-to-chromium@^1.5.393:
   version "1.5.401"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz#3e931926d8fdc117f6a834e58daa74c1114200d8"
   integrity sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==
+
+electron-to-chromium@^1.5.402:
+  version "1.5.412"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz#79b93ba8d96ada5c9ef0d916ea0663f01ea15498"
+  integrity sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -3188,7 +4223,77 @@ environment@^1.0.0:
   resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
   integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
-es-define-property@^1.0.1:
+es-abstract-get@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-abstract-get/-/es-abstract-get-1.0.0.tgz#1eae87101f42bedeb6a740e8c5051271aef89088"
+  integrity sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==
+  dependencies:
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.2"
+    is-callable "^1.2.7"
+    object-inspect "^1.13.4"
+
+es-abstract@^1.23.5, es-abstract@^1.23.6, es-abstract@^1.23.9, es-abstract@^1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.2.tgz#2dbd38c180735ee983f77585140a2706a963ed9a"
+  integrity sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==
+  dependencies:
+    array-buffer-byte-length "^1.0.2"
+    arraybuffer.prototype.slice "^1.0.4"
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    data-view-buffer "^1.0.2"
+    data-view-byte-length "^1.0.2"
+    data-view-byte-offset "^1.0.1"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    es-set-tostringtag "^2.1.0"
+    es-to-primitive "^1.3.0"
+    function.prototype.name "^1.1.8"
+    get-intrinsic "^1.3.0"
+    get-proto "^1.0.1"
+    get-symbol-description "^1.1.0"
+    globalthis "^1.0.4"
+    gopd "^1.2.0"
+    has-property-descriptors "^1.0.2"
+    has-proto "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    internal-slot "^1.1.0"
+    is-array-buffer "^3.0.5"
+    is-callable "^1.2.7"
+    is-data-view "^1.0.2"
+    is-negative-zero "^2.0.3"
+    is-regex "^1.2.1"
+    is-set "^2.0.3"
+    is-shared-array-buffer "^1.0.4"
+    is-string "^1.1.1"
+    is-typed-array "^1.1.15"
+    is-weakref "^1.1.1"
+    math-intrinsics "^1.1.0"
+    object-inspect "^1.13.4"
+    object-keys "^1.1.1"
+    object.assign "^4.1.7"
+    own-keys "^1.0.1"
+    regexp.prototype.flags "^1.5.4"
+    safe-array-concat "^1.1.3"
+    safe-push-apply "^1.0.0"
+    safe-regex-test "^1.1.0"
+    set-proto "^1.0.0"
+    stop-iteration-iterator "^1.1.0"
+    string.prototype.trim "^1.2.10"
+    string.prototype.trimend "^1.0.9"
+    string.prototype.trimstart "^1.0.8"
+    typed-array-buffer "^1.0.3"
+    typed-array-byte-length "^1.0.3"
+    typed-array-byte-offset "^1.0.4"
+    typed-array-length "^1.0.7"
+    unbox-primitive "^1.1.0"
+    which-typed-array "^1.1.19"
+
+es-define-property@^1.0.0, es-define-property@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
@@ -3203,7 +4308,7 @@ es-module-lexer@^1.7.0:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1, es-object-atoms@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
   integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
@@ -3219,6 +4324,18 @@ es-set-tostringtag@^2.1.0:
     get-intrinsic "^1.2.6"
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
+
+es-to-primitive@^1.3.0:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.4.tgz#0c854291cf0d7b439d6b9e5771ea837ffaf1f991"
+  integrity sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==
+  dependencies:
+    es-abstract-get "^1.0.0"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    is-callable "^1.2.7"
+    is-date-object "^1.1.0"
+    is-symbol "^1.1.1"
 
 "esbuild@^0.27.0 || ^0.28.0":
   version "0.28.1"
@@ -3401,6 +4518,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+estree-walker@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+
 estree-walker@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
@@ -3412,6 +4534,11 @@ esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+eta@^4.5.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/eta/-/eta-4.6.0.tgz#9bf9adb6d5833f3359c7ead1d57109e6064b9430"
+  integrity sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==
 
 etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
@@ -3585,7 +4712,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3651,6 +4778,13 @@ file-entry-cache@^8.0.0:
   integrity sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
   dependencies:
     flat-cache "^4.0.0"
+
+filelist@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.6.tgz#1e8870942a7c636c862f7c49b9394937b6a995a3"
+  integrity sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==
+  dependencies:
+    minimatch "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -3849,7 +4983,14 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-foreground-child@^3.1.0:
+for-each@^0.3.3, for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
+  dependencies:
+    is-callable "^1.2.7"
+
+foreground-child@^3.1.0, foreground-child@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
   integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
@@ -3911,6 +5052,16 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^9.0.1:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
@@ -3926,10 +5077,30 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
+function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.2.0.tgz#758f3e84fa542672454bd5e14cb081a5ce07f70c"
+  integrity sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
+    has-property-descriptors "^1.0.2"
+    hasown "^2.0.4"
+    is-callable "^1.2.7"
+    is-document.all "^1.0.0"
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
+
+functions-have-names@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 fuzzy@^0.1.3:
   version "0.1.3"
@@ -3993,6 +5164,11 @@ gcp-metadata@^8.0.0:
     google-logging-utils "1.1.3"
     json-bigint "^1.0.0"
 
+generator-function@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/generator-function/-/generator-function-2.0.1.tgz#0e75dd410d1243687a0ba2e951b94eedb8f737a2"
+  integrity sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==
+
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
@@ -4003,7 +5179,7 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.2.7, get-intrinsic@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -4019,6 +5195,11 @@ get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
     hasown "^2.0.2"
     math-intrinsics "^1.1.0"
 
+get-own-enumerable-property-symbols@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
+  integrity sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==
+
 get-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
@@ -4026,6 +5207,15 @@ get-proto@^1.0.1:
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
+
+get-symbol-description@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz#7bdd54e0befe8ffc9f3b4e203220d9f1e881b6ee"
+  integrity sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
 
 get-uri@^6.0.1:
   version "6.0.5"
@@ -4076,6 +5266,18 @@ glob@^10.0.0, glob@^10.3.10, glob@^10.3.7, glob@^10.4.1, glob@^10.5.0:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
+glob@^11.0.1:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-11.1.0.tgz#4f826576e4eb99c7dad383793d2f9f08f67e50a6"
+  integrity sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==
+  dependencies:
+    foreground-child "^3.3.1"
+    jackspeak "^4.1.1"
+    minimatch "^10.1.1"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^2.0.0"
+
 global-dirs@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
@@ -4087,6 +5289,14 @@ globals@^17.11.0:
   version "17.11.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-17.11.0.tgz#d643485bb30220d7751e511cf4f68c73d3870d87"
   integrity sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==
+
+globalthis@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"
+  integrity sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==
+  dependencies:
+    define-properties "^1.2.1"
+    gopd "^1.0.1"
 
 google-auth-library@10.5.0:
   version "10.5.0"
@@ -4169,7 +5379,7 @@ googleapis-common@^8.0.0:
     qs "^6.7.0"
     url-template "^2.0.8"
 
-gopd@^1.2.0:
+gopd@^1.0.1, gopd@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
@@ -4200,10 +5410,29 @@ gtoken@^8.0.0:
     gaxios "^7.0.0"
     jws "^4.0.0"
 
+has-bigints@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.1.0.tgz#28607e965ac967e03cd2a2c70a2636a1edad49fe"
+  integrity sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
+
+has-proto@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/has-proto/-/has-proto-1.2.0.tgz#5de5a6eabd95fdffd9818b43055e8065e39fe9d5"
+  integrity sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==
+  dependencies:
+    dunder-proto "^1.0.0"
 
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
@@ -4222,7 +5451,7 @@ has-yarn@^2.1.0:
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
   integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
 
-hasown@^2.0.2, hasown@^2.0.4:
+hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -4336,7 +5565,7 @@ iconv-lite@~0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-idb@7.1.1:
+idb@7.1.1, idb@^7.0.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/idb/-/idb-7.1.1.tgz#d910ded866d32c7ced9befc5bfdf36f572ced72b"
   integrity sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==
@@ -4391,6 +5620,15 @@ install-artifact-from-github@^1.7.0:
   resolved "https://registry.yarnpkg.com/install-artifact-from-github/-/install-artifact-from-github-1.7.0.tgz#986a8c404dc67bf62315517c993322a31f25ad4a"
   integrity sha512-qAb91yAKVF9rFY4rVP21ZtYUyCScxAFt9udwzVWNLBE1pQcdQeB2gd1HlNPcQNYCzCDvJ/QJQPuWQ6aTmSlU8g==
 
+internal-slot@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.1.0.tgz#1eac91762947d2f7056bc838d93e13b2e9604961"
+  integrity sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==
+  dependencies:
+    es-errors "^1.3.0"
+    hasown "^2.0.2"
+    side-channel "^1.1.0"
+
 ip-address@^10.1.1, ip-address@^10.2.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.4.0.tgz#c5910bc541b6eae287765d1e4846be0308a05d93"
@@ -4406,12 +5644,52 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
+is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-3.0.5.tgz#65742e1e687bd2cc666253068fd8707fe4d44280"
+  integrity sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
+
+is-async-function@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.1.1.tgz#3e69018c8e04e73b738793d020bfe884b9fd3523"
+  integrity sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==
+  dependencies:
+    async-function "^1.0.0"
+    call-bound "^1.0.3"
+    get-proto "^1.0.1"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
+
+is-bigint@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.1.0.tgz#dda7a3445df57a42583db4228682eba7c4170672"
+  integrity sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==
+  dependencies:
+    has-bigints "^1.0.2"
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-boolean-object@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.2.2.tgz#7067f47709809a393c71ff5bb3e135d8a9215d9e"
+  integrity sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
+
+is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -4420,15 +5698,64 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
+is-core-module@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.2.tgz#3e07450a8080ebce3fbf0cac494f4d2ab324e082"
+  integrity sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==
+  dependencies:
+    hasown "^2.0.3"
+
+is-data-view@^1.0.1, is-data-view@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-data-view/-/is-data-view-1.0.2.tgz#bae0a41b9688986c2188dda6657e56b8f9e63b8e"
+  integrity sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==
+  dependencies:
+    call-bound "^1.0.2"
+    get-intrinsic "^1.2.6"
+    is-typed-array "^1.1.13"
+
+is-date-object@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.1.0.tgz#ad85541996fc7aa8b2729701d27b7319f95d82f7"
+  integrity sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
+
+is-document.all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-document.all/-/is-document.all-1.0.0.tgz#163a4bfb362c6ed7b118ce46cdecc4e37dee3195"
+  integrity sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==
+  dependencies:
+    call-bound "^1.0.4"
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
+is-finalizationregistry@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz#eefdcdc6c94ddd0674d9c85887bf93f944a97c90"
+  integrity sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==
+  dependencies:
+    call-bound "^1.0.3"
+
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-generator-function@^1.0.10:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
+  integrity sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==
+  dependencies:
+    call-bound "^1.0.4"
+    generator-function "^2.0.0"
+    get-proto "^1.0.1"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
@@ -4450,15 +5777,43 @@ is-interactive@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-map@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.3.tgz#ede96b7fe1e270b3c4465e3a465658764926d62e"
+  integrity sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==
+
+is-negative-zero@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
+  integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
+
 is-npm@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-5.0.0.tgz#43e8d65cc56e1b67f8d47262cf667099193f45a8"
   integrity sha512-WW/rQLOazUq+ST/bCAVBp/2oMERWLsR7OrKyt052dNDk4DHcDE0/7QSXITlmi+VBcV13DfIbysG3tZJm5RfdBA==
 
+is-number-object@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.1.1.tgz#144b21e95a1bc148205dcc2814a9134ec41b2541"
+  integrity sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==
 
 is-obj@^2.0.0:
   version "2.0.0"
@@ -4480,6 +5835,33 @@ is-promise@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
   integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
+is-regex@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
+  integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
+  dependencies:
+    call-bound "^1.0.2"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  integrity sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==
+
+is-set@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-set/-/is-set-2.0.3.tgz#8ab209ea424608141372ded6e0cb200ef1d9d01d"
+  integrity sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==
+
+is-shared-array-buffer@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz#9b67844bd9b7f246ba0708c3a93e34269c774f6f"
+  integrity sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==
+  dependencies:
+    call-bound "^1.0.3"
+
 is-stream-ended@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
@@ -4489,6 +5871,30 @@ is-stream@^2.0.0, is-stream@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-string@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
+  integrity sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==
+  dependencies:
+    call-bound "^1.0.3"
+    has-tostringtag "^1.0.2"
+
+is-symbol@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.1.1.tgz#f47761279f532e2b05a7024a7506dbbedacd0634"
+  integrity sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==
+  dependencies:
+    call-bound "^1.0.2"
+    has-symbols "^1.1.0"
+    safe-regex-test "^1.1.0"
+
+is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
+  integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
+  dependencies:
+    which-typed-array "^1.1.16"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -4509,6 +5915,26 @@ is-url@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
   integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
+
+is-weakmap@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakmap/-/is-weakmap-2.0.2.tgz#bf72615d649dfe5f699079c54b83e47d1ae19cfd"
+  integrity sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==
+
+is-weakref@^1.0.2, is-weakref@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.1.1.tgz#eea430182be8d64174bd96bffbc46f21bf3f9293"
+  integrity sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==
+  dependencies:
+    call-bound "^1.0.3"
+
+is-weakset@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-weakset/-/is-weakset-2.0.4.tgz#c9f5deb0bc1906c6d6f1027f284ddf459249daca"
+  integrity sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==
+  dependencies:
+    call-bound "^1.0.3"
+    get-intrinsic "^1.2.6"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -4533,6 +5959,11 @@ isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -4596,6 +6027,22 @@ jackspeak@^3.1.2:
     "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
+
+jackspeak@^4.1.1:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-4.2.3.tgz#27ef80f33b93412037c3bea4f8eddf80e1931483"
+  integrity sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==
+  dependencies:
+    "@isaacs/cliui" "^9.0.0"
+
+jake@^10.8.5:
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.4.tgz#d626da108c63d5cfb00ab5c25fadc7e0084af8e6"
+  integrity sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==
+  dependencies:
+    async "^3.2.6"
+    filelist "^1.0.4"
+    picocolors "^1.1.1"
 
 jiti@^2.7.0:
   version "2.7.0"
@@ -4670,7 +6117,7 @@ jsdom@^30.0.1:
     whatwg-url "^17.1.0"
     xml-name-validator "^5.0.0"
 
-jsesc@^3.0.2:
+jsesc@^3.0.2, jsesc@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
@@ -4732,6 +6179,11 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonpointer@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
+  integrity sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==
 
 jsonwebtoken@^9.0.0, jsonwebtoken@^9.0.2:
   version "9.0.3"
@@ -4796,6 +6248,11 @@ lazystream@^1.0.0:
   integrity sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==
   dependencies:
     readable-stream "^2.0.5"
+
+leven@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
+  integrity sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -4992,6 +6449,11 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
 
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -5114,7 +6576,7 @@ lz-string@^1.5.0:
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
   integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
 
-magic-string@^0.30.17, magic-string@^0.30.21:
+magic-string@^0.30.17, magic-string@^0.30.21, magic-string@^0.30.3:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -5246,7 +6708,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
+minimatch@^10.1.1, minimatch@^10.2.2, minimatch@^10.2.4, minimatch@^10.2.5:
   version "10.2.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.6.tgz#fd956bbe0b77241e9f15ac5dccb1c638060968ef"
   integrity sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==
@@ -5260,7 +6722,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.1.0:
+minimatch@^5.0.1, minimatch@^5.1.0:
   version "5.1.9"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.9.tgz#1293ef15db0098b394540e8f9f744f9fda8dee4b"
   integrity sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==
@@ -5445,6 +6907,11 @@ node-releases@^2.0.51:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.52.tgz#d8283ba25e577a4d9756d5b45eca353ba5500300"
   integrity sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==
 
+node-releases@^2.0.53:
+  version "2.0.53"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.53.tgz#0fe5ad8a7935e075172f574e56f0c20f07fa41af"
+  integrity sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==
+
 nopt@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-10.0.1.tgz#2d53bfda504b31c447967648ba5ea1a44e594d05"
@@ -5471,6 +6938,23 @@ object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
+
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.7:
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.7.tgz#8c14ca1a424c6a561b0bb2a22f66f5049a945d3d"
+  integrity sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
+    has-symbols "^1.1.0"
+    object-keys "^1.1.1"
 
 on-finished@^2.2.0, on-finished@^2.4.1, on-finished@~2.4.1:
   version "2.4.1"
@@ -5552,6 +7036,16 @@ ora@^5.4.1:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
+
+own-keys@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.2.tgz#31448ec1f781ecb1447f6f6aa0d6534222af59de"
+  integrity sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==
+  dependencies:
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
+    object-keys "^1.1.1"
+    safe-push-apply "^1.0.0"
 
 p-defer@^3.0.0:
   version "3.0.0"
@@ -5648,6 +7142,11 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
 path-scurry@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
@@ -5655,6 +7154,14 @@ path-scurry@^1.11.1:
   dependencies:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
+
+path-scurry@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-2.0.2.tgz#6be0d0ee02a10d9e0de7a98bae65e182c9061f85"
+  integrity sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==
+  dependencies:
+    lru-cache "^11.0.0"
+    minipass "^7.1.2"
 
 path-to-regexp@^1.9.0:
   version "1.9.0"
@@ -5791,6 +7298,11 @@ portfinder@^1.0.32:
     async "^3.2.6"
     debug "^4.3.6"
 
+possible-typed-array-names@^1.0.0, possible-typed-array-names@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
+  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
 postcss@^8.5.25, postcss@^8.5.6:
   version "8.5.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.26.tgz#6e75135780c7e10df3433bf2266c552d35c8c620"
@@ -5836,6 +7348,16 @@ prettier@^3.9.6:
   version "3.9.6"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.9.6.tgz#b3ea5146515d40fc53f18aa63f74dfab1e10dbf6"
   integrity sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==
+
+pretty-bytes@^5.3.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
+  integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
+
+pretty-bytes@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-6.1.1.tgz#38cd6bb46f47afbf667c202cfc754bffd2016a3b"
+  integrity sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==
 
 pretty-format@^27.0.2:
   version "27.5.1"
@@ -6101,6 +7623,56 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reflect.getprototypeof@^1.0.10, reflect.getprototypeof@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
+  integrity sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.9"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    get-intrinsic "^1.2.7"
+    get-proto "^1.0.1"
+    which-builtin-type "^1.2.1"
+
+regenerate-unicode-properties@^10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz#aa113812ba899b630658c7623466be71e1f86f66"
+  integrity sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==
+  dependencies:
+    regenerate "^1.4.2"
+
+regenerate@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+
+regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz#1ad6c62d44a259007e55b3970e00f746efbcaa19"
+  integrity sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==
+  dependencies:
+    call-bind "^1.0.8"
+    define-properties "^1.2.1"
+    es-errors "^1.3.0"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    set-function-name "^2.0.2"
+
+regexpu-core@^6.3.1:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-6.4.0.tgz#3580ce0c4faedef599eccb146612436b62a176e5"
+  integrity sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==
+  dependencies:
+    regenerate "^1.4.2"
+    regenerate-unicode-properties "^10.2.2"
+    regjsgen "^0.8.0"
+    regjsparser "^0.13.0"
+    unicode-match-property-ecmascript "^2.0.0"
+    unicode-match-property-value-ecmascript "^2.2.1"
+
 registry-auth-token@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.1.1.tgz#f1ff69c8e492e7edee07110b4752dd0a8aa82853"
@@ -6115,6 +7687,18 @@ registry-url@^5.1.0:
   dependencies:
     rc "^1.2.8"
 
+regjsgen@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/regjsgen/-/regjsgen-0.8.0.tgz#df23ff26e0c5b300a6470cad160a9d090c3a37ab"
+  integrity sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==
+
+regjsparser@^0.13.0:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regjsparser/-/regjsparser-0.13.2.tgz#f654734b5c588b22ba3e21693b30523417180808"
+  integrity sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==
+  dependencies:
+    jsesc "~3.1.0"
+
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -6124,6 +7708,16 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resolve@^1.22.1, resolve@^1.22.11:
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
+  dependencies:
+    es-errors "^1.3.0"
+    is-core-module "^2.16.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -6225,6 +7819,41 @@ rollup@^4.43.0:
     "@rollup/rollup-win32-x64-msvc" "4.62.4"
     fsevents "~2.3.2"
 
+rollup@^4.53.3:
+  version "4.62.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.62.5.tgz#b287260e2178bebbcf60ed144b9ed59159d55afb"
+  integrity sha512-/tqMfgP7GPA3PHhCmuiS4vIjrSVhHLgY++i+dhbG462euyAj7FpM4D9uq1X3BgjlqRdpcOrYhcQtfiQLNc8tqw==
+  dependencies:
+    "@types/estree" "1.0.9"
+  optionalDependencies:
+    "@napi-rs/lzma-linux-x64-gnu" "1.5.1"
+    "@rollup/rollup-android-arm-eabi" "4.62.5"
+    "@rollup/rollup-android-arm64" "4.62.5"
+    "@rollup/rollup-darwin-arm64" "4.62.5"
+    "@rollup/rollup-darwin-x64" "4.62.5"
+    "@rollup/rollup-freebsd-arm64" "4.62.5"
+    "@rollup/rollup-freebsd-x64" "4.62.5"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.62.5"
+    "@rollup/rollup-linux-arm-musleabihf" "4.62.5"
+    "@rollup/rollup-linux-arm64-gnu" "4.62.5"
+    "@rollup/rollup-linux-arm64-musl" "4.62.5"
+    "@rollup/rollup-linux-loong64-gnu" "4.62.5"
+    "@rollup/rollup-linux-loong64-musl" "4.62.5"
+    "@rollup/rollup-linux-ppc64-gnu" "4.62.5"
+    "@rollup/rollup-linux-ppc64-musl" "4.62.5"
+    "@rollup/rollup-linux-riscv64-gnu" "4.62.5"
+    "@rollup/rollup-linux-riscv64-musl" "4.62.5"
+    "@rollup/rollup-linux-s390x-gnu" "4.62.5"
+    "@rollup/rollup-linux-x64-gnu" "4.62.5"
+    "@rollup/rollup-linux-x64-musl" "4.62.5"
+    "@rollup/rollup-openbsd-x64" "4.62.5"
+    "@rollup/rollup-openharmony-arm64" "4.62.5"
+    "@rollup/rollup-win32-arm64-msvc" "4.62.5"
+    "@rollup/rollup-win32-ia32-msvc" "4.62.5"
+    "@rollup/rollup-win32-x64-gnu" "4.62.5"
+    "@rollup/rollup-win32-x64-msvc" "4.62.5"
+    fsevents "~2.3.2"
+
 router@^2.0.0, router@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/router/-/router-2.2.0.tgz#019be620b711c87641167cc79b99090f00b146ef"
@@ -6236,6 +7865,17 @@ router@^2.0.0, router@^2.2.0:
     parseurl "^1.3.3"
     path-to-regexp "^8.0.0"
 
+safe-array-concat@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.4.tgz#a54cc9b61a57f33b42abad3cbdda3a2b38cc5719"
+  integrity sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
+    has-symbols "^1.1.0"
+    isarray "^2.0.5"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -6245,6 +7885,23 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.2.1, 
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-push-apply@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/safe-push-apply/-/safe-push-apply-1.0.0.tgz#01850e981c1602d398c85081f360e4e6d03d27f5"
+  integrity sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==
+  dependencies:
+    es-errors "^1.3.0"
+    isarray "^2.0.5"
+
+safe-regex-test@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
+  integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-regex "^1.2.1"
 
 safe-stable-stringify@^2.3.1:
   version "2.5.0"
@@ -6321,6 +7978,11 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
+serialize-javascript@^7.0.3:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.1.0.tgz#9e462c5c6dec5dbc8b55d90c52a4ad6aff985b9f"
+  integrity sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==
+
 serve-static@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-2.2.1.tgz#7f186a4a4e5f5b663ad7a4294ff1bf37cf0e98a9"
@@ -6345,6 +8007,37 @@ set-cookie-parser@^2.6.0:
   version "2.7.2"
   resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
   integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==
+
+set-function-length@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
+set-function-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/set-function-name/-/set-function-name-2.0.2.tgz#16a705c5a0dc2f5e638ca96d8a8cd4e1c2b90985"
+  integrity sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    functions-have-names "^1.2.3"
+    has-property-descriptors "^1.0.2"
+
+set-proto@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/set-proto/-/set-proto-1.0.0.tgz#0760dbcff30b2d7e801fd6e19983e56da337565e"
+  integrity sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
 
 setprototypeof@1.2.0, setprototypeof@~1.2.0:
   version "1.2.0"
@@ -6392,7 +8085,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.1.1:
+side-channel@^1.1.0, side-channel@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
   integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
@@ -6430,6 +8123,11 @@ smart-buffer@^4.2.0:
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
+smob@^1.0.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/smob/-/smob-1.6.2.tgz#190b94c25530c631a7ccc63de0d4c0087222d21d"
+  integrity sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==
+
 socks-proxy-agent@^8.0.5:
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
@@ -6452,10 +8150,23 @@ source-map-js@^1.2.0, source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map@~0.6.1:
+source-map-support@~0.5.20:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.8.0-beta.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0.tgz#72b9006383bd9fc70d52e435c91c2d73249c60a4"
+  integrity sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==
 
 split2@^4.1.0:
   version "4.2.0"
@@ -6494,6 +8205,14 @@ std-env@^3.9.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
+
+stop-iteration-iterator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz#f481ff70a548f6124d0312c3aa14cbfa7aa542ad"
+  integrity sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==
+  dependencies:
+    es-errors "^1.3.0"
+    internal-slot "^1.1.0"
 
 stream-chain@^2.2.4, stream-chain@^2.2.5:
   version "2.2.5"
@@ -6555,6 +8274,58 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string.prototype.matchall@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz#6c88740e49ad4956b1332a911e949583a275d4c0"
+  integrity sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.3"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.6"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.0.0"
+    get-intrinsic "^1.2.6"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    internal-slot "^1.1.0"
+    regexp.prototype.flags "^1.5.3"
+    set-function-name "^2.0.2"
+    side-channel "^1.1.0"
+
+string.prototype.trim@^1.2.10:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz#e6bd19cda3985d05a42dda31f3ddf4d35d3430e3"
+  integrity sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    define-data-property "^1.1.4"
+    define-properties "^1.2.1"
+    es-abstract "^1.24.2"
+    es-object-atoms "^1.1.2"
+    has-property-descriptors "^1.0.2"
+    safe-regex-test "^1.1.0"
+
+string.prototype.trimend@^1.0.9:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz#be6bcf4f3fe0460bdeccdb2cf4f971b310f8346e"
+  integrity sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==
+  dependencies:
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.1.2"
+
+string.prototype.trimstart@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz#7ee834dda8c7c17eff3118472bb35bfedaa34dde"
+  integrity sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
+
 string_decoder@^1.1.1, string_decoder@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -6568,6 +8339,15 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+stringify-object@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.3.0.tgz#703065aefca19300d3ce88af4f5b3956d7556629"
+  integrity sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==
+  dependencies:
+    get-own-enumerable-property-symbols "^3.0.0"
+    is-obj "^1.0.1"
+    is-regexp "^1.0.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -6589,6 +8369,11 @@ strip-ansi@^7.0.1:
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
   dependencies:
     ansi-regex "^6.2.2"
+
+strip-comments@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-comments/-/strip-comments-2.0.1.tgz#4ad11c3fbcac177a67a40ac224ca339ca1c1ba9b"
+  integrity sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -6660,6 +8445,11 @@ supports-hyperlinks@^3.1.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -6733,6 +8523,31 @@ teex@^1.0.1:
   dependencies:
     streamx "^2.12.5"
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
+tempy@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.6.0.tgz#65e2c35abc06f1124a97f387b08303442bde59f3"
+  integrity sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==
+  dependencies:
+    is-stream "^2.0.0"
+    temp-dir "^2.0.0"
+    type-fest "^0.16.0"
+    unique-string "^2.0.0"
+
+terser@^5.17.4:
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.50.0.tgz#4e560a46704f9172f96ba31c3bd6dc108ad2cead"
+  integrity sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==
+  dependencies:
+    "@jridgewell/source-map" "^0.3.3"
+    acorn "^8.15.0"
+    commander "^2.20.0"
+    source-map-support "~0.5.20"
+
 test-exclude@^7.0.1:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.2.tgz#482392077630bc57d5630c13abe908bb910dfc65"
@@ -6778,7 +8593,7 @@ tinyexec@^0.3.2:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.15, tinyglobby@^0.2.17:
+tinyglobby@^0.2.10, tinyglobby@^0.2.12, tinyglobby@^0.2.14, tinyglobby@^0.2.15, tinyglobby@^0.2.17:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
   integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
@@ -6883,6 +8698,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-fest@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.16.0.tgz#3240b891a78b0deae910dbeb86553e552a148860"
+  integrity sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
@@ -6904,6 +8724,51 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typed-array-buffer@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz#a72395450a4869ec033fd549371b47af3a2ee536"
+  integrity sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==
+  dependencies:
+    call-bound "^1.0.3"
+    es-errors "^1.3.0"
+    is-typed-array "^1.1.14"
+
+typed-array-byte-length@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz#8407a04f7d78684f3d252aa1a143d2b77b4160ce"
+  integrity sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==
+  dependencies:
+    call-bind "^1.0.8"
+    for-each "^0.3.3"
+    gopd "^1.2.0"
+    has-proto "^1.2.0"
+    is-typed-array "^1.1.14"
+
+typed-array-byte-offset@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz#ae3698b8ec91a8ab945016108aef00d5bff12355"
+  integrity sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    for-each "^0.3.3"
+    gopd "^1.2.0"
+    has-proto "^1.2.0"
+    is-typed-array "^1.1.15"
+    reflect.getprototypeof "^1.0.9"
+
+typed-array-length@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/typed-array-length/-/typed-array-length-1.0.8.tgz#0b70e982c9e9dafe2def6d6458ff4b3f2d2b6d70"
+  integrity sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==
+  dependencies:
+    call-bind "^1.0.9"
+    for-each "^0.3.5"
+    gopd "^1.2.0"
+    is-typed-array "^1.1.15"
+    possible-typed-array-names "^1.1.0"
+    reflect.getprototypeof "^1.0.10"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -6927,6 +8792,16 @@ typescript@^6.0.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
+unbox-primitive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.1.0.tgz#8d9d2c9edeea8460c7f35033a88867944934d1e2"
+  integrity sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==
+  dependencies:
+    call-bound "^1.0.3"
+    has-bigints "^1.0.2"
+    has-symbols "^1.1.0"
+    which-boxed-primitive "^1.1.1"
+
 undici-types@~8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
@@ -6942,10 +8817,33 @@ undici@^8.4.1, undici@^8.9.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
   integrity sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==
 
+unicode-canonical-property-names-ecmascript@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz#cb3173fe47ca743e228216e4a3ddc4c84d628cc2"
+  integrity sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==
+
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz#dbbd5b54ba30f287e2a8d5a249da6c0cef369459"
   integrity sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==
+
+unicode-match-property-ecmascript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz#54fd16e0ecb167cf04cf1f756bdcc92eba7976c3"
+  integrity sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==
+  dependencies:
+    unicode-canonical-property-names-ecmascript "^2.0.0"
+    unicode-property-aliases-ecmascript "^2.0.0"
+
+unicode-match-property-value-ecmascript@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz#65a7adfad8574c219890e219285ce4c64ed67eaa"
+  integrity sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==
+
+unicode-property-aliases-ecmascript@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz#301d4f8a43d2b75c97adfad87c9dd5350c9475d1"
+  integrity sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==
 
 unique-string@^2.0.0:
   version "2.0.0"
@@ -6972,10 +8870,23 @@ unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
+upath@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 update-browserslist-db@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
   integrity sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==
+  dependencies:
+    escalade "^3.2.0"
+    picocolors "^1.1.1"
+
+update-browserslist-db@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz#a71c28dd22f505481dbc4689087b18d933e90afd"
+  integrity sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
@@ -7059,6 +8970,17 @@ vite-node@3.2.4:
     es-module-lexer "^1.7.0"
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
+vite-plugin-pwa@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-pwa/-/vite-plugin-pwa-1.3.0.tgz#98f06224027479c541dafb1fd474d907a12039bd"
+  integrity sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==
+  dependencies:
+    debug "^4.3.6"
+    pretty-bytes "^6.1.1"
+    tinyglobby "^0.2.10"
+    workbox-build "^7.4.1"
+    workbox-window "^7.4.1"
 
 "vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
   version "7.3.6"
@@ -7200,6 +9122,59 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz#d76ec27df7fa165f18d5808374a5fe23c29b176e"
+  integrity sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==
+  dependencies:
+    is-bigint "^1.1.0"
+    is-boolean-object "^1.2.1"
+    is-number-object "^1.1.1"
+    is-string "^1.1.1"
+    is-symbol "^1.1.1"
+
+which-builtin-type@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/which-builtin-type/-/which-builtin-type-1.2.1.tgz#89183da1b4907ab089a6b02029cc5d8d6574270e"
+  integrity sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==
+  dependencies:
+    call-bound "^1.0.2"
+    function.prototype.name "^1.1.6"
+    has-tostringtag "^1.0.2"
+    is-async-function "^2.0.0"
+    is-date-object "^1.1.0"
+    is-finalizationregistry "^1.1.0"
+    is-generator-function "^1.0.10"
+    is-regex "^1.2.1"
+    is-weakref "^1.0.2"
+    isarray "^2.0.5"
+    which-boxed-primitive "^1.1.0"
+    which-collection "^1.0.2"
+    which-typed-array "^1.1.16"
+
+which-collection@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-collection/-/which-collection-1.0.2.tgz#627ef76243920a107e7ce8e96191debe4b16c2a0"
+  integrity sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==
+  dependencies:
+    is-map "^2.0.3"
+    is-set "^2.0.3"
+    is-weakmap "^2.0.2"
+    is-weakset "^2.0.3"
+
+which-typed-array@^1.1.16, which-typed-array@^1.1.19:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
@@ -7259,6 +9234,164 @@ word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
+workbox-background-sync@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-7.4.1.tgz#2a7112bef7a734e665ca75d1d9ceb0a90c2c6357"
+  integrity sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==
+  dependencies:
+    idb "^7.0.1"
+    workbox-core "7.4.1"
+
+workbox-broadcast-update@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-update/-/workbox-broadcast-update-7.4.1.tgz#32a9d019b1cd2d98a7c8f39815b2edd0b52023a4"
+  integrity sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-build@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-7.4.1.tgz#b705d678dde0559d5e818cb6a9e9908668f792e1"
+  integrity sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==
+  dependencies:
+    "@apideck/better-ajv-errors" "^0.3.1"
+    "@babel/core" "^7.24.4"
+    "@babel/preset-env" "^7.11.0"
+    "@babel/runtime" "^7.11.2"
+    "@rollup/plugin-babel" "^6.1.0"
+    "@rollup/plugin-node-resolve" "^16.0.3"
+    "@rollup/plugin-replace" "^6.0.3"
+    "@rollup/plugin-terser" "^1.0.0"
+    "@trickfilm400/rollup-plugin-off-main-thread" "^3.0.0-pre1"
+    ajv "^8.6.0"
+    common-tags "^1.8.0"
+    eta "^4.5.1"
+    fast-json-stable-stringify "^2.1.0"
+    fs-extra "^9.0.1"
+    glob "^11.0.1"
+    pretty-bytes "^5.3.0"
+    rollup "^4.53.3"
+    source-map "^0.8.0-beta.0"
+    stringify-object "^3.3.0"
+    strip-comments "^2.0.1"
+    tempy "^0.6.0"
+    upath "^1.2.0"
+    workbox-background-sync "7.4.1"
+    workbox-broadcast-update "7.4.1"
+    workbox-cacheable-response "7.4.1"
+    workbox-core "7.4.1"
+    workbox-expiration "7.4.1"
+    workbox-google-analytics "7.4.1"
+    workbox-navigation-preload "7.4.1"
+    workbox-precaching "7.4.1"
+    workbox-range-requests "7.4.1"
+    workbox-recipes "7.4.1"
+    workbox-routing "7.4.1"
+    workbox-strategies "7.4.1"
+    workbox-streams "7.4.1"
+    workbox-sw "7.4.1"
+    workbox-window "7.4.1"
+
+workbox-cacheable-response@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-7.4.1.tgz#a18a4f23132de3f5596d3e714c75249232e1993a"
+  integrity sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-core@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-7.4.1.tgz#5a8811ba5d25a2049821a7b66f63ee9b204dc691"
+  integrity sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==
+
+workbox-expiration@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-expiration/-/workbox-expiration-7.4.1.tgz#24d234859d2b19604827b30f0de3458e72e0c51a"
+  integrity sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==
+  dependencies:
+    idb "^7.0.1"
+    workbox-core "7.4.1"
+
+workbox-google-analytics@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-7.4.1.tgz#6507fcee4d12bf62b387b3426851b71d8e7361dc"
+  integrity sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==
+  dependencies:
+    workbox-background-sync "7.4.1"
+    workbox-core "7.4.1"
+    workbox-routing "7.4.1"
+    workbox-strategies "7.4.1"
+
+workbox-navigation-preload@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-navigation-preload/-/workbox-navigation-preload-7.4.1.tgz#941727db52389c8778bb61dbc92c193a732aa77a"
+  integrity sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-precaching@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-7.4.1.tgz#059a88c092e762c341cf080ab88b4e8568af21ae"
+  integrity sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==
+  dependencies:
+    workbox-core "7.4.1"
+    workbox-routing "7.4.1"
+    workbox-strategies "7.4.1"
+
+workbox-range-requests@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-7.4.1.tgz#0d5655ac424065f6f2e594722b23a0ff166be09b"
+  integrity sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-recipes@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-recipes/-/workbox-recipes-7.4.1.tgz#a82b6ccca9ee26ec9fd16afd570bf08dac79e852"
+  integrity sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==
+  dependencies:
+    workbox-cacheable-response "7.4.1"
+    workbox-core "7.4.1"
+    workbox-expiration "7.4.1"
+    workbox-precaching "7.4.1"
+    workbox-routing "7.4.1"
+    workbox-strategies "7.4.1"
+
+workbox-routing@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-7.4.1.tgz#159fdd88260fce25f8ab15b46674852ad8aa48eb"
+  integrity sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-strategies@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-7.4.1.tgz#6efe950e9d434b5d70a6277c4bdcdc5be4dfc8e5"
+  integrity sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==
+  dependencies:
+    workbox-core "7.4.1"
+
+workbox-streams@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-7.4.1.tgz#2f2430d6ea2fe360d630c3ab8df3f9ff667a0ce0"
+  integrity sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==
+  dependencies:
+    workbox-core "7.4.1"
+    workbox-routing "7.4.1"
+
+workbox-sw@7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-7.4.1.tgz#aca04313ae6591222024ee80219b223384c9119c"
+  integrity sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==
+
+workbox-window@7.4.1, workbox-window@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/workbox-window/-/workbox-window-7.4.1.tgz#ab3bfb2db306fb1584e791cc9ea02bf6e2f69e19"
+  integrity sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==
+  dependencies:
+    "@types/trusted-types" "^2.0.2"
+    workbox-core "7.4.1"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"


### PR DESCRIPTION
### Summary

The app becomes usable without a network, and gains the one thing that must
ship with a service worker rather than after it: a way to end its own version.

Closes #67. Closes #68.

They are one pull request because separating them ships a defect. Before a
worker, a stale chunk fixed itself — the next load fetched a new `index.html`
and the new chunk names came with it. Under a worker it does not: a controlled
client keeps being served the precached build until every tab on the origin
closes. Reloading, the thing a reader tries and the thing a support reply would
say, becomes the action that does not help.

### #67 — the offline shell

`vite-plugin-pwa` in `generateSW` mode precaches the built output: **37 entries**
— the shell, the CSS, all four icons, the manifest, and **every one of the nine
route chunks**. The chunks are the point. Every route in `src/router.tsx` is a
`lazy: () => import(...)`, so a precached shell without them reaches no screen
at all, which is exactly the state #67 describes.

`navigateFallback: '/index.html'` matches the rewrite already in `firebase.json`.

### #68 — the prompt

`AppUpdatePort` in `src/domain/ports.ts`, wired through `src/lib/backend.ts`
like every other adapter, so the `e2e` build supplies its own implementation
through the seam the architecture already had. That implementation reports a
waiting build never — not as a stub, but because a build with no worker
genuinely never has one.

`UpdatePrompt` is a polite live region rather than a dialog. It only ever
arrives while the reader is mid-something — that is the only time it *can*
arrive — and a modal taking focus would interrupt a dictation answer to talk
about deployment. Strings are in all five locales, and the copy says the app
reloads, because it does, and half-typed input goes with it.

### The `skipWaiting` / `clientsClaim` decision

Both off. Reasoning lives in `pwa-config.ts` next to the values.

Claiming immediately swaps the precached assets under a session already
running, so the next lazily imported route arrives from a bundle the loaded code
was never compiled against. Mid-dictation that is worse than the staleness it
fixes: unreproducible, and it lands on whoever was busiest.

The cost of the other side is not being waved away — a waiting worker waits for
every tab to close, which for an installed app can be days. The prompt is what
ends that wait, on the reader's word rather than the browser's. A reader who
keeps choosing "Later" stays on the old build, deliberately: old and working
beats new and halfway.

### One thing neither issue asked for

`navigateFallbackDenylist: [/^\/__\//]`. Firebase reserves that prefix and
`signInWithPopup` opens `/__/auth/handler` under it. That is another origin
while the auth domain is the `firebaseapp.com` default — but pointing it at the
hosting domain is a documented way around third-party cookies, and on that day a
navigation fallback would answer the auth handler with `index.html` and break
sign-in with nothing naming the cause.

### A bug this introduced, and the test that now catches it

`main.tsx` first imported `./lib/backend`. The end-to-end alias is
`/^@\/lib\/backend$/` — anchored on the **absolute** specifier — so the relative
form resolved straight past it. No error, a green build, and an end-to-end
bundle quietly carrying the Firebase SDK and the service-worker registration
that `mode === 'e2e'` exists to keep out.

Nothing in a diff shows it: every other importer in the repo uses
`@/lib/backend`, and a relative import sitting among other relative imports is
what `main.tsx` already looked like.

`tests/unit/backendSeam.test.ts` scans `src/` for it. The bundle claim was also
checked by hand — the `e2e` output contains no `firebase`, `initializeApp`,
`workbox-window` or `onNeedRefresh`.

### Testing

Three layers, each the cheapest that can see its defect.

| Layer | File | Sees |
| --- | --- | --- |
| Unit | `tests/unit/pwaConfig.test.ts` | the worker's settings, all of whose failures are silent |
| Unit | `tests/unit/backendSeam.test.ts` | the alias bypass above, a property of the source text |
| Component | `tests/component/UpdatePrompt.test.tsx` | what the reader is shown and what each button does |

`pwaOptions` was extracted to `pwa-config.ts` — beside `build-info.ts`, which
exists for the same reason — because `VitePWA(options)` returns plugin objects
that carry the options nowhere a test can reach. Inlined, every decision above
was beyond anything short of a full build.

The component test implements `AppUpdatePort` rather than substituting for it.
That is standing in for a service worker at a seam `src/lib/backend.e2e.ts`
already implements, not stubbing `src/lib` or `src/components`.

**Proved red before claimed green.** Ten injected defects, restoring after each;
every one turned its own assertions and no others:

| Injected | Red |
| --- | --- |
| worker enabled under `e2e` | 1 — the suite would pass against a build nobody shipped |
| worker disabled everywhere | 2 |
| `registerType: 'autoUpdate'` | 1 |
| `skipWaiting`/`clientsClaim` on | 1 |
| `injectRegister` set | 1 |
| `js` dropped from `globPatterns` | 1 — shell cached, every screen missing |
| `/__/*` denylist removed | 3 |
| relative backend import restored | 1 |
| banner rendered with no waiting build | 1 |
| `Update now` wired to dismiss | 1 — the button that looks like it worked |
| `Later` activating as well | 1 |
| `role="status"` removed | 1 |

The denylist is asserted over paths rather than by comparing the pattern to
itself, which would pass for any regular expression at all.

### Verified in a real browser, not against documentation

Production-mode build, served locally, driven with Chromium.

Offline:

```
✓ every built file is precached (37/37, all nine route chunks)
✓ the first page is not claimed — clientsClaim:false behaving correctly
✓ the worker controls the page from the second navigation
✓ offline: / renders the shell
✓ offline: /vocabulary resolves through navigateFallback and renders
✓ offline: the manifest is still served (200)
✓ no same-origin request failed offline
```

The handover, across two real builds:

```
✓ no prompt while the running build is the only build
✓ a waiting build raises the prompt
✓ the page is still on build A until the reader agrees
✓ taking the update lands the session on the new build
✓ the prompt is gone afterwards
```

Suites: unit + component **707**, emulator **81**, end-to-end **128**.
`yarn build` now emits no config-loader warning.

### What is deliberately not covered here

**Offline navigation has no committed test.** The end-to-end build has no worker
by design, so the Playwright harness — which builds `--mode e2e` — structurally
cannot exercise one. Landing it would mean a second build mode, a second server
and real credentials in the harness. #65 owns that and names the layer it needs;
the behaviour was verified by hand instead, above. `tests/unit/pwaConfig.test.ts`
says so in as many words rather than leaving the gap implied.

**Installability's second half.** Chromium's own manifest parse reports no
errors (`Page.getAppManifest` over CDP, the same source DevTools shows), but
headless Chromium does not fire `beforeinstallprompt`. That check needs a real
browser against this pull request's preview channel and will be done there.

### Unrelated flake, seen while running this

`wordsets.spec.ts:267 › auto-scrolls a large member list…` fails intermittently
on `expect(scrollTop).toBeGreaterThan(0)` receiving `0` — the auto-scroll never
advances under parallel load. It passes 6/6 in isolation.

**Not caused by this branch.** Checked by alternating full-suite runs against
`develop`, which fails the same test with none of these changes: 1 failure in 6
runs there, 3 in 7 here, and the difference is machine load rather than code —
the worker does not exist in the build this test runs against. Filed as #79 rather than folded
in, with the rates above and a suggested fix (poll for the condition instead of
sleeping past it).

### Follow-ups

- #63 offline as a state the interface can show
- #64 `env(safe-area-inset-*)` — which now covers one more fixed element, the
  banner, alongside the add button already there. Noted in `UpdatePrompt.tsx`.
- #65 the tests named above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline support with application precaching and navigation fallback.
  * Added installable PWA support with automatic cache cleanup.
  * Added in-app notifications when a new version is ready.
  * Users can activate updates immediately or defer them for the session.
  * Added localized update messages in English, Japanese, Traditional Chinese, Korean, and Spanish.

* **Documentation**
  * Added setup, deployment, update behavior, offline testing, and installability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
