### PR TITLE
feat(layout): read the device safe-area insets, and give /login a way out

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -110,7 +110,7 @@ function AuthenticatedLayout({
                 footer floating with page background under it, which reads as a
                 stray edge across the screen in dark mode. */}
             <div className="flex min-h-dvh flex-col bg-bg text-ink">
-              <header className="sticky top-0 z-30 border-b border-line bg-card/85 backdrop-blur">
+              <header className="sticky top-0 z-30 border-b border-line bg-card/85 pt-safe px-safe backdrop-blur">
                 <div className="mx-auto flex max-w-5xl items-center gap-2 px-4 py-3">
                   <NavLink
                     to="/"
@@ -153,8 +153,20 @@ function AuthenticatedLayout({
                 {menuOpen && <MobileNav onNavigate={() => setMenuOpen(false)} />}
               </header>
 
-              <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-6 pb-28 nav:pb-10">
-                <Outlet />
+              {/* Two boxes rather than one, because `px-4` and the side inset
+                  both want padding-inline and a single element cannot hold both.
+                  The outer one takes the device's strips, the inner one the
+                  gutter and the width — so the page centres inside the space
+                  the screen actually gives, not inside the notch.
+
+                  `pb-safe nav:pb-0`, because below the `nav` breakpoint this is
+                  the last thing on the page: the footer is `nav:block` and the
+                  home indicator would otherwise sit on the final row of cards.
+                  Above it the footer follows and carries its own. */}
+              <main className="w-full flex-1 px-safe pb-safe nav:pb-0">
+                <div className="mx-auto max-w-5xl px-4 py-6 pb-28 nav:pb-10">
+                  <Outlet />
+                </div>
               </main>
 
               {/* The same footer the public pages carry, so the two never
@@ -169,7 +181,7 @@ function AuthenticatedLayout({
                 type="button"
                 onClick={() => setAdding(true)}
                 aria-label={t('action.addVocabulary')}
-                className="fixed right-5 bottom-5 z-20 grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
+                className="fixed right-5 bottom-5 z-20 mr-safe mb-safe grid h-14 w-14 place-items-center rounded-pill bg-accent text-2xl text-on-accent shadow-panel nav:hidden"
               >
                 ＋
               </button>

--- a/src/components/BottomNotices.tsx
+++ b/src/components/BottomNotices.tsx
@@ -36,12 +36,16 @@ import { UpdatePrompt } from './UpdatePrompt';
  * the transparent gap between the two panels would swallow taps meant for the
  * page underneath — the add button among them.
  *
- * The bottom offset still does not read `env(safe-area-inset-bottom)`; that is
- * #64, and this stack is now the single place it has to be applied.
+ * `mx-safe mb-safe` is where the device's own strips land, and one stack is
+ * why it is one line: with the two panels still placing themselves, the same
+ * inset would have had to be written twice and stay in agreement with the add
+ * button's. Margin rather than a bigger offset, because `inset-x-4` and
+ * `bottom-24` are the design's spacing and the inset is not — keeping them
+ * separate is what lets a reader see which number came from where.
  */
 export function BottomNotices() {
   return (
-    <div className="pointer-events-none fixed inset-x-4 bottom-24 z-40 flex flex-col gap-3 nav:bottom-5">
+    <div className="pointer-events-none fixed inset-x-4 bottom-24 z-40 mx-safe mb-safe flex flex-col gap-3 nav:bottom-5">
       {/* Above the prompt, which is the one with buttons on it: the reachable
           end of the stack belongs to the panel that asks for an action. */}
       <OfflineNotice />

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -193,7 +193,7 @@ export function Modal({
         aria-modal="true"
         aria-label={title}
         tabIndex={-1}
-        className="flex max-h-[88vh] w-full flex-col rounded-t-3xl bg-card shadow-panel nav:max-h-[86vh] nav:max-w-2xl nav:rounded-3xl"
+        className="flex max-h-[88vh] w-full flex-col rounded-t-3xl bg-card px-safe pb-safe shadow-panel nav:max-h-[86vh] nav:max-w-2xl nav:rounded-3xl nav:px-0 nav:pb-0"
       >
         <div className="shrink-0 px-5 pt-3 nav:pt-5">
           <div className="mx-auto mb-3 h-1 w-10 rounded-full bg-line nav:hidden" />

--- a/src/components/PublicLayout.tsx
+++ b/src/components/PublicLayout.tsx
@@ -24,7 +24,7 @@ export function PublicLayout({ children }: { children: ReactNode }) {
   const { t } = useI18n();
   return (
     <div className="flex min-h-dvh flex-col bg-bg text-ink">
-      <header className="border-b border-line bg-card">
+      <header className="border-b border-line bg-card pt-safe px-safe">
         <div className="mx-auto flex max-w-3xl items-center gap-2 px-4 py-3">
           <Link to="/" className="flex items-center gap-2">
             <LogoMark className="h-8 w-8" />
@@ -39,7 +39,12 @@ export function PublicLayout({ children }: { children: ReactNode }) {
         </div>
       </header>
 
-      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-8">{children}</main>
+      {/* Split for the same reason as `AppLayout`: the outer box takes the
+          device's side strips, the inner one the reading gutter and the
+          measure. */}
+      <main className="w-full flex-1 px-safe">
+        <div className="mx-auto max-w-3xl px-4 py-8">{children}</div>
+      </main>
 
       <PublicFooter />
     </div>
@@ -62,8 +67,11 @@ export function PublicLayout({ children }: { children: ReactNode }) {
  */
 export function PublicFooter({ width = 'max-w-3xl' }: { width?: string }) {
   const { t } = useI18n();
+  // The bottom inset lives here rather than on each shell, because this is the
+  // last element of all three of them — the public pages, the login screen, and
+  // the signed-in layout above the `nav` breakpoint.
   return (
-    <footer className="border-t border-line bg-card">
+    <footer className="border-t border-line bg-card px-safe pb-safe">
       <div
         className={`mx-auto flex ${width} flex-wrap items-center justify-center gap-x-4 gap-y-2 px-4 py-5 text-xs text-muted sm:justify-start`}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -100,7 +100,7 @@
 }
 
 /*
- * The four strips of the screen a phone does not actually give the page.
+ * The strips of the screen a phone does not actually give the page.
  *
  * `index.html` has asked for `viewport-fit=cover` since before the manifest,
  * which lays the document out edge to edge — under the notch, under the status
@@ -111,36 +111,6 @@
  * the header ran under the status bar and the add button sat under the home
  * indicator, where the swipe that leaves the app starts.
  *
- * **Named properties rather than `env()` at each use site, and the indirection
- * is what makes the layout testable.** `env(safe-area-inset-*)` resolves to
- * zero in every browser Playwright can drive, and there is no protocol for
- * setting it, so geometry measured against `env()` directly measures nothing —
- * a layout that ignores the insets entirely passes identically. Against a
- * variable, a test overrides `:root` with a real device's 34px and 47px and
- * asserts the layout moved. That is `tests/e2e/safeArea.spec.ts`, and it is
- * red without the declarations below.
- *
- * The `0px` fallbacks change nothing today and are kept for the edit that
- * would need them. Measured in Chromium against a deliberately unknown keyword:
- * with the inset alone on its own property, `margin-bottom: var(--safe-bottom)`
- * computes to `0px` with the fallback and `0px` without it — an `env()` the
- * browser cannot resolve is invalid at computed-value time, and the property
- * falls back to its initial value, which is the same zero. Combined with a
- * design offset it is not the same: `calc(20px + var(--safe-bottom))` computes
- * to `20px` with the fallback and `0px` without, losing the offset as well as
- * the inset. This stylesheet never combines them — `bottom-5` and `mb-safe` are
- * separate properties for exactly that reason — so the fallbacks are insurance
- * against the first person who writes the combined form, not something holding
- * the current layout up.
- */
-:root {
-  --safe-top: env(safe-area-inset-top, 0px);
-  --safe-right: env(safe-area-inset-right, 0px);
-  --safe-bottom: env(safe-area-inset-bottom, 0px);
-  --safe-left: env(safe-area-inset-left, 0px);
-}
-
-/*
  * Padding for the elements whose background has to keep reaching the screen
  * edge — a header inset by its own margin leaves a strip of page showing above
  * it, which is the notch drawn in the wrong colour rather than a layout that
@@ -154,36 +124,48 @@
  * (CSS 2.1 10.6.4 solves for `top`), so `bottom-5 mb-safe` reads as "five
  * spacing units above whatever the device takes", which is the intent exactly.
  *
- * Two screens deliberately take nothing: the login card and the error screen
- * are single boxes centred in both axes and narrower than any notched viewport
- * — 360px and 448px against 844px in landscape — so no strip can reach them.
- * They carry the top inset only, for the case where their content grows tall
- * enough to run to the edges.
+ * Two screens deliberately take nothing horizontal: the login card and the
+ * error screen are single boxes centred in both axes and narrower than any
+ * notched viewport — 360px and 448px against 844px in landscape — so no strip
+ * can reach them. They carry the top inset only, for the case where their
+ * content grows tall enough to run to the edges.
+ *
+ * The `0px` fallbacks change nothing today and are kept for the edit that
+ * would need them. Measured in Chromium against a deliberately unknown
+ * keyword: `padding-top: env(unknown, 0px)` and `padding-top: env(unknown)`
+ * both compute to `0px`, because an `env()` the browser cannot resolve is
+ * invalid at computed-value time and the property falls back to its initial
+ * value, which is the same zero. Combined with a design offset it differs —
+ * `calc(20px + env(unknown, 0px))` computes to `20px` and the same without a
+ * fallback to `0px`, losing the offset as well as the inset. Nothing here
+ * combines them, because `bottom-5` and `mb-safe` are separate properties for
+ * exactly that reason, so the fallbacks are insurance against the first person
+ * to write the combined form rather than something holding this layout up.
  */
 @utility pt-safe {
-  padding-top: var(--safe-top);
+  padding-top: env(safe-area-inset-top, 0px);
 }
 
 @utility pb-safe {
-  padding-bottom: var(--safe-bottom);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 @utility px-safe {
-  padding-left: var(--safe-left);
-  padding-right: var(--safe-right);
+  padding-left: env(safe-area-inset-left, 0px);
+  padding-right: env(safe-area-inset-right, 0px);
 }
 
 @utility mb-safe {
-  margin-bottom: var(--safe-bottom);
+  margin-bottom: env(safe-area-inset-bottom, 0px);
 }
 
 @utility mx-safe {
-  margin-left: var(--safe-left);
-  margin-right: var(--safe-right);
+  margin-left: env(safe-area-inset-left, 0px);
+  margin-right: env(safe-area-inset-right, 0px);
 }
 
 @utility mr-safe {
-  margin-right: var(--safe-right);
+  margin-right: env(safe-area-inset-right, 0px);
 }
 
 html {

--- a/src/index.css
+++ b/src/index.css
@@ -120,9 +120,18 @@
  * asserts the layout moved. That is `tests/e2e/safeArea.spec.ts`, and it is
  * red without the declarations below.
  *
- * The `0px` fallbacks are load-bearing rather than tidy: `env()` naming a
- * keyword the browser does not know makes the whole declaration invalid, which
- * for `bottom` or `padding` means losing the offset as well as the inset.
+ * The `0px` fallbacks change nothing today and are kept for the edit that
+ * would need them. Measured in Chromium against a deliberately unknown keyword:
+ * with the inset alone on its own property, `margin-bottom: var(--safe-bottom)`
+ * computes to `0px` with the fallback and `0px` without it — an `env()` the
+ * browser cannot resolve is invalid at computed-value time, and the property
+ * falls back to its initial value, which is the same zero. Combined with a
+ * design offset it is not the same: `calc(20px + var(--safe-bottom))` computes
+ * to `20px` with the fallback and `0px` without, losing the offset as well as
+ * the inset. This stylesheet never combines them — `bottom-5` and `mb-safe` are
+ * separate properties for exactly that reason — so the fallbacks are insurance
+ * against the first person who writes the combined form, not something holding
+ * the current layout up.
  */
 :root {
   --safe-top: env(safe-area-inset-top, 0px);

--- a/src/index.css
+++ b/src/index.css
@@ -99,6 +99,84 @@
   --shadow-panel: var(--shadow-card);
 }
 
+/*
+ * The four strips of the screen a phone does not actually give the page.
+ *
+ * `index.html` has asked for `viewport-fit=cover` since before the manifest,
+ * which lays the document out edge to edge — under the notch, under the status
+ * bar, under the home indicator — instead of inside the safe rectangle. In a
+ * browser tab that is nearly invisible, because Safari's own chrome already
+ * occupies those strips. Installed, with `display: standalone`, there is no
+ * chrome and the app owns the whole screen; nothing here read the insets, so
+ * the header ran under the status bar and the add button sat under the home
+ * indicator, where the swipe that leaves the app starts.
+ *
+ * **Named properties rather than `env()` at each use site, and the indirection
+ * is what makes the layout testable.** `env(safe-area-inset-*)` resolves to
+ * zero in every browser Playwright can drive, and there is no protocol for
+ * setting it, so geometry measured against `env()` directly measures nothing —
+ * a layout that ignores the insets entirely passes identically. Against a
+ * variable, a test overrides `:root` with a real device's 34px and 47px and
+ * asserts the layout moved. That is `tests/e2e/safeArea.spec.ts`, and it is
+ * red without the declarations below.
+ *
+ * The `0px` fallbacks are load-bearing rather than tidy: `env()` naming a
+ * keyword the browser does not know makes the whole declaration invalid, which
+ * for `bottom` or `padding` means losing the offset as well as the inset.
+ */
+:root {
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+}
+
+/*
+ * Padding for the elements whose background has to keep reaching the screen
+ * edge — a header inset by its own margin leaves a strip of page showing above
+ * it, which is the notch drawn in the wrong colour rather than a layout that
+ * respects it. So the box stays full bleed and only its contents move in,
+ * which means the inset belongs on an ancestor that carries no padding of its
+ * own: `px-safe` on `<header>`, `px-4` on the row inside it.
+ *
+ * Margin for the fixed elements, which cannot use padding without changing
+ * their own shape — the add button is a 56px circle and padding would make it
+ * an oval. A fixed box with `bottom` set is displaced by its bottom margin
+ * (CSS 2.1 10.6.4 solves for `top`), so `bottom-5 mb-safe` reads as "five
+ * spacing units above whatever the device takes", which is the intent exactly.
+ *
+ * Two screens deliberately take nothing: the login card and the error screen
+ * are single boxes centred in both axes and narrower than any notched viewport
+ * — 360px and 448px against 844px in landscape — so no strip can reach them.
+ * They carry the top inset only, for the case where their content grows tall
+ * enough to run to the edges.
+ */
+@utility pt-safe {
+  padding-top: var(--safe-top);
+}
+
+@utility pb-safe {
+  padding-bottom: var(--safe-bottom);
+}
+
+@utility px-safe {
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
+}
+
+@utility mb-safe {
+  margin-bottom: var(--safe-bottom);
+}
+
+@utility mx-safe {
+  margin-left: var(--safe-left);
+  margin-right: var(--safe-right);
+}
+
+@utility mr-safe {
+  margin-right: var(--safe-right);
+}
+
 html {
   color-scheme: light dark;
 }

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -45,9 +45,23 @@ export function Component() {
     <div className="flex min-h-dvh flex-col bg-bg pt-safe">
       <main className="grid flex-1 place-items-center px-4 py-8">
         <div className="w-full max-w-[360px] rounded-card bg-card p-8 shadow-panel">
-          <h1 className="flex flex-col items-center gap-3">
-            <LogoMark className="h-16 w-16" />
-            <span className="font-display text-3xl font-bold text-accent">{t('brand.name')}</span>
+          {/*
+            A link, and the only way off this screen that does not require a
+            Google account.
+
+            The manifest asks for `display: standalone`, so an installed app has
+            no browser chrome and no back button. A visitor who opened `/`,
+            read the landing page and tapped through to here had nothing to
+            press: the card offered sign-in, the policies, and nothing else, and
+            the four footer links all lead further away rather than back. The
+            same brand mark is the way home from every other public shell, so
+            it is the one here too.
+          */}
+          <h1>
+            <Link to="/" className="flex flex-col items-center gap-3">
+              <LogoMark className="h-16 w-16" />
+              <span className="font-display text-3xl font-bold text-accent">{t('brand.name')}</span>
+            </Link>
           </h1>
           <p className="mt-2 text-center text-sm text-muted">{t('auth.continue')}</p>
 

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -42,7 +42,7 @@ export function Component() {
   return (
     /* A column with the card centred in the growing part, so the footer sits on
        the bottom edge instead of wherever the card happens to end. */
-    <div className="flex min-h-dvh flex-col bg-bg">
+    <div className="flex min-h-dvh flex-col bg-bg pt-safe">
       <main className="grid flex-1 place-items-center px-4 py-8">
         <div className="w-full max-w-[360px] rounded-card bg-card p-8 shadow-panel">
           <h1 className="flex flex-col items-center gap-3">

--- a/tests/e2e/safeArea.spec.ts
+++ b/tests/e2e/safeArea.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { seed } from './fixtures';
 
 /**
@@ -12,17 +12,15 @@ import { seed } from './fixtures';
  * button sat under the home indicator — on top of the swipe that leaves the
  * app, so the control the reader reaches for most was the one hardest to hit.
  *
- * **The insets are injected, and that is the only way this claim can be
- * measured.** `env(safe-area-inset-*)` resolves to zero in every browser
- * Playwright can drive and no protocol sets it, so a spec written against
- * `env()` directly passes just as well on a layout that ignores it entirely.
- * `src/index.css` therefore reads the four values into `--safe-*` once, and
- * this overrides those on `:root` with numbers taken off real hardware. What
- * stays untested by geometry is the one line joining the two, so the first test
- * below asserts that join directly.
+ * The insets are set through the DevTools protocol, so what these tests measure
+ * is the real thing: `Emulation.setSafeAreaInsetsOverride` makes
+ * `env(safe-area-inset-*)` resolve to the given values, and the layout is then
+ * observed the way any other layout is. Nothing here knows how the stylesheet
+ * is written.
  *
- * Chromium only. Every claim here is box arithmetic, which both engines agree
- * on; WebKit is reserved for how something is painted.
+ * Chromium only. Every claim is box arithmetic, which both engines agree on;
+ * WebKit is reserved for how something is painted. The override is a Chromium
+ * protocol method, which is the second reason.
  */
 
 /** iPhone 14 Pro, held upright: the status bar above, the home indicator below. */
@@ -45,15 +43,9 @@ type Insets = typeof PORTRAIT;
 
 async function applyInsets(page: Page, insets: Insets) {
   await page.setViewportSize(insets.viewport);
-  // Appended to <head> after the bundle's own stylesheet, so it wins on order
-  // at equal specificity.
-  await page.addStyleTag({
-    content: `:root {
-      --safe-top: ${insets.top}px;
-      --safe-right: ${insets.right}px;
-      --safe-bottom: ${insets.bottom}px;
-      --safe-left: ${insets.left}px;
-    }`,
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Emulation.setSafeAreaInsetsOverride', {
+    insets: { top: insets.top, left: insets.left, bottom: insets.bottom, right: insets.right },
   });
 }
 
@@ -75,7 +67,7 @@ function elements(page: Page) {
   };
 }
 
-async function openSignedInApp(page: Page, context: { setOffline: (v: boolean) => Promise<void> }) {
+async function openSignedInApp(page: Page, context: BrowserContext) {
   await seed(page, { signedIn: true });
   await page.goto('/');
   // The offline pill is one of the two panels in the bottom stack, and the
@@ -85,64 +77,33 @@ async function openSignedInApp(page: Page, context: { setOffline: (v: boolean) =
 }
 
 /**
- * The join the geometry cannot see.
+ * Guards every measurement below.
  *
- * Every other test here proves the layout responds to `--safe-bottom`. None of
- * them can prove `--safe-bottom` is fed by the device, because the value it is
- * fed is zero on every machine this runs on — so a stylesheet declaring
- * `--safe-bottom: 0px` and nothing else would pass every one of them.
- *
- * **The stylesheet, not the computed style, and the difference is why this
- * test exists in the shape it does.** Reading `--safe-bottom` off
- * `getComputedStyle(document.documentElement)` was the obvious way to do it and
- * returns `0px`: `env()` is substituted when the custom property is computed,
- * not deferred to its use sites the way `var()` is, so the computed value of a
- * correctly wired variable is byte for byte the computed value of the constant
- * this is meant to catch. The specified value on the rule keeps the token.
+ * If the override ever stops taking effect — a protocol method renamed, a
+ * browser build without it — `env()` quietly returns to zero and every
+ * assertion here passes against a layout that ignores the insets entirely,
+ * which is the exact defect this file exists for. So one test reads the value
+ * back out of a real declaration first.
  */
-test('reads the device insets rather than a constant the tests can satisfy', async ({ page }) => {
-  await seed(page, { signedIn: true });
-  await page.goto('/');
+test('sets insets the page can actually see, so the rest is not measuring zero', async ({
+  page,
+  context,
+}) => {
+  await openSignedInApp(page, context);
+  await applyInsets(page, PORTRAIT);
 
-  const declared = await page.evaluate(() => {
-    const sides = ['top', 'right', 'bottom', 'left'] as const;
-    for (const sheet of Array.from(document.styleSheets)) {
-      let rules: CSSRule[];
-      // Cross-origin sheets throw rather than return nothing. There are none in
-      // this build, but a font or an extension would make this the difference
-      // between skipping a sheet and failing the test for the wrong reason.
-      try {
-        rules = Array.from(sheet.cssRules);
-      } catch {
-        continue;
-      }
-      for (const rule of rules) {
-        if (!(rule instanceof CSSStyleRule) || rule.selectorText !== ':root') continue;
-        // Whitespace stripped rather than trimmed: the production build
-        // minifies the declaration to `env(safe-area-inset-top,0px)`, and the
-        // dev server does not, so comparing the raw text passes in one and
-        // fails in the other.
-        const values = sides.map((side) =>
-          rule.style.getPropertyValue(`--safe-${side}`).replace(/\s+/g, ''),
-        );
-        if (values.every(Boolean)) return values;
-      }
-    }
-    return null;
+  const seen = await page.evaluate(() => {
+    const probe = document.createElement('div');
+    probe.style.paddingTop = 'env(safe-area-inset-top, 0px)';
+    probe.style.paddingBottom = 'env(safe-area-inset-bottom, 0px)';
+    document.body.append(probe);
+    const style = getComputedStyle(probe);
+    const result = { top: style.paddingTop, bottom: style.paddingBottom };
+    probe.remove();
+    return result;
   });
 
-  // What breaks when this goes red: the app renders under the notch and the
-  // home indicator on a real installed device, while every other test in this
-  // file — and the whole suite — stays green. That is the failure this exists
-  // to catch, because the four tests below can only prove the layout follows
-  // `--safe-*`; nothing they can measure distinguishes a variable fed by the
-  // device from one hardcoded to `0px`.
-  expect(declared).toEqual([
-    'env(safe-area-inset-top,0px)',
-    'env(safe-area-inset-right,0px)',
-    'env(safe-area-inset-bottom,0px)',
-    'env(safe-area-inset-left,0px)',
-  ]);
+  expect(seen).toEqual({ top: `${PORTRAIT.top}px`, bottom: `${PORTRAIT.bottom}px` });
 });
 
 test('keeps the add button and the notices above the home indicator', async ({ page, context }) => {
@@ -200,11 +161,11 @@ test('clears the notch and the rounded corners when the phone is turned sideways
 /**
  * The other half of the change, and the one a browser tab actually sees.
  *
- * `env()` falls back to `0px` everywhere except an installed app on a notched
- * device, so these declarations are inert for almost every reader — and inert
- * has to mean *unchanged*, not "shifted by a few pixels nobody measured". A
- * `bottom` that had been rewritten as an inset rather than added to one would
- * put the add button flat against the edge here.
+ * `env()` is zero everywhere except an installed app on a notched device, so
+ * these declarations are inert for almost every reader — and inert has to mean
+ * *unchanged*, not "shifted by a few pixels nobody measured". A `bottom` that
+ * had been rewritten as an inset rather than added to one would put the add
+ * button flat against the edge here.
  */
 test('leaves the layout exactly where it was when the device asks for nothing', async ({
   page,

--- a/tests/e2e/safeArea.spec.ts
+++ b/tests/e2e/safeArea.spec.ts
@@ -131,6 +131,12 @@ test('reads the device insets rather than a constant the tests can satisfy', asy
     return null;
   });
 
+  // What breaks when this goes red: the app renders under the notch and the
+  // home indicator on a real installed device, while every other test in this
+  // file — and the whole suite — stays green. That is the failure this exists
+  // to catch, because the four tests below can only prove the layout follows
+  // `--safe-*`; nothing they can measure distinguishes a variable fed by the
+  // device from one hardcoded to `0px`.
   expect(declared).toEqual([
     'env(safe-area-inset-top,0px)',
     'env(safe-area-inset-right,0px)',

--- a/tests/e2e/safeArea.spec.ts
+++ b/tests/e2e/safeArea.spec.ts
@@ -1,0 +1,217 @@
+import { expect, test, type Page } from '@playwright/test';
+import { seed } from './fixtures';
+
+/**
+ * The strips of the screen an installed app is given but does not own.
+ *
+ * `index.html` asks for `viewport-fit=cover`, so the document is laid out edge
+ * to edge. In a browser tab Safari's own chrome covers the notch and the home
+ * indicator and nothing shows; installed, with `display: standalone` in the
+ * manifest, there is no chrome, and until this change no rule anywhere read
+ * `env(safe-area-inset-*)`. The header ran under the status bar and the add
+ * button sat under the home indicator — on top of the swipe that leaves the
+ * app, so the control the reader reaches for most was the one hardest to hit.
+ *
+ * **The insets are injected, and that is the only way this claim can be
+ * measured.** `env(safe-area-inset-*)` resolves to zero in every browser
+ * Playwright can drive and no protocol sets it, so a spec written against
+ * `env()` directly passes just as well on a layout that ignores it entirely.
+ * `src/index.css` therefore reads the four values into `--safe-*` once, and
+ * this overrides those on `:root` with numbers taken off real hardware. What
+ * stays untested by geometry is the one line joining the two, so the first test
+ * below asserts that join directly.
+ *
+ * Chromium only. Every claim here is box arithmetic, which both engines agree
+ * on; WebKit is reserved for how something is painted.
+ */
+
+/** iPhone 14 Pro, held upright: the status bar above, the home indicator below. */
+const PORTRAIT = { viewport: { width: 390, height: 844 }, top: 59, right: 0, bottom: 34, left: 0 };
+
+/**
+ * The same phone turned sideways. The notch moves into one edge and the
+ * rounded corners take the other, so iOS reports both — which is why the layout
+ * reads left and right separately instead of one horizontal inset.
+ */
+const LANDSCAPE = {
+  viewport: { width: 844, height: 390 },
+  top: 0,
+  right: 47,
+  bottom: 21,
+  left: 47,
+};
+
+type Insets = typeof PORTRAIT;
+
+async function applyInsets(page: Page, insets: Insets) {
+  await page.setViewportSize(insets.viewport);
+  // Appended to <head> after the bundle's own stylesheet, so it wins on order
+  // at equal specificity.
+  await page.addStyleTag({
+    content: `:root {
+      --safe-top: ${insets.top}px;
+      --safe-right: ${insets.right}px;
+      --safe-bottom: ${insets.bottom}px;
+      --safe-left: ${insets.left}px;
+    }`,
+  });
+}
+
+function elements(page: Page) {
+  return {
+    /** The one control pinned to the corner the home indicator occupies. */
+    add: page.getByRole('button', { name: '単語を追加' }),
+    /** The bottom stack, which places itself with `inset-x-4 bottom-24 mx-safe mb-safe`. */
+    notice: page.getByRole('status').filter({ hasText: 'オフライン' }),
+    /** Header contents. The bar itself stays full bleed; only what is in it moves. */
+    brand: page.getByRole('banner').getByRole('link', { name: '語彙庭' }),
+    /**
+     * The box inside `<main>` that carries the page gutter and the measure. The
+     * inset lives on `<main>` itself, so this is the element that has to have
+     * moved — asserting on `<main>` would measure a box that spans the viewport
+     * by design and never moves at all.
+     */
+    content: page.getByRole('main').locator('> div'),
+  };
+}
+
+async function openSignedInApp(page: Page, context: { setOffline: (v: boolean) => Promise<void> }) {
+  await seed(page, { signedIn: true });
+  await page.goto('/');
+  // The offline pill is one of the two panels in the bottom stack, and the
+  // cheapest way to put a panel there.
+  await context.setOffline(true);
+  await expect(page.getByRole('status').filter({ hasText: 'オフライン' })).toBeVisible();
+}
+
+/**
+ * The join the geometry cannot see.
+ *
+ * Every other test here proves the layout responds to `--safe-bottom`. None of
+ * them can prove `--safe-bottom` is fed by the device, because the value it is
+ * fed is zero on every machine this runs on — so a stylesheet declaring
+ * `--safe-bottom: 0px` and nothing else would pass every one of them.
+ *
+ * **The stylesheet, not the computed style, and the difference is why this
+ * test exists in the shape it does.** Reading `--safe-bottom` off
+ * `getComputedStyle(document.documentElement)` was the obvious way to do it and
+ * returns `0px`: `env()` is substituted when the custom property is computed,
+ * not deferred to its use sites the way `var()` is, so the computed value of a
+ * correctly wired variable is byte for byte the computed value of the constant
+ * this is meant to catch. The specified value on the rule keeps the token.
+ */
+test('reads the device insets rather than a constant the tests can satisfy', async ({ page }) => {
+  await seed(page, { signedIn: true });
+  await page.goto('/');
+
+  const declared = await page.evaluate(() => {
+    const sides = ['top', 'right', 'bottom', 'left'] as const;
+    for (const sheet of Array.from(document.styleSheets)) {
+      let rules: CSSRule[];
+      // Cross-origin sheets throw rather than return nothing. There are none in
+      // this build, but a font or an extension would make this the difference
+      // between skipping a sheet and failing the test for the wrong reason.
+      try {
+        rules = Array.from(sheet.cssRules);
+      } catch {
+        continue;
+      }
+      for (const rule of rules) {
+        if (!(rule instanceof CSSStyleRule) || rule.selectorText !== ':root') continue;
+        // Whitespace stripped rather than trimmed: the production build
+        // minifies the declaration to `env(safe-area-inset-top,0px)`, and the
+        // dev server does not, so comparing the raw text passes in one and
+        // fails in the other.
+        const values = sides.map((side) =>
+          rule.style.getPropertyValue(`--safe-${side}`).replace(/\s+/g, ''),
+        );
+        if (values.every(Boolean)) return values;
+      }
+    }
+    return null;
+  });
+
+  expect(declared).toEqual([
+    'env(safe-area-inset-top,0px)',
+    'env(safe-area-inset-right,0px)',
+    'env(safe-area-inset-bottom,0px)',
+    'env(safe-area-inset-left,0px)',
+  ]);
+});
+
+test('keeps the add button and the notices above the home indicator', async ({ page, context }) => {
+  await openSignedInApp(page, context);
+  await applyInsets(page, PORTRAIT);
+
+  const { add, notice } = elements(page);
+  const floor = PORTRAIT.viewport.height - PORTRAIT.bottom;
+
+  const addBox = (await add.boundingBox())!;
+  expect(addBox, 'the add button is `nav:hidden`, so a phone width must find it').not.toBeNull();
+  // Its own 20px offset is still there on top of the inset — the inset is added
+  // to the design's spacing, not substituted for it.
+  expect(addBox.y + addBox.height).toBeLessThanOrEqual(floor - 20);
+
+  const noticeBox = (await notice.boundingBox())!;
+  expect(noticeBox.y + noticeBox.height).toBeLessThanOrEqual(floor);
+});
+
+test('starts the header below the status bar instead of under it', async ({ page, context }) => {
+  await openSignedInApp(page, context);
+  await applyInsets(page, PORTRAIT);
+
+  const { brand } = elements(page);
+  const box = (await brand.boundingBox())!;
+  expect(box.y).toBeGreaterThanOrEqual(PORTRAIT.top);
+});
+
+test('clears the notch and the rounded corners when the phone is turned sideways', async ({
+  page,
+  context,
+}) => {
+  await openSignedInApp(page, context);
+  await applyInsets(page, LANDSCAPE);
+
+  const { add, brand, content, notice } = elements(page);
+  const rightEdge = LANDSCAPE.viewport.width - LANDSCAPE.right;
+
+  for (const [name, locator] of [
+    ['the header brand', brand],
+    ['the page content', content],
+    ['the offline notice', notice],
+  ] as const) {
+    const box = (await locator.boundingBox())!;
+    expect(box, `${name} was not on screen to measure`).not.toBeNull();
+    expect(box.x, `${name} starts inside the left inset`).toBeGreaterThanOrEqual(LANDSCAPE.left);
+    expect(box.x + box.width, `${name} runs past the right inset`).toBeLessThanOrEqual(rightEdge);
+  }
+
+  // 844px is above the `nav` breakpoint, where the add button is hidden and the
+  // header's own 単語を追加 takes over — so the corner it defended is empty.
+  expect(await add.count()).toBe(0);
+});
+
+/**
+ * The other half of the change, and the one a browser tab actually sees.
+ *
+ * `env()` falls back to `0px` everywhere except an installed app on a notched
+ * device, so these declarations are inert for almost every reader — and inert
+ * has to mean *unchanged*, not "shifted by a few pixels nobody measured". A
+ * `bottom` that had been rewritten as an inset rather than added to one would
+ * put the add button flat against the edge here.
+ */
+test('leaves the layout exactly where it was when the device asks for nothing', async ({
+  page,
+  context,
+}) => {
+  await openSignedInApp(page, context);
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  const { add, notice } = elements(page);
+  const addBox = (await add.boundingBox())!;
+  expect(addBox.x + addBox.width).toBe(390 - 20);
+  expect(addBox.y + addBox.height).toBe(844 - 20);
+
+  const noticeBox = (await notice.boundingBox())!;
+  expect(noticeBox.x).toBe(16);
+});

--- a/tests/e2e/standaloneNavigation.spec.ts
+++ b/tests/e2e/standaloneNavigation.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from '@playwright/test';
+import { seed } from './fixtures';
+
+/**
+ * Every route has to be leavable without a browser back button.
+ *
+ * `public/manifest.webmanifest` asks for `display: standalone`, so an installed
+ * app is a window with no chrome: no address bar, no back button, and on iOS no
+ * gesture that substitutes for one. Whatever the page itself offers is the
+ * entire set of exits, and a route that offers none is a window the reader has
+ * to close and reopen.
+ *
+ * `/login` was one. The card had sign-in, the terms and the privacy policy, and
+ * the footer's four links all lead further out rather than back — so a visitor
+ * who read the landing page and tapped through to sign in, then thought better
+ * of it, had nowhere to press. The brand mark is the way home from every other
+ * public shell, so it is a link here too.
+ *
+ * End-to-end because the claim is about routing: what is asserted is that the
+ * URL actually changed, not that something that looks like a link is on screen.
+ * Chromium only — nothing here is about how a page is painted.
+ */
+
+/**
+ * The brand mark, which is the exit every shell already had — the header of
+ * `PublicLayout`, the header of the signed-in layout, and now the login card.
+ * One locator across all of them on purpose: an exit that is somewhere
+ * different on every screen is one a reader has to find each time.
+ */
+const HOME = { name: '語彙庭', exact: true } as const;
+
+/**
+ * Asserted visible before it is clicked, and the extra line is the point.
+ *
+ * Clicking a locator that does not exist waits out the whole test timeout and
+ * reports thirty seconds of nothing, which reads as an infrastructure problem
+ * rather than as the missing exit it is. Measured against the shipped login
+ * screen, that is exactly what happened. The assertion fails in five with the
+ * route in the message.
+ */
+async function expectHome(page: Page, from: string) {
+  const home = page.getByRole('link', HOME).first();
+  await expect(home, `${from} offers no way back to the landing page`).toBeVisible();
+  await home.click();
+  await expect(page).toHaveURL('/');
+}
+
+/** Signed out, where `/` is the landing page rather than a redirect. */
+const PUBLIC_ROUTES = ['/login', '/about', '/privacy', '/terms', '/support'];
+
+for (const path of PUBLIC_ROUTES) {
+  test(`leaves ${path} without a back button`, async ({ page }) => {
+    await seed(page, {});
+    await page.goto(path);
+
+    await expectHome(page, path);
+  });
+}
+
+/**
+ * A mistyped address reaches `NotFound` through the router's error boundary
+ * rather than a catch-all route, which makes it the one screen here that is
+ * arrived at by accident — and the one where being stuck is most likely.
+ */
+test('leaves a mistyped address without a back button', async ({ page }) => {
+  await seed(page, {});
+  await page.goto('/no-such-page');
+
+  await expectHome(page, '/no-such-page');
+});
+
+/**
+ * The signed-in half. Its exit is the same mark in the sticky header, and it is
+ * reachable at a phone width too — where the navigation collapses into a
+ * hamburger and the brand is the only thing left in the bar.
+ */
+test('leaves a signed-in route at a phone width, where the nav is behind a menu', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await seed(page, { signedIn: true });
+  await page.goto('/history');
+
+  await expectHome(page, '/history');
+});

--- a/tests/e2e/visual.spec.ts
+++ b/tests/e2e/visual.spec.ts
@@ -228,7 +228,13 @@ test.describe('visual', () => {
 
     const cards = page.locator('a[href^="/vocabulary/"]');
     await expect(cards.first()).toBeVisible();
-    await expect(page.locator('main')).toHaveScreenshot('long-entry-cards.png');
+    // `main > div`, not `main`. `<main>` is now the full-bleed box that carries
+    // the device's side insets so its background still reaches the screen edge,
+    // and the column with the gutter and the `max-w-5xl` measure is its child.
+    // Shooting `<main>` captures the viewport's full 1280px and 256px of page
+    // background either side of the grid — which is not what this baseline is
+    // of, and would have quietly widened every future comparison.
+    await expect(page.locator('main > div')).toHaveScreenshot('long-entry-cards.png');
   });
 
   /**

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -376,12 +376,21 @@ test.describe('the footer', () => {
       const footer = document.querySelector('footer');
       const main = document.querySelector('main');
       if (!footer || !main) return null;
-      const inner = footer.firstElementChild;
-      if (!inner) return null;
+      // Both measured one level in, because both outer boxes are now full
+      // bleed: they carry the device's safe-area insets so their backgrounds
+      // still reach the screen edge, and the box that carries the gutter and
+      // the measure is the child. Comparing `<main>` itself, which is what this
+      // did while it *was* that box, now compares the viewport to a centred
+      // 1024px column and reports a 128px misalignment that is not there.
+      const innerFooter = footer.firstElementChild;
+      const innerMain = main.firstElementChild;
+      if (!innerFooter || !innerMain) return null;
+      const f = innerFooter.getBoundingClientRect();
+      const m = innerMain.getBoundingClientRect();
       return {
         gapBelow: Math.round(window.innerHeight - footer.getBoundingClientRect().bottom),
-        left: Math.round(inner.getBoundingClientRect().left - main.getBoundingClientRect().left),
-        width: Math.round(inner.getBoundingClientRect().width - main.getBoundingClientRect().width),
+        left: Math.round(f.left - m.left),
+        width: Math.round(f.width - m.width),
       };
     });
 


### PR DESCRIPTION
`viewport-fit=cover` has been in `index.html` since before the manifest, and
nothing ever read the insets it opts into. Both halves of #64: the layout now
takes the strips the device keeps, and `/login` is no longer a room with no
door.

## The insets

Installed, with `display: standalone`, there is no browser chrome to hide the
problem — the app owns the whole screen. The header ran under the status bar,
and the add button sat on top of the swipe that leaves the app, which is the
control a reader reaches for most.

`src/index.css` defines six utilities that read `env(safe-area-inset-*)`
directly:

- **Padding** for boxes whose background has to keep reaching the screen edge.
  A header inset by its own margin leaves a strip of page showing above it,
  which is the notch drawn in the wrong colour rather than a layout that
  respects it. So the box stays full bleed and only its contents move in —
  which means the inset belongs on an ancestor carrying no padding of its own:
  `px-safe` on `<header>`, `px-4` on the row inside it.
- **Margin** for the fixed elements, which cannot take padding without changing
  shape — the add button is a 56px circle and padding would make it an oval. A
  fixed box with `bottom` set is displaced by its bottom margin, so
  `bottom-5 mb-safe` reads as "five spacing units above whatever the device
  takes".

`<main>` gains an outer box in both shells, because `px-4` and the side inset
both want `padding-inline` and one element cannot hold two values. The outer
box takes the device's strips, the inner one the gutter and the measure — so
the page centres inside the space the screen actually gives, not inside the
notch.

Two screens deliberately take nothing horizontal: the login card and the error
screen are single boxes centred in both axes and narrower than any notched
viewport (360px and 448px against 844px in landscape), so no strip can reach
them. Both carry the top inset only.

`BottomNotices` needed one line rather than three, which is the dividend from
the stack introduced in #82 — with the panels still placing themselves, the
same inset would have had to be written twice and kept in agreement with the
add button's.

## How the insets are tested

Chromium's `Emulation.setSafeAreaInsetsOverride` makes `env(safe-area-inset-*)`
resolve to given values, so the spec sets a real iPhone 14 Pro's insets in both
orientations and then observes the layout the way any other layout is observed.
It knows nothing about how the stylesheet is written.

One test guards the rest: it reads a real `env()` back off a probe element
before the geometry runs. Without it, a renamed protocol method would quietly
return every measurement to zero and the whole file would pass against a layout
that ignores the insets entirely.

**This is the second design.** The first read the four values into `--safe-*`
custom properties and had the spec override those on `:root`, on the stated
grounds that `env()` could not be set from a test. That was wrong — see the
thread on `tests/e2e/safeArea.spec.ts`, where qodo pushed back on the CSSOM
assertion it forced and turned out to be right. With the insets reachable
directly, the assertion is gone, the indirection is gone with it, and the
utilities read `env()` themselves.

## The way out of `/login`

Whatever a route offers is the entire set of exits when there is no back
button. `/login` offered none: sign-in, the terms, the privacy policy, and four
footer links that all lead further out. A visitor who read the landing page,
tapped through to sign in and then thought better of it had nothing to press.

The brand mark is already the way home from `PublicLayout` and from the
signed-in header, so it is a link here too — one exit in the same place on
every screen rather than a different one to find each time.

The other routes were audited and were already fine: the public shells and the
404 have the header mark, the signed-in routes have it plus the nav, and the
error screen reaches `/support`, which has it. `tests/e2e/standaloneNavigation.spec.ts`
now holds that audit, asserting the URL changed rather than that something
link-shaped is on screen.

## Test layers

| Layer | Why |
| --- | --- |
| `tests/e2e/safeArea.spec.ts` | Geometry across two orientations, from four files sharing one viewport. jsdom has no layout to be wrong about, and `env()` needs a real engine. Chromium only — box arithmetic, which both engines agree on. |
| `tests/e2e/standaloneNavigation.spec.ts` | The claim is about routing: what is asserted is that the URL changed. |

## Proved red

**`safeArea.spec.ts`** — with `src/` reverted to `1faacc0`, three of five fail,
each for its own reason:

| | |
| --- | --- |
| add button's bottom edge | `824` on an 844px screen — flat on the home indicator |
| header brand | `y=20`, under the status bar |
| header brand, landscape | `x=16`, under the notch |

The remaining two are green there and are meant to be: one asserts the layout is
unchanged when the device asks for nothing, and the other is a claim about the
protocol rather than the app. That is the point of it: `env()` falls back to `0px`
for almost every reader, and inert has to mean *unchanged*, not "shifted by a
few pixels nobody measured".

**`standaloneNavigation.spec.ts`** — reverting `Login.tsx` fails exactly one
test and names the route. The visibility assertion before the click is
deliberate: the first attempt clicked a locator that was not there, waited out
the full thirty-second timeout and reported nothing, which reads as
infrastructure rather than as the missing exit it is.

## One existing test changed, and it was not to make it pass

`tests/e2e/vocabulary.spec.ts` measured the footer's alignment against
`<main>`. `<main>` is now the full-bleed box that carries the inset, and its
child carries the gutter and the measure — so the old comparison put a 1280px
viewport next to a centred 1024px column and reported `left: 128, width: -256`,
a misalignment that is not there. Both sides are now measured one level in.
`gapBelow: 0` never moved: the footer sits flush on the bottom edge throughout.

## The #79 flake, measured

`wordsets.spec.ts:267` failed on the first two full runs of this branch, which
is well above the 1-in-6 recorded in #79. It is not the layout change, and it
is partly this branch:

| | full runs | `auto-scrolls` failures |
| --- | --- | --- |
| `develop` | 3 | 0 |
| this branch's `src/`, new specs removed | 3 | 1 |
| this branch as it stands | 2 | 2 |

Removing the new specs returns it to #79's own rate, so the layout is not
implicated. What this branch does is add twelve tests, which makes the machine
busier — and #79's diagnosis is that a busy machine is exactly the trigger, the
assertion firing on schedule whether or not the frame loop it measures has had
any frames. CI retries once, so a run is unlikely to go red on it — it did not
fire in either of the two CI runs on this branch — but this PR does raise the
rate.

## The screenshots, and the one that went red

`visual.spec.ts` cannot run on this machine — Docker Desktop is unresponsive and
the baselines are `-linux` — so it is skipped locally and CI was the first place
it could fail. It did, once, and the cause was mine rather than the baseline's:

```
long-entry-cards.png
Expected an image 1024px by 807px, received 1280px by 807px
```

`locator('main')` was shooting the box that is now full bleed, so the frame
gained the viewport's full width and 128px of page background either side of the
card grid. **The baseline was not regenerated.** It is still what the page looks
like; the locator had to name the box that carries the measure, which is now the
child. Measured on the branch: `main` is 1280x806.67 and `main > div` is
1024x806.67 — the same box the baseline was taken of, to the pixel, with the
height unmoved.

Same mistake as the footer test in `8ac192a`, in the one project that has no
local run. `92e89a0` fixes it and the job is green.

`login.png` passed unchanged, which settles the one thing this branch was
guessing at: wrapping the `<h1>`'s contents in a link renders identically,
because Tailwind's preflight resets `a` to `color: inherit` and
`text-decoration: inherit` and the heading keeps `margin: 0` and
`font-size: inherit`.

## Checks

`yarn typecheck` · `yarn test:unit` 745 · `yarn test:emulator` · `yarn lint`
(0 errors, 17 pre-existing warnings) · `prettier --check`

Closes #64
