### PR TITLE
docs(readme): correct rules rollout contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ signups are closed until an operator grants it. Nothing in front of the site can
 substitute for this: Hosting serves the config that reaches Firestore, so a
 password on the HTML protects the page, not the data.
 
-Rules deploy before anything that writes through them, so a schema addition is
-allowlisted before any client can send it. A client that ships a new field
+Rules deploy before anything that writes through them, so a new top-level field
+is allowlisted before any client can send it. A client that ships a new field
 before the rules that name it is denied by `hasOnly` until the rules follow;
 the direction that really stays open is a looser product limit in the deployed
 rules.
@@ -347,8 +347,8 @@ the data — that part takes effect now.
 3. Run _Deploy (production)_.
 
 The order is not a preference. The workflow deploys rules before hosting on
-purpose, so a schema addition is allowlisted before any client can send it —
-and because the rules being deployed require a claim that no token issued
+purpose, so a new top-level field is allowlisted before any client can send it
+— and because the rules being deployed require a claim that no token issued
 before step 1 carries. Reversing steps 1 and 3 locks out everyone who was
 already signed in, for up to an hour, including whoever is doing the deploy.
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,11 @@ signups are closed until an operator grants it. Nothing in front of the site can
 substitute for this: Hosting serves the config that reaches Firestore, so a
 password on the HTML protects the page, not the data.
 
-Rules deploy before anything that writes through them. A client briefly older
-than its rules fails closed; the other way round fails open.
+Rules deploy before anything that writes through them, so a schema addition is
+allowlisted before any client can send it. A client that ships a new field
+before the rules that name it is denied by `hasOnly` until the rules follow;
+the direction that really stays open is a looser product limit in the deployed
+rules.
 
 ### Response headers
 
@@ -344,9 +347,9 @@ the data — that part takes effect now.
 3. Run _Deploy (production)_.
 
 The order is not a preference. The workflow deploys rules before hosting on
-purpose — a client briefly older than its rules fails closed, the other way
-round fails open — and the rules being deployed require a claim that no token
-issued before step 1 carries. Reversing steps 1 and 3 locks out everyone who was
+purpose, so a schema addition is allowlisted before any client can send it —
+and because the rules being deployed require a claim that no token issued
+before step 1 carries. Reversing steps 1 and 3 locks out everyone who was
 already signed in, for up to an hour, including whoever is doing the deploy.
 
 This matters most exactly once: the first production run of that workflow _is_

--- a/tests/unit/readme.test.ts
+++ b/tests/unit/readme.test.ts
@@ -3,21 +3,24 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const readme = readFileSync(fileURLToPath(new URL('../../README.md', import.meta.url)), 'utf8');
+const normalizedReadme = readme.replace(/\s+/g, ' ');
 
 describe('README rules rollout contract', () => {
   it('does not promise that every newer-client mismatch fails open', () => {
-    expect(readme).not.toContain(
+    expect(normalizedReadme).not.toContain(
       'A client briefly older than its rules fails closed; the other way round fails open.',
     );
   });
 
-  it('states that rules go first so a schema addition is allowlisted before any client sends it', () => {
-    expect(readme).toContain(
-      'so a schema addition is allowlisted before any client can send it',
+  it('states that rules go first so a new top-level field is allowlisted before any client sends it', () => {
+    expect(normalizedReadme).toContain(
+      'so a new top-level field is allowlisted before any client can send it',
     );
   });
 
   it('names the mismatch that stays open as looser deployed rules, not client age itself', () => {
-    expect(readme).toContain('the direction that really stays open is a looser product limit');
+    expect(normalizedReadme).toContain(
+      'the direction that really stays open is a looser product limit',
+    );
   });
 });

--- a/tests/unit/readme.test.ts
+++ b/tests/unit/readme.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const readme = readFileSync(fileURLToPath(new URL('../../README.md', import.meta.url)), 'utf8');
+
+describe('README rules rollout contract', () => {
+  it('does not promise that every newer-client mismatch fails open', () => {
+    expect(readme).not.toContain(
+      'A client briefly older than its rules fails closed; the other way round fails open.',
+    );
+  });
+
+  it('states that rules go first so a schema addition is allowlisted before any client sends it', () => {
+    expect(readme).toContain(
+      'so a schema addition is allowlisted before any client can send it',
+    );
+  });
+
+  it('names the mismatch that stays open as looser deployed rules, not client age itself', () => {
+    expect(readme).toContain('the direction that really stays open is a looser product limit');
+  });
+});


### PR DESCRIPTION
### 概要

[#75]
Correct the README's rules rollout contract so it matches the actual `hasOnly` behavior for schema additions.

### 変更内容

- replace the incorrect "newer client fails open" wording in the two README rollout sections
- explain that rules deploy first so schema additions are allowlisted before any client can send them
- add a focused unit test that pins the corrected README wording and rejects the old sentence

### テスト方法

Run the focused check below.

**Unit / integration tests:**

- `yarn vitest run tests/unit/readme.test.ts --project unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deployment guidance for schema allowlisting and claim availability before production rollout.
  * Documented that looser product limits may fail open during deployment.

* **Tests**
  * Added coverage to verify the documented rules rollout behavior and mismatch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->