### PR TITLE
feat(admin): allow project overrides in allow-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,11 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
    alias points at your project) or
    `yarn firebase deploy --only firestore:rules --project <your-project-id>`.
 5. Sign in once, then grant yourself access — the rules deny everything until
-   your account carries the `allowed` custom claim. `yarn allow <your-email>`
-   sets it, and the account must have signed in before that, because the claim
-   goes on the uid Google issued and there is nothing to set it on until then.
-   **`yarn allow` is the one step here that cannot be pointed at your project.**
-   `admin/allow-user.ts` names `goitei-dev` and `goitei` directly, never reads
-   `.firebaserc`, and rejects any argument other than `prod` and `--revoke` — so
-   on a fresh project it will tell you the account has never signed in. Set the
-   claim through the Admin SDK yourself; that script is the worked example.
+   your account carries the `allowed` custom claim. `yarn allow <your-email>
+--project <your-project-id>` sets it, and the account must have signed in
+   before that, because the claim goes on the uid Google issued and there is
+   nothing to set it on until then. The repository shortcuts still work too:
+   omit `--project` for `goitei-dev`, or pass `prod` for `goitei`.
 6. **Sign out and sign back in.** A claim reaches the client only in a freshly
    minted ID token, so the session you granted access to is still denied — for
    up to an hour, until its token expires on its own.

--- a/README.md
+++ b/README.md
@@ -343,10 +343,12 @@ browser against the dev site or a preview channel.
 Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth
 application-default login` against the right project.
 
-**Granting access.** `yarn allow you@example.com prod`. The account must have
-signed in once first — the claim is set on the uid Google issued, so there is
-nothing to set it on before that. Anything other than `prod` or `--revoke` is
-rejected rather than ignored.
+**Granting access.** `yarn allow you@example.com prod` targets the repository
+production project, and `yarn allow you@example.com --project your-project-id`
+targets any other Firebase project. The account must have signed in once first
+— the claim is set on the uid Google issued, so there is nothing to set it on
+before that. Anything other than `prod`, `--project <project-id>` or
+`--revoke` is rejected rather than ignored.
 
 **Revoking it.** `yarn allow you@example.com prod --revoke`. **This lands within
 the hour, not on the keystroke.** The claim lives inside the ID token the client

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
    alias points at your project) or
    `yarn firebase deploy --only firestore:rules --project <your-project-id>`.
 5. Sign in once, then grant yourself access — the rules deny everything until
-   your account carries the `allowed` custom claim. `yarn allow <your-email>
---project <your-project-id>` sets it, and the account must have signed in
+   your account carries the `allowed` custom claim. `yarn allow <your-email> --project <your-project-id>`
+   sets it, and the account must have signed in
    before that, because the claim goes on the uid Google issued and there is
    nothing to set it on until then. The repository shortcuts still work too:
    omit `--project` for `goitei-dev`, or pass `prod` for `goitei`.

--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -3,6 +3,71 @@ type CredentialEnv = {
   GOOGLE_APPLICATION_CREDENTIALS?: string;
 };
 
+export type ParsedAllowUserArgs =
+  | {
+      ok: true;
+      email: string;
+      revoke: boolean;
+      projectId: string;
+    }
+  | {
+      ok: false;
+      errors: string[];
+      usage: string;
+    };
+
+const USAGE = 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]';
+
+export function parseAllowUserArgs(args: string[]): ParsedAllowUserArgs {
+  const [email, ...rest] = args;
+  const errors: string[] = [];
+
+  let revoke = false;
+  let prod = false;
+  let projectId: string | null = null;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    if (arg === '--revoke') {
+      revoke = true;
+      continue;
+    }
+    if (arg === 'prod') {
+      prod = true;
+      continue;
+    }
+    if (arg === '--project') {
+      const value = rest[index + 1];
+      if (!value || value.startsWith('--')) {
+        errors.push('--project requires a project id');
+        continue;
+      }
+      projectId = value;
+      index += 1;
+      continue;
+    }
+    errors.push(`unknown argument: ${arg}`);
+  }
+
+  if (!email) errors.push('missing email');
+  if (prod && projectId) errors.push('choose either prod or --project <project-id>, not both');
+
+  if (errors.length > 0) {
+    return { ok: false, errors, usage: USAGE };
+  }
+
+  if (!email) {
+    return { ok: false, errors: ['missing email'], usage: USAGE };
+  }
+
+  return {
+    ok: true,
+    email,
+    revoke,
+    projectId: projectId ?? (prod ? 'goitei' : 'goitei-dev'),
+  };
+}
+
 export function describeCredentialSource(env: CredentialEnv): string {
   if (env.GOOGLE_APPLICATION_CREDENTIALS) {
     return `GOOGLE_APPLICATION_CREDENTIALS=${env.GOOGLE_APPLICATION_CREDENTIALS}`;

--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -19,8 +19,12 @@ export type ParsedAllowUserArgs =
 const USAGE = 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]';
 
 export function parseAllowUserArgs(args: string[]): ParsedAllowUserArgs {
-  const [email, ...rest] = args;
+  const [emailToken, ...rest] = args;
   const errors: string[] = [];
+  const emailIsMissing = !emailToken || emailToken === 'prod' || emailToken.startsWith('--');
+  const email = emailIsMissing ? null : emailToken;
+
+  if (emailIsMissing) errors.push('missing email');
 
   let revoke = false;
   let prod = false;
@@ -42,6 +46,11 @@ export function parseAllowUserArgs(args: string[]): ParsedAllowUserArgs {
         errors.push('--project requires a project id');
         continue;
       }
+      if (projectId) {
+        errors.push('--project specified multiple times');
+        index += 1;
+        continue;
+      }
       projectId = value;
       index += 1;
       continue;
@@ -49,15 +58,10 @@ export function parseAllowUserArgs(args: string[]): ParsedAllowUserArgs {
     errors.push(`unknown argument: ${arg}`);
   }
 
-  if (!email) errors.push('missing email');
   if (prod && projectId) errors.push('choose either prod or --project <project-id>, not both');
 
-  if (errors.length > 0) {
+  if (errors.length > 0 || !email) {
     return { ok: false, errors, usage: USAGE };
-  }
-
-  if (!email) {
-    return { ok: false, errors: ['missing email'], usage: USAGE };
   }
 
   return {

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,6 +1,6 @@
 import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth, type UserRecord } from 'firebase-admin/auth';
-import { lookupErrorCode, lookupFailureLines } from './allow-user.shared';
+import { lookupErrorCode, lookupFailureLines, parseAllowUserArgs } from './allow-user.shared';
 
 /**
  * Grant or revoke access, by custom claim.
@@ -8,6 +8,7 @@ import { lookupErrorCode, lookupFailureLines } from './allow-user.shared';
  *   yarn allow you@example.com          # grant on goitei-dev
  *   yarn allow you@example.com --revoke
  *   yarn allow you@example.com prod
+ *   yarn allow you@example.com --project your-project-id
  *
  * The security rules read `request.auth.token.allowed`, so this is the only
  * thing that opens the door. It replaced an `allowedUsers` document that rules
@@ -26,24 +27,15 @@ import { lookupErrorCode, lookupFailureLines } from './allow-user.shared';
  * — deleting the offending data is the part that takes effect now.
  */
 
-const [email, ...rest] = process.argv.slice(2);
+const parsed = parseAllowUserArgs(process.argv.slice(2));
 
-// Rejected rather than ignored, because the mistake this catches is silent and
-// natural: `--revoke` is spelled with dashes, so `--prod` is how one reaches
-// for the other — and `rest.includes('prod')` is false for it, so the run would
-// grant access on **dev** and say so only in its last line.
-const unknown = rest.filter((arg) => arg !== 'prod' && arg !== '--revoke');
-
-if (!email || unknown.length > 0) {
-  if (unknown.length > 0) console.error(`unknown argument: ${unknown.join(' ')}`);
-  console.error('usage: allow-user.ts <email> [prod] [--revoke]');
+if (!parsed.ok) {
+  for (const error of parsed.errors) console.error(error);
+  console.error(parsed.usage);
   process.exit(1);
 }
 
-const revoke = rest.includes('--revoke');
-const env = rest.includes('prod') ? 'prod' : 'dev';
-
-const projectId = env === 'prod' ? 'goitei' : 'goitei-dev';
+const { email, revoke, projectId } = parsed;
 
 if (getApps().length === 0) {
   const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -6,8 +6,8 @@ import {
   parseAllowUserArgs,
 } from '../../admin/allow-user.shared';
 
-describe('allow-user lookup failures', () => {
-  it('accepts an explicit project override for fresh Firebase projects', () => {
+describe('allow-user helpers', () => {
+  it('parseAllowUserArgs accepts an explicit project override instead of falling back to goitei-dev', () => {
     expect(parseAllowUserArgs(['reader@example.com', '--project', 'reader-dev'])).toEqual({
       ok: true,
       email: 'reader@example.com',
@@ -16,7 +16,7 @@ describe('allow-user lookup failures', () => {
     });
   });
 
-  it('keeps the prod shorthand for the repository production project', () => {
+  it('parseAllowUserArgs keeps the prod shorthand from falling back to goitei-dev', () => {
     expect(parseAllowUserArgs(['reader@example.com', 'prod', '--revoke'])).toEqual({
       ok: true,
       email: 'reader@example.com',
@@ -25,7 +25,7 @@ describe('allow-user lookup failures', () => {
     });
   });
 
-  it('rejects missing project ids instead of silently granting access on dev', () => {
+  it('parseAllowUserArgs rejects missing project ids instead of silently granting access on dev', () => {
     expect(parseAllowUserArgs(['reader@example.com', '--project'])).toEqual({
       ok: false,
       errors: ['--project requires a project id'],
@@ -33,7 +33,7 @@ describe('allow-user lookup failures', () => {
     });
   });
 
-  it('rejects mixing the prod shorthand with an explicit project override', () => {
+  it('parseAllowUserArgs rejects mixing the prod shorthand with an explicit project override', () => {
     expect(parseAllowUserArgs(['reader@example.com', 'prod', '--project', 'reader-prod'])).toEqual({
       ok: false,
       errors: ['choose either prod or --project <project-id>, not both'],
@@ -41,7 +41,7 @@ describe('allow-user lookup failures', () => {
     });
   });
 
-  it('rejects the --prod typo so operators do not silently grant the dev project', () => {
+  it('parseAllowUserArgs rejects the --prod typo so operators do not silently grant the dev project', () => {
     expect(parseAllowUserArgs(['reader@example.com', '--prod'])).toEqual({
       ok: false,
       errors: ['unknown argument: --prod'],
@@ -49,7 +49,41 @@ describe('allow-user lookup failures', () => {
     });
   });
 
-  it('prevents diagnostics from hiding a configured GOOGLE_APPLICATION_CREDENTIALS file', () => {
+  it('parseAllowUserArgs rejects repeated project overrides instead of silently taking the last one', () => {
+    expect(
+      parseAllowUserArgs([
+        'reader@example.com',
+        '--project',
+        'reader-dev',
+        '--project',
+        'reader-prod',
+      ]),
+    ).toEqual({
+      ok: false,
+      errors: ['--project specified multiple times'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+  });
+
+  it('parseAllowUserArgs rejects option tokens in the required email position', () => {
+    expect(parseAllowUserArgs(['--revoke'])).toEqual({
+      ok: false,
+      errors: ['missing email'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+    expect(parseAllowUserArgs(['--project', 'reader-dev'])).toEqual({
+      ok: false,
+      errors: ['missing email', 'unknown argument: reader-dev'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+    expect(parseAllowUserArgs(['prod'])).toEqual({
+      ok: false,
+      errors: ['missing email'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+  });
+
+  it('describeCredentialSource prefers a configured GOOGLE_APPLICATION_CREDENTIALS file', () => {
     expect(
       describeCredentialSource({
         GOOGLE_APPLICATION_CREDENTIALS: '/tmp/service-account.json',
@@ -57,17 +91,17 @@ describe('allow-user lookup failures', () => {
     ).toBe('GOOGLE_APPLICATION_CREDENTIALS=/tmp/service-account.json');
   });
 
-  it('prevents diagnostics from hiding a configured CLOUDSDK_CONFIG directory', () => {
+  it('describeCredentialSource falls back to a configured CLOUDSDK_CONFIG directory', () => {
     expect(describeCredentialSource({ CLOUDSDK_CONFIG: '.gcloud' })).toBe(
       'applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
     );
   });
 
-  it('prevents diagnostics from inventing a configured gcloud directory when none is set', () => {
+  it('describeCredentialSource reports when no gcloud directory is configured', () => {
     expect(describeCredentialSource({})).toBe('applicationDefault() with CLOUDSDK_CONFIG unset');
   });
 
-  it('prevents non-user-not-found failures from being misreported as never-signed-in accounts', () => {
+  it('lookupFailureLines keeps auth/user-not-found failures on the signed-in-once guidance', () => {
     expect(
       lookupFailureLines(
         'reader@example.com',
@@ -78,7 +112,7 @@ describe('allow-user lookup failures', () => {
     ).toEqual(['reader@example.com has never signed in to goitei; ask them to try once first.']);
   });
 
-  it('prevents other lookup failures from hiding their credential configuration', () => {
+  it('lookupFailureLines reports other lookup failures with credential diagnostics', () => {
     expect(
       lookupFailureLines(
         'reader@example.com',
@@ -92,7 +126,7 @@ describe('allow-user lookup failures', () => {
     ]);
   });
 
-  it('prevents non-string thrown codes from being treated as valid Firebase error codes', () => {
+  it('lookupErrorCode returns only string Firebase error codes', () => {
     expect(lookupErrorCode({ code: 'auth/user-not-found' })).toBe('auth/user-not-found');
     expect(lookupErrorCode({ code: 404 })).toBeUndefined();
     expect(lookupErrorCode(null)).toBeUndefined();

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -3,9 +3,44 @@ import {
   describeCredentialSource,
   lookupErrorCode,
   lookupFailureLines,
+  parseAllowUserArgs,
 } from '../../admin/allow-user.shared';
 
 describe('allow-user lookup failures', () => {
+  it('accepts an explicit project override for fresh Firebase projects', () => {
+    expect(parseAllowUserArgs(['reader@example.com', '--project', 'reader-dev'])).toEqual({
+      ok: true,
+      email: 'reader@example.com',
+      revoke: false,
+      projectId: 'reader-dev',
+    });
+  });
+
+  it('keeps the prod shorthand for the repository production project', () => {
+    expect(parseAllowUserArgs(['reader@example.com', 'prod', '--revoke'])).toEqual({
+      ok: true,
+      email: 'reader@example.com',
+      revoke: true,
+      projectId: 'goitei',
+    });
+  });
+
+  it('rejects missing project ids instead of silently granting access on dev', () => {
+    expect(parseAllowUserArgs(['reader@example.com', '--project'])).toEqual({
+      ok: false,
+      errors: ['--project requires a project id'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+  });
+
+  it('rejects mixing the prod shorthand with an explicit project override', () => {
+    expect(parseAllowUserArgs(['reader@example.com', 'prod', '--project', 'reader-prod'])).toEqual({
+      ok: false,
+      errors: ['choose either prod or --project <project-id>, not both'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+  });
+
   it('prevents diagnostics from hiding a configured GOOGLE_APPLICATION_CREDENTIALS file', () => {
     expect(
       describeCredentialSource({

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -41,6 +41,14 @@ describe('allow-user lookup failures', () => {
     });
   });
 
+  it('rejects the --prod typo so operators do not silently grant the dev project', () => {
+    expect(parseAllowUserArgs(['reader@example.com', '--prod'])).toEqual({
+      ok: false,
+      errors: ['unknown argument: --prod'],
+      usage: 'usage: allow-user.ts <email> [prod] [--project <project-id>] [--revoke]',
+    });
+  });
+
   it('prevents diagnostics from hiding a configured GOOGLE_APPLICATION_CREDENTIALS file', () => {
     expect(
       describeCredentialSource({


### PR DESCRIPTION
### 概要

[#25]
Allow `yarn allow` to target Firebase projects beyond the repository dev/prod aliases, and close the remaining review gaps before merge.

### 変更内容

- add `parseAllowUserArgs` support for `--project <project-id>` while keeping `prod` and `--revoke`
- reject conflicting or malformed arguments instead of silently falling back to `goitei-dev`
- update the fresh-project setup docs and operator runbook to document project overrides consistently
- add unit coverage for explicit project overrides, `prod` conflicts, missing project ids, and the `--prod` typo guard

### テスト方法

- `yarn vitest run tests/unit/allowUser.test.ts --project unit`
- `yarn tsc -p tsconfig.scripts.json --noEmit`
- `yarn prettier --write admin/allow-user.shared.ts admin/allow-user.ts tests/unit/allowUser.test.ts README.md`
- `git diff --check`

**Unit / integration tests:**

- `yarn vitest run tests/unit/allowUser.test.ts --project unit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for granting or revoking access in any Firebase project using `--project <project-id>`.
  - Retained `prod` as a shortcut for the production project.
  - Added clearer command usage guidance and validation for unsupported or conflicting arguments.

- **Bug Fixes**
  - Removed the need for manual Admin SDK configuration when working with fresh projects.

- **Tests**
  - Added coverage for project selection, missing values, conflicting options, and invalid production flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->