### PR TITLE
fix(admin): report allow-user lookup failures accurately

### DIFF
--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -1,0 +1,37 @@
+type CredentialEnv = {
+  CLOUDSDK_CONFIG?: string;
+  GOOGLE_APPLICATION_CREDENTIALS?: string;
+};
+
+export function describeCredentialSource(env: CredentialEnv): string {
+  if (env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return `GOOGLE_APPLICATION_CREDENTIALS=${env.GOOGLE_APPLICATION_CREDENTIALS}`;
+  }
+  if (env.CLOUDSDK_CONFIG) {
+    return `applicationDefault() with CLOUDSDK_CONFIG=${env.CLOUDSDK_CONFIG}`;
+  }
+  return 'applicationDefault() with CLOUDSDK_CONFIG unset';
+}
+
+export function lookupErrorCode(cause: unknown): string | undefined {
+  if (!cause || typeof cause !== 'object') return undefined;
+  const { code } = cause as { code?: unknown };
+  return typeof code === 'string' ? code : undefined;
+}
+
+export function lookupFailureLines(
+  email: string,
+  projectId: string,
+  cause: unknown,
+  env: CredentialEnv,
+): string[] {
+  if (lookupErrorCode(cause) === 'auth/user-not-found') {
+    return [`${email} has never signed in to ${projectId}; ask them to try once first.`];
+  }
+
+  const code = lookupErrorCode(cause);
+  return [
+    `failed to look up ${email} in ${projectId}${code ? ` (${code})` : ''}.`,
+    `credential source: ${describeCredentialSource(env)}`,
+  ];
+}

--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -32,6 +32,6 @@ export function lookupFailureLines(
   const code = lookupErrorCode(cause);
   return [
     `failed to look up ${email} in ${projectId}${code ? ` (${code})` : ''}.`,
-    `credential source: ${describeCredentialSource(env)}`,
+    `credential configuration: ${describeCredentialSource(env)}`,
   ];
 }

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,5 +1,6 @@
 import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
+import { lookupErrorCode, lookupFailureLines } from './allow-user.shared';
 
 /**
  * Grant or revoke access, by custom claim.
@@ -54,11 +55,19 @@ if (getApps().length === 0) {
 
 const auth = getAuth();
 
-const user = await auth.getUserByEmail(email).catch(() => null);
-if (!user) {
+let user;
+
+try {
+  user = await auth.getUserByEmail(email);
+} catch (cause) {
   // Deliberately not created here: the uid has to be the one Google issued, so
   // the account must have signed in once before it can be allowed.
-  console.error(`${email} has never signed in to ${projectId}; ask them to try once first.`);
+  for (const line of lookupFailureLines(email, projectId, cause, process.env)) {
+    console.error(line);
+  }
+  if (lookupErrorCode(cause) !== 'auth/user-not-found') {
+    console.error(cause);
+  }
   process.exit(1);
 }
 

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,5 +1,5 @@
 import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
+import { getAuth, type UserRecord } from 'firebase-admin/auth';
 import { lookupErrorCode, lookupFailureLines } from './allow-user.shared';
 
 /**
@@ -55,7 +55,7 @@ if (getApps().length === 0) {
 
 const auth = getAuth();
 
-let user;
+let user: UserRecord;
 
 try {
   user = await auth.getUserByEmail(email);

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  describeCredentialSource,
+  lookupErrorCode,
+  lookupFailureLines,
+} from '../../admin/allow-user.shared';
+
+describe('allow-user lookup failures', () => {
+  it('describes GOOGLE_APPLICATION_CREDENTIALS when one is set', () => {
+    expect(
+      describeCredentialSource({
+        GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json',
+      }),
+    ).toBe('GOOGLE_APPLICATION_CREDENTIALS=/tmp/service-account.json');
+  });
+
+  it('describes CLOUDSDK_CONFIG for application default credentials', () => {
+    expect(describeCredentialSource({ CLOUDSDK_CONFIG: '.gcloud' })).toBe(
+      'applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
+    );
+  });
+
+  it('says when application default credentials use the default config location', () => {
+    expect(describeCredentialSource({})).toBe('applicationDefault() with CLOUDSDK_CONFIG unset');
+  });
+
+  it('keeps the signed-in-once wording only for auth/user-not-found', () => {
+    expect(
+      lookupFailureLines(
+        'reader@example.com',
+        'goitei',
+        { code: 'auth/user-not-found' },
+        { CLOUDSDK_CONFIG: '.gcloud' },
+      ),
+    ).toEqual(['reader@example.com has never signed in to goitei; ask them to try once first.']);
+  });
+
+  it('reports other lookup failures as themselves, with the credential source', () => {
+    expect(
+      lookupFailureLines(
+        'reader@example.com',
+        'goitei',
+        { code: 'app/invalid-credential' },
+        { CLOUDSDK_CONFIG: '.gcloud' },
+      ),
+    ).toEqual([
+      'failed to look up reader@example.com in goitei (app/invalid-credential).',
+      'credential source: applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
+    ]);
+  });
+
+  it('extracts string error codes only', () => {
+    expect(lookupErrorCode({ code: 'auth/user-not-found' })).toBe('auth/user-not-found');
+    expect(lookupErrorCode({ code: 404 })).toBeUndefined();
+    expect(lookupErrorCode(null)).toBeUndefined();
+  });
+});

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../admin/allow-user.shared';
 
 describe('allow-user lookup failures', () => {
-  it('describes GOOGLE_APPLICATION_CREDENTIALS when one is set', () => {
+  it('prevents diagnostics from hiding a configured GOOGLE_APPLICATION_CREDENTIALS file', () => {
     expect(
       describeCredentialSource({
         GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json',
@@ -14,17 +14,17 @@ describe('allow-user lookup failures', () => {
     ).toBe('GOOGLE_APPLICATION_CREDENTIALS=/tmp/service-account.json');
   });
 
-  it('describes CLOUDSDK_CONFIG for application default credentials', () => {
+  it('prevents diagnostics from hiding a configured CLOUDSDK_CONFIG directory', () => {
     expect(describeCredentialSource({ CLOUDSDK_CONFIG: '.gcloud' })).toBe(
       'applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
     );
   });
 
-  it('says when application default credentials use the default config location', () => {
+  it('prevents diagnostics from inventing a configured gcloud directory when none is set', () => {
     expect(describeCredentialSource({})).toBe('applicationDefault() with CLOUDSDK_CONFIG unset');
   });
 
-  it('keeps the signed-in-once wording only for auth/user-not-found', () => {
+  it('prevents non-user-not-found failures from being misreported as never-signed-in accounts', () => {
     expect(
       lookupFailureLines(
         'reader@example.com',
@@ -35,7 +35,7 @@ describe('allow-user lookup failures', () => {
     ).toEqual(['reader@example.com has never signed in to goitei; ask them to try once first.']);
   });
 
-  it('reports other lookup failures as themselves, with the credential source', () => {
+  it('prevents other lookup failures from hiding their credential configuration', () => {
     expect(
       lookupFailureLines(
         'reader@example.com',
@@ -45,11 +45,11 @@ describe('allow-user lookup failures', () => {
       ),
     ).toEqual([
       'failed to look up reader@example.com in goitei (app/invalid-credential).',
-      'credential source: applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
+      'credential configuration: applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
     ]);
   });
 
-  it('extracts string error codes only', () => {
+  it('prevents non-string thrown codes from being treated as valid Firebase error codes', () => {
     expect(lookupErrorCode({ code: 'auth/user-not-found' })).toBe('auth/user-not-found');
     expect(lookupErrorCode({ code: 404 })).toBeUndefined();
     expect(lookupErrorCode(null)).toBeUndefined();


### PR DESCRIPTION
### 概要

[#52]
Report the actual `allow-user` lookup failure instead of collapsing every `getUserByEmail` error into a false signed-in diagnosis.

### 変更内容

- branch `getUserByEmail` failures by the observed error code instead of `.catch(() => null)`
- keep the existing signed-in-once wording only for `auth/user-not-found`
- print the resolved credential source for other lookup failures and log the original error
- add unit coverage for credential-source formatting and lookup failure classification

### テスト方法

Run the focused checks below.

**Unit / integration tests:**

- `yarn vitest run tests/unit/allowUser.test.ts --project unit`
- `yarn tsc -p tsconfig.scripts.json --noEmit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user lookup error messages with clearer, contextual guidance.
  * Added a specific message when a user has never signed in.
  * Preserved existing command exit behavior while reporting unexpected lookup failures.

* **Tests**
  * Added coverage for credential configuration, lookup errors, and error-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->