### PR TITLE
test(e2e): poll for word set autoscroll

### DIFF
--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -291,8 +291,9 @@ test.describe('word sets', () => {
     const ghostBox = await ghost.boundingBox();
     expect(ghostBox).not.toBeNull();
     expect(ghostBox?.width ?? Infinity).toBeLessThanOrEqual(320);
-    await page.waitForTimeout(1000);
-    expect(await list.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    await expect
+      .poll(() => list.evaluate((element) => element.scrollTop), { timeout: 5000 })
+      .toBeGreaterThan(0);
     await page.keyboard.press('Escape');
     await page.mouse.up();
 


### PR DESCRIPTION
### 概要

[#79]
Replace the fixed one-second sleep in the held-drag auto-scroll test with a condition-driven wait, so the spec fails on missing scroll behavior instead of on a busy runner.

### 変更内容

- replace the fixed `waitForTimeout(1000)` in `tests/e2e/wordsets.spec.ts` with `expect.poll` on the member list's `scrollTop`
- keep the assertion focused on the same auto-scroll behavior while letting a slow machine take longer instead of flaking immediately

### テスト方法

Run the focused Playwright check below.

**Unit / integration tests:**

- `yarn playwright test tests/e2e/wordsets.spec.ts -g "auto-scrolls a large member list during a held drag and cancels safely on Escape"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved drag-and-drop auto-scroll test reliability by allowing more time for scrolling to occur before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->