### PR TITLE
refactor(e2e): tighten shared seed typing

### DIFF
--- a/scripts/manifest-screenshot-specs.ts
+++ b/scripts/manifest-screenshot-specs.ts
@@ -1,7 +1,7 @@
-export interface ManifestSeed {
-  signedIn?: boolean;
-  entries?: Record<string, unknown>[];
-}
+import type { Entry } from '@/domain/entry';
+import type { E2ESeed } from '@/lib/e2eSeed';
+
+export type ManifestSeed = Pick<E2ESeed, 'signedIn' | 'entries'>;
 
 export interface ManifestScreenshotSpec {
   file: string;
@@ -15,7 +15,7 @@ export interface ManifestScreenshotSpec {
   seed: ManifestSeed;
 }
 
-const WORDS: Record<string, unknown>[] = [
+const WORDS = [
   {
     id: 'w-kiriwake',
     headword: '切り分け',
@@ -68,7 +68,7 @@ const WORDS: Record<string, unknown>[] = [
     createdAt: '2026-01-15T01:00:00.000Z',
     updatedAt: '2026-01-15T01:00:00.000Z',
   },
-];
+] satisfies Partial<Entry>[];
 
 export const manifestScreenshots: readonly ManifestScreenshotSpec[] = [
   {

--- a/scripts/manifest-screenshot-specs.ts
+++ b/scripts/manifest-screenshot-specs.ts
@@ -1,5 +1,4 @@
-import type { Entry } from '@/domain/entry';
-import type { E2ESeed } from '@/lib/e2eSeed';
+import type { E2ESeed, SeedEntry } from '@/lib/e2eSeed';
 
 export type ManifestSeed = Pick<E2ESeed, 'signedIn' | 'entries'>;
 
@@ -68,7 +67,7 @@ const WORDS = [
     createdAt: '2026-01-15T01:00:00.000Z',
     updatedAt: '2026-01-15T01:00:00.000Z',
   },
-] satisfies Partial<Entry>[];
+] satisfies SeedEntry[];
 
 export const manifestScreenshots: readonly ManifestScreenshotSpec[] = [
   {

--- a/scripts/manifest-screenshots.ts
+++ b/scripts/manifest-screenshots.ts
@@ -3,6 +3,7 @@ import { createServer } from 'node:net';
 import { writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { chromium } from '@playwright/test';
+import type { E2ESeed } from '@/lib/e2eSeed';
 import { manifestScreenshots } from './manifest-screenshot-specs';
 
 const root = (path: string) => fileURLToPath(new URL(`../${path}`, import.meta.url));
@@ -86,12 +87,12 @@ async function stopPreview(preview: ReturnType<typeof spawn>): Promise<void> {
   ]);
 }
 
-async function seed(page: import('@playwright/test').Page, data: unknown): Promise<void> {
+async function seed(page: import('@playwright/test').Page, data: E2ESeed): Promise<void> {
   await page.clock.setFixedTime(NOW);
   await page.addInitScript((value) => {
     (
-      globalThis as unknown as {
-        __GOITEI_E2E__?: unknown;
+      globalThis as {
+        __GOITEI_E2E__?: E2ESeed;
       }
     ).__GOITEI_E2E__ = value;
   }, data);

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -13,6 +13,7 @@ import type {
 import type { EntryProgress, PracticeSession, PracticeSessionDraft } from '@/domain/practice';
 import type { UserProfile, UserProfileDraft } from '@/domain/user';
 import type { WordSet, WordSetDraft } from '@/domain/wordSet';
+import type { E2ESeed } from './e2eSeed';
 import { sanitizeEntry, sanitizeSession, sanitizeWordSet } from './sanitize';
 
 /**
@@ -31,36 +32,15 @@ import { sanitizeEntry, sanitizeSession, sanitizeWordSet } from './sanitize';
  * tests/rules, both against a real emulator, and neither needs a browser.
  */
 
-interface Seed {
-  /** Start already signed in, skipping the login screen. */
-  signedIn?: boolean;
-  /** Raw documents, coerced through the same sanitiser the real read path uses. */
-  entries?: unknown[];
-  /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
-  weak?: string[];
-  /** Raw 単語集 documents. Nothing in the app creates one yet. */
-  wordSets?: unknown[];
-  /** Test-only network latency used to make concurrent-write guards observable. */
-  wordSetWriteDelayMs?: number;
-  /** Finished sessions, so 履歴 can be reached without drilling first. */
-  sessions?: unknown[];
-  /** Raw persisted profile; absent means first sign-in. */
-  profile?: unknown;
-  /** Force the next settings write to fail so the localized error path is reachable. */
-  settingsSave?: 'fail' | 'defer' | 'unreachable';
-  settingsRefresh?: 'fail';
-  updateWaiting?: boolean;
-}
-
 declare global {
   interface Window {
-    __GOITEI_E2E__?: Seed;
+    __GOITEI_E2E__?: E2ESeed;
     __GOITEI_E2E_READS__?: Record<'entries' | 'progress' | 'wordSets', number>;
     __GOITEI_E2E_RELEASE_SETTINGS_SAVE__?: () => void;
   }
 }
 
-const seed = (): Seed => (typeof window === 'undefined' ? {} : (window.__GOITEI_E2E__ ?? {}));
+const seed = (): E2ESeed => (typeof window === 'undefined' ? {} : (window.__GOITEI_E2E__ ?? {}));
 
 function countRead(store: 'entries' | 'progress' | 'wordSets'): void {
   if (typeof window === 'undefined') return;

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -170,7 +170,7 @@ function persistedProfile(uid: string): UserProfile | null {
   const raw = seed().profile;
   if (typeof raw !== 'object' || raw === null) return null;
   const now = new Date().toISOString();
-  const record = raw as Partial<UserProfile>;
+  const record = raw;
   const profile: UserProfile = {
     uid,
     nickname: typeof record.nickname === 'string' ? record.nickname : '',

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -1,0 +1,36 @@
+import type { Entry } from '@/domain/entry';
+import type { PracticeSession } from '@/domain/practice';
+import type { UserProfile } from '@/domain/user';
+import type { WordSet } from '@/domain/wordSet';
+
+export interface E2ESeed {
+  /** Start already signed in, skipping the login screen. */
+  signedIn?: boolean;
+  /**
+   * Checked-in seed literals should still be entry-shaped, even though the
+   * runtime adapter sanitises them before use.
+   */
+  entries?: Partial<Entry>[];
+  /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
+  weak?: string[];
+  /** Checked-in 単語集 seed literals should stay word-set-shaped. */
+  wordSets?: Partial<WordSet>[];
+  /** Keep a word-set write in flight long enough to exercise the busy gate. */
+  wordSetWriteDelayMs?: number;
+  /** Finished sessions, so 履歴 can be reached without drilling first. */
+  sessions?: Partial<PracticeSession>[];
+  /** Raw persisted profile; absent means first sign-in. */
+  profile?: Partial<UserProfile>;
+  /**
+   * `unreachable` rejects with Firestore's `unavailable`, which is what a
+   * settings save produces when the backend cannot be reached — the save is a
+   * transaction, and a transaction cannot be queued. Named for what the client
+   * saw, not for a cause: the same code arrives whether the device dropped off
+   * the network or the service did.
+   */
+  settingsSave?: 'fail' | 'defer' | 'unreachable';
+  /** Fail the profile re-read that follows a committed save, and only that one. */
+  settingsRefresh?: 'fail';
+  /** Put a waiting build on screen, so `UpdatePrompt` can be laid out against. */
+  updateWaiting?: boolean;
+}

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -3,6 +3,10 @@ import type { PracticeSession } from '@/domain/practice';
 import type { UserProfile } from '@/domain/user';
 import type { WordSet } from '@/domain/wordSet';
 
+export type SeedEntry = Pick<Entry, 'id'> & Partial<Entry>;
+export type SeedWordSet = Pick<WordSet, 'id'> & Partial<WordSet>;
+export type SeedSession = Pick<PracticeSession, 'id'> & Partial<PracticeSession>;
+
 export interface E2ESeed {
   /** Start already signed in, skipping the login screen. */
   signedIn?: boolean;
@@ -10,15 +14,15 @@ export interface E2ESeed {
    * Checked-in seed literals should still be entry-shaped, even though the
    * runtime adapter sanitises them before use.
    */
-  entries?: Partial<Entry>[];
+  entries?: SeedEntry[];
   /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
   weak?: string[];
   /** Checked-in 単語集 seed literals should stay word-set-shaped. */
-  wordSets?: Partial<WordSet>[];
+  wordSets?: SeedWordSet[];
   /** Keep a word-set write in flight long enough to exercise the busy gate. */
   wordSetWriteDelayMs?: number;
   /** Finished sessions, so 履歴 can be reached without drilling first. */
-  sessions?: Partial<PracticeSession>[];
+  sessions?: SeedSession[];
   /** Raw persisted profile; absent means first sign-in. */
   profile?: Partial<UserProfile>;
   /**

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,4 +1,8 @@
 import type { Page } from '@playwright/test';
+import type { Entry } from '@/domain/entry';
+import type { PracticeSession } from '@/domain/practice';
+import type { WordSet } from '@/domain/wordSet';
+import type { E2ESeed } from '@/lib/e2eSeed';
 
 /**
  * Shared setup for every end-to-end spec.
@@ -10,32 +14,6 @@ import type { Page } from '@playwright/test';
  * every screenshot overnight).
  */
 
-export interface E2ESeed {
-  /** Start already signed in, skipping the login screen. */
-  signedIn?: boolean;
-  entries?: Record<string, unknown>[];
-  /** Entry ids to start marked wrong, so 苦手のみ has something to select. */
-  weak?: string[];
-  wordSets?: Record<string, unknown>[];
-  /** Keep a word-set write in flight long enough to exercise the busy gate. */
-  wordSetWriteDelayMs?: number;
-  /** Finished sessions, so 履歴 can be reached without drilling first. */
-  sessions?: Record<string, unknown>[];
-  profile?: Record<string, unknown>;
-  /**
-   * `unreachable` rejects with Firestore's `unavailable`, which is what a
-   * settings save produces when the backend cannot be reached — the save is a
-   * transaction, and a transaction cannot be queued. Named for what the client
-   * saw, not for a cause: the same code arrives whether the device dropped off
-   * the network or the service did.
-   */
-  settingsSave?: 'fail' | 'defer' | 'unreachable';
-  /** Fail the profile re-read that follows a committed save, and only that one. */
-  settingsRefresh?: 'fail';
-  /** Put a waiting build on screen, so `UpdatePrompt` can be laid out against. */
-  updateWaiting?: boolean;
-}
-
 /** Fixed instant every spec runs at. A Wednesday; its ISO week starts on the 22nd. */
 export const NOW = new Date('2026-06-24T10:00:00+09:00');
 
@@ -46,7 +24,7 @@ export const NOW = new Date('2026-06-24T10:00:00+09:00');
  * with no kanji at all. The dates put two in the current ISO week and one
  * earlier in the same year.
  */
-export const WORDS: Record<string, unknown>[] = [
+export const WORDS = [
   {
     id: 'w-kiriwake',
     headword: '切り分け',
@@ -101,7 +79,7 @@ export const WORDS: Record<string, unknown>[] = [
     createdAt: '2026-01-15T01:00:00.000Z',
     updatedAt: '2026-01-15T01:00:00.000Z',
   },
-];
+] satisfies Partial<Entry>[];
 
 /**
  * A note whose fields are long enough to break the layout, in the two ways that
@@ -124,7 +102,7 @@ export const WORDS: Record<string, unknown>[] = [
  *    card beside it, so one long word leaves a grid of otherwise short entries
  *    with a band of empty space through it.
  */
-export const OVERSIZE_WORDS: Record<string, unknown>[] = [
+export const OVERSIZE_WORDS = [
   {
     id: 'w-latin',
     headword: 'W'.repeat(200),
@@ -151,7 +129,7 @@ export const OVERSIZE_WORDS: Record<string, unknown>[] = [
     createdAt: '2026-06-23T02:00:00.000Z',
     updatedAt: '2026-06-23T02:00:00.000Z',
   },
-];
+] satisfies Partial<Entry>[];
 
 /**
  * A 単語集 whose name is far past its limit, holding the oversize entries.
@@ -161,14 +139,14 @@ export const OVERSIZE_WORDS: Record<string, unknown>[] = [
  * still has to survive one — a set written before the limit existed, or by
  * anything that is not this client.
  */
-export const OVERSIZE_SET: Record<string, unknown>[] = [
+export const OVERSIZE_SET = [
   {
     id: 'set-oversize',
     name: 'W'.repeat(400),
     description: 'この単語集の説明。'.repeat(40),
     entryIds: ['w-latin', 'w-longja', 'w-kiriwake'],
   },
-];
+] satisfies Partial<WordSet>[];
 
 /**
  * Must be called before the first navigation: `addInitScript` runs ahead of the
@@ -178,7 +156,7 @@ export const OVERSIZE_SET: Record<string, unknown>[] = [
 export async function seed(page: Page, data: E2ESeed = {}): Promise<void> {
   await page.clock.setFixedTime(NOW);
   await page.addInitScript((value) => {
-    (window as unknown as { __GOITEI_E2E__?: unknown }).__GOITEI_E2E__ = value;
+    (window as { __GOITEI_E2E__?: E2ESeed }).__GOITEI_E2E__ = value;
   }, data);
 }
 
@@ -217,9 +195,9 @@ export async function watchForBlanking(page: Page): Promise<() => Promise<boolea
  * the specs about what a set *does* should not each pay for the four clicks
  * that make it. `wordsets.spec.ts` covers those clicks once.
  */
-export const WORD_SETS: Record<string, unknown>[] = [
+export const WORD_SETS = [
   { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
-];
+] satisfies Partial<WordSet>[];
 
 /**
  * One 単語集 holding all three words.
@@ -228,13 +206,13 @@ export const WORD_SETS: Record<string, unknown>[] = [
  * rows it renders — the state in which a visible row index and a stored index
  * stop agreeing, and the only shape that can see it.
  */
-export const FULL_SET: Record<string, unknown>[] = [
+export const FULL_SET = [
   {
     id: 'set-all',
     name: '全部セット',
     entryIds: ['w-kiriwake', 'w-choukou', 'w-chotto'],
   },
-];
+] satisfies Partial<WordSet>[];
 
 /**
  * Two 単語集 that both claim 兆候.
@@ -243,10 +221,10 @@ export const FULL_SET: Record<string, unknown>[] = [
  * set, and nothing on the entry records which of them claimed it. That is what
  * makes deleting the word a question about several documents at once.
  */
-export const OVERLAPPING_SETS: Record<string, unknown>[] = [
+export const OVERLAPPING_SETS = [
   { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
   { id: 'set-news', name: 'ニュースセット', entryIds: ['w-choukou'] },
-];
+] satisfies Partial<WordSet>[];
 
 /**
  * `count` finished sessions, newest last, an hour apart.
@@ -255,7 +233,7 @@ export const OVERLAPPING_SETS: Record<string, unknown>[] = [
  * than a couple of them is the cursor, and a page boundary needs more rows than
  * anybody wants to read in a fixture.
  */
-export function makeSessions(count: number): Record<string, unknown>[] {
+export function makeSessions(count: number): Partial<PracticeSession>[] {
   return Array.from({ length: count }, (_, index) => ({
     id: `e2e-session-${index + 1}`,
     mode: index % 2 === 0 ? 'flashcard' : 'dictation',
@@ -265,5 +243,5 @@ export function makeSessions(count: number): Record<string, unknown>[] {
     missed: [],
     startedAt: new Date(Date.UTC(2026, 5, 1, index)).toISOString(),
     finishedAt: new Date(Date.UTC(2026, 5, 1, index, 5)).toISOString(),
-  }));
+  })) satisfies Partial<PracticeSession>[];
 }

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,8 +1,5 @@
 import type { Page } from '@playwright/test';
-import type { Entry } from '@/domain/entry';
-import type { PracticeSession } from '@/domain/practice';
-import type { WordSet } from '@/domain/wordSet';
-import type { E2ESeed } from '@/lib/e2eSeed';
+import type { E2ESeed, SeedEntry, SeedSession, SeedWordSet } from '@/lib/e2eSeed';
 
 /**
  * Shared setup for every end-to-end spec.
@@ -79,7 +76,7 @@ export const WORDS = [
     createdAt: '2026-01-15T01:00:00.000Z',
     updatedAt: '2026-01-15T01:00:00.000Z',
   },
-] satisfies Partial<Entry>[];
+] satisfies SeedEntry[];
 
 /**
  * A note whose fields are long enough to break the layout, in the two ways that
@@ -129,7 +126,7 @@ export const OVERSIZE_WORDS = [
     createdAt: '2026-06-23T02:00:00.000Z',
     updatedAt: '2026-06-23T02:00:00.000Z',
   },
-] satisfies Partial<Entry>[];
+] satisfies SeedEntry[];
 
 /**
  * A 単語集 whose name is far past its limit, holding the oversize entries.
@@ -146,7 +143,7 @@ export const OVERSIZE_SET = [
     description: 'この単語集の説明。'.repeat(40),
     entryIds: ['w-latin', 'w-longja', 'w-kiriwake'],
   },
-] satisfies Partial<WordSet>[];
+] satisfies SeedWordSet[];
 
 /**
  * Must be called before the first navigation: `addInitScript` runs ahead of the
@@ -197,7 +194,7 @@ export async function watchForBlanking(page: Page): Promise<() => Promise<boolea
  */
 export const WORD_SETS = [
   { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
-] satisfies Partial<WordSet>[];
+] satisfies SeedWordSet[];
 
 /**
  * One 単語集 holding all three words.
@@ -212,7 +209,7 @@ export const FULL_SET = [
     name: '全部セット',
     entryIds: ['w-kiriwake', 'w-choukou', 'w-chotto'],
   },
-] satisfies Partial<WordSet>[];
+] satisfies SeedWordSet[];
 
 /**
  * Two 単語集 that both claim 兆候.
@@ -224,7 +221,7 @@ export const FULL_SET = [
 export const OVERLAPPING_SETS = [
   { id: 'set-work', name: '仕事セット', entryIds: ['w-kiriwake', 'w-choukou'] },
   { id: 'set-news', name: 'ニュースセット', entryIds: ['w-choukou'] },
-] satisfies Partial<WordSet>[];
+] satisfies SeedWordSet[];
 
 /**
  * `count` finished sessions, newest last, an hour apart.
@@ -233,7 +230,7 @@ export const OVERLAPPING_SETS = [
  * than a couple of them is the cursor, and a page boundary needs more rows than
  * anybody wants to read in a fixture.
  */
-export function makeSessions(count: number): Partial<PracticeSession>[] {
+export function makeSessions(count: number): SeedSession[] {
   return Array.from({ length: count }, (_, index) => ({
     id: `e2e-session-${index + 1}`,
     mode: index % 2 === 0 ? 'flashcard' : 'dictation',
@@ -243,5 +240,5 @@ export function makeSessions(count: number): Partial<PracticeSession>[] {
     missed: [],
     startedAt: new Date(Date.UTC(2026, 5, 1, index)).toISOString(),
     finishedAt: new Date(Date.UTC(2026, 5, 1, index, 5)).toISOString(),
-  })) satisfies Partial<PracticeSession>[];
+  })) satisfies SeedSession[];
 }

--- a/tests/e2e/monkey.spec.ts
+++ b/tests/e2e/monkey.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page, TestInfo } from '@playwright/test';
-import type { Entry, Frequency } from '@/domain/entry';
-import type { WordSet } from '@/domain/wordSet';
+import type { Frequency } from '@/domain/entry';
+import type { SeedEntry, SeedWordSet } from '@/lib/e2eSeed';
 import { seed } from './fixtures';
 
 interface Scenario {
@@ -66,8 +66,6 @@ const TEXT_CORPUS = [
   '長'.repeat(500),
 ];
 
-type SeedEntry = Pick<Entry, 'id'> & Partial<Entry>;
-
 function makeMonkeyEntry(index: number): SeedEntry {
   return {
     id: `monkey-word-${index + 1}`,
@@ -99,7 +97,7 @@ const MONKEY_SET = {
   name: 'W'.repeat(200),
   description: 'W'.repeat(5000),
   entryIds: MONKEY_ENTRIES.slice(0, 12).map((entry) => entry.id),
-} satisfies Partial<WordSet>;
+} satisfies SeedWordSet;
 
 function hashSeed(value: string): number {
   let hash = 2166136261;

--- a/tests/e2e/monkey.spec.ts
+++ b/tests/e2e/monkey.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page, TestInfo } from '@playwright/test';
 import type { Entry, Frequency } from '@/domain/entry';
+import type { WordSet } from '@/domain/wordSet';
 import { seed } from './fixtures';
 
 interface Scenario {
@@ -65,34 +66,40 @@ const TEXT_CORPUS = [
   '長'.repeat(500),
 ];
 
-const MONKEY_ENTRIES = Array.from({ length: 50 }, (_, index) => ({
-  id: `monkey-word-${index + 1}`,
-  headword:
-    index === 0
-      ? 'W'.repeat(200)
-      : index === 1
-        ? '<script>🚀</script>'
-        : `負荷試験${String(index + 1).padStart(2, '0')}`,
-  reading: index < 2 ? '' : `ふかしけん${String(index + 1).padStart(2, '0')}`,
-  definition: index === 0 ? 'W'.repeat(500) : `予測できない操作を試す語 ${index + 1}`,
-  pos: ['名詞'],
-  jlpt: 'N2',
-  origin: '漢語',
-  style: '書き言葉',
-  politeness: '普通',
-  freq: ((index % 5) + 1) as Frequency,
-  tags: index % 2 === 0 ? ['負荷試験'] : ['monkey'],
-  learnedOn: `2026-06-${String(24 - (index % 20)).padStart(2, '0')}`,
-  createdAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
-  updatedAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
-})) satisfies Partial<Entry>[];
+type SeedEntry = Pick<Entry, 'id'> & Partial<Entry>;
+
+function makeMonkeyEntry(index: number): SeedEntry {
+  return {
+    id: `monkey-word-${index + 1}`,
+    headword:
+      index === 0
+        ? 'W'.repeat(200)
+        : index === 1
+          ? '<script>🚀</script>'
+          : `負荷試験${String(index + 1).padStart(2, '0')}`,
+    reading: index < 2 ? '' : `ふかしけん${String(index + 1).padStart(2, '0')}`,
+    definition: index === 0 ? 'W'.repeat(500) : `予測できない操作を試す語 ${index + 1}`,
+    pos: ['名詞'],
+    jlpt: 'N2',
+    origin: '漢語',
+    style: '書き言葉',
+    politeness: '普通',
+    freq: ((index % 5) + 1) as Frequency,
+    tags: index % 2 === 0 ? ['負荷試験'] : ['monkey'],
+    learnedOn: `2026-06-${String(24 - (index % 20)).padStart(2, '0')}`,
+    createdAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
+    updatedAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
+  };
+}
+
+const MONKEY_ENTRIES = Array.from({ length: 50 }, (_, index) => makeMonkeyEntry(index));
 
 const MONKEY_SET = {
   id: 'monkey-set',
   name: 'W'.repeat(200),
   description: 'W'.repeat(5000),
   entryIds: MONKEY_ENTRIES.slice(0, 12).map((entry) => entry.id),
-};
+} satisfies Partial<WordSet>;
 
 function hashSeed(value: string): number {
   let hash = 2166136261;

--- a/tests/e2e/monkey.spec.ts
+++ b/tests/e2e/monkey.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 import type { Locator, Page, TestInfo } from '@playwright/test';
+import type { Entry, Frequency } from '@/domain/entry';
 import { seed } from './fixtures';
 
 interface Scenario {
@@ -64,7 +65,7 @@ const TEXT_CORPUS = [
   '長'.repeat(500),
 ];
 
-const MONKEY_ENTRIES: Record<string, unknown>[] = Array.from({ length: 50 }, (_, index) => ({
+const MONKEY_ENTRIES = Array.from({ length: 50 }, (_, index) => ({
   id: `monkey-word-${index + 1}`,
   headword:
     index === 0
@@ -79,12 +80,12 @@ const MONKEY_ENTRIES: Record<string, unknown>[] = Array.from({ length: 50 }, (_,
   origin: '漢語',
   style: '書き言葉',
   politeness: '普通',
-  freq: (index % 5) + 1,
+  freq: ((index % 5) + 1) as Frequency,
   tags: index % 2 === 0 ? ['負荷試験'] : ['monkey'],
   learnedOn: `2026-06-${String(24 - (index % 20)).padStart(2, '0')}`,
   createdAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
   updatedAt: new Date(Date.UTC(2026, 5, 24, 0, 0, index)).toISOString(),
-}));
+})) satisfies Partial<Entry>[];
 
 const MONKEY_SET = {
   id: 'monkey-set',

--- a/tests/unit/e2eSeed.test.ts
+++ b/tests/unit/e2eSeed.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from 'vitest';
+import type { E2ESeed } from '@/lib/e2eSeed';
+import { WORDS } from '../e2e/fixtures';
+
+const validSeed: E2ESeed = {
+  entries: [{ id: 'w-seeded', headword: '切り分け', definition: 'seeded entry' }],
+};
+
+// @ts-expect-error checked-in E2E seed literals should reject excess entry fields
+const invalidSeed: E2ESeed = { entries: [{ typoField: 1 }] };
+
+test('shared E2E seed fixtures stay entry-shaped', () => {
+  void validSeed;
+  void invalidSeed;
+  expect(WORDS.length).toBeGreaterThan(0);
+});

--- a/tests/unit/e2eSeed.test.ts
+++ b/tests/unit/e2eSeed.test.ts
@@ -9,8 +9,12 @@ const validSeed: E2ESeed = {
 // @ts-expect-error checked-in E2E seed literals should reject excess entry fields
 const invalidSeed: E2ESeed = { entries: [{ typoField: 1 }] };
 
-test('shared E2E seed fixtures stay entry-shaped', () => {
+// @ts-expect-error checked-in E2E seed literals should require explicit entry ids
+const missingIdSeed: E2ESeed = { entries: [{ headword: '切り分け' }] };
+
+test('rejects excess fields in E2E entry seed literals', () => {
   void validSeed;
   void invalidSeed;
+  void missingIdSeed;
   expect(WORDS.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- extract a shared E2E seed contract for the browser transport and backend adapter
- tighten checked-in E2E and manifest seed literals to use entry/word-set/session-shaped partials
- add focused type coverage and explicit monkey fixture factories so excess fields are rejected earlier

## Testing
- yarn typecheck
- yarn vitest run tests/unit/e2eSeed.test.ts tests/unit/manifest.test.ts --project unit
- yarn prettier --write tests/e2e/monkey.spec.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation for end-to-end test configuration and shared fixtures.
  * Improved coverage for valid and invalid seed data.
  * Strengthened typing for generated test entries, word sets, and practice sessions.

* **Refactor**
  * Centralized end-to-end test seed definitions for consistent use across test utilities and fixtures.
  * Improved validation of test data without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->