### PR TITLE
docs(release): record that the squash title setting is now PR_TITLE

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -60,19 +60,19 @@ jobs:
             build
             ci
           # The title alone is not enough, because GitHub does not always use
-          # it. `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, and on a
-          # pull request with exactly one commit the squash dialog offers that
-          # commit's message instead — so a title this check passed as `feat:`
-          # can land on `develop` as `chore:` and quietly change the next
-          # version. The action's own documentation describes this case, and
-          # these two options close it: the single commit is validated too, and
-          # it has to say the same thing the title does, so whichever GitHub
-          # picks is the same string.
+          # it. Under `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, which is
+          # what this repository had until 2026-08-22, a pull request with
+          # exactly one commit gets that commit's message offered instead — so
+          # a title this check passed as `feat:` could land on `develop` as
+          # `chore:` and quietly change the next version. The action's own
+          # documentation describes this case, and these two options close it:
+          # the single commit is validated too, and it has to say the same
+          # thing the title does, so whichever GitHub picks is the same string.
           #
-          # Setting the repository's `squash_merge_commit_title` to `PR_TITLE`
-          # fixes it as well, and is worth doing. It is not enough on its own:
-          # a repository setting is invisible to a reader of this file and can
-          # be changed without review, whereas this is version-controlled.
+          # The setting is now `PR_TITLE`, which fixes it from the other side.
+          # These stay anyway: a repository setting is invisible to a reader of
+          # this file and can be changed back without review, whereas this is
+          # version-controlled.
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true
           # Scopes are optional here. Most titles carry one, but a change that

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,16 +50,18 @@ changes the version and nothing downstream can tell. That is what
 [`.github/workflows/pr-title.yml`](../.github/workflows/pr-title.yml) is for, and
 why its type list has to stay in step with `.versionrc.json`.
 
-Checking the title is not quite sufficient, because GitHub does not always use
-it. The repository's `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, and on
-a pull request with exactly one commit the squash dialog offers that commit's
-message instead — so a title accepted as `feat:` can land as `chore:`. The
-workflow therefore also sets `validateSingleCommit` and
-`validateSingleCommitMatchesPrTitle`, which make the two agree before the choice
-can matter. Setting `squash_merge_commit_title` to `PR_TITLE` closes the same
-gap from the other side and is worth doing; it is not a substitute, because a
-repository setting can be changed without review and is invisible to anyone
-reading this.
+Checking the title is not quite sufficient on its own, because GitHub does not
+always use it. Under `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, which is
+what this repository had until 2026-08-22, a pull request with exactly one commit
+gets that commit's message offered instead — so a title accepted as `feat:` can
+land as `chore:` and move the next version with nothing reporting it.
+
+Two things now prevent that, and both should stay. The setting is `PR_TITLE`, so
+the title is what lands. The workflow also sets `validateSingleCommit` and
+`validateSingleCommitMatchesPrTitle`, which make the commit and the title agree
+before the choice can matter — because the setting is invisible to anyone reading
+the repository and can be changed back without review, while the workflow is a
+file that says why it exists.
 
 ### Why this project left `0.x`
 


### PR DESCRIPTION
`squash_merge_commit_title` was changed from `COMMIT_OR_PR_TITLE` to `PR_TITLE`
after #96 merged. Two passages written during that review still described it in
the present tense as `COMMIT_OR_PR_TITLE` — `docs/releasing.md` and the comment
above the `validateSingleCommit` options in `.github/workflows/pr-title.yml`.

They were therefore stating something false about the one setting they exist to
explain, and in a direction that matters: a reader would have concluded the
workflow options were the only thing standing between a `feat:` title and a
`chore:` merge commit, and might have relaxed them on the strength of it.

Both now say what the setting was, what it is, and why the options stay anyway —
a repository setting is invisible to someone reading the repository and can be
changed back without review, whereas the workflow is a file that says why it
exists. Keeping both is the point, not redundancy.

## Testing

None. Prose and a YAML comment; no expression, input or step changed. The
workflow still parses and `validateSingleCommit` is still `true`, checked, and
`prettier --check` passes on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that squash merge commit messages use the pull request title.
  * Documented the title validation safeguards for single-commit pull requests.
  * Updated release guidance to reflect the repository’s `PR_TITLE` configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->