### PR TITLE
fix(import): default learnedOn to today instead of trusting the assistant's guess

### DIFF
--- a/src/lib/jsonImport.ts
+++ b/src/lib/jsonImport.ts
@@ -1,7 +1,7 @@
 import type { EntryDraft } from '@/domain/entry';
 import { INPUT_LIMITS } from '@/domain/limits';
 import type { TranslationLanguage } from '@/domain/user';
-import { describeSizeProblem, draftSizeProblems } from './draft';
+import { describeSizeProblem, draftSizeProblems, emptyDraft } from './draft';
 import { sanitizeDraft } from './sanitize';
 
 const PROMPT_LANGUAGE_NAMES = {
@@ -228,6 +228,18 @@ export function jsonToDraft(
   // enum values, wrong types, or nulls inside arrays — all of which would
   // otherwise reach the form and Firestore intact.
   const draft: EntryDraft = sanitizeDraft(parsed);
+
+  // `sanitizeDraft`'s `isoDate` only rejects a `learnedOn` that fails to
+  // parse — it has no way to tell a real date from an invented one, and
+  // nothing in `buildPrompt` tells the assistant what today is. The result
+  // over real replies is not a fallback the reader can rely on: sometimes
+  // today, sometimes an empty string, sometimes a well-formed date that is
+  // neither. The reader cannot see the difference on screen, and the field
+  // drives the dashboard heatmap, so a wrong value is silent. Today is
+  // always what a freshly imported note should start from — the same
+  // default `emptyDraft` gives a note started by hand — and the field
+  // stays user-editable in the form afterwards.
+  draft.learnedOn = emptyDraft().learnedOn;
 
   if (context.original?.trim()) draft.context.original = context.original.trim();
   if (context.source?.trim()) draft.source = context.source.trim();

--- a/src/lib/jsonImport.ts
+++ b/src/lib/jsonImport.ts
@@ -1,7 +1,8 @@
 import type { EntryDraft } from '@/domain/entry';
 import { INPUT_LIMITS } from '@/domain/limits';
 import type { TranslationLanguage } from '@/domain/user';
-import { describeSizeProblem, draftSizeProblems, emptyDraft } from './draft';
+import { dateKey } from './dates';
+import { describeSizeProblem, draftSizeProblems } from './draft';
 import { sanitizeDraft } from './sanitize';
 
 const PROMPT_LANGUAGE_NAMES = {
@@ -197,6 +198,7 @@ function delimiterMayStandAt(text: string, from: number): boolean {
 export function jsonToDraft(
   raw: string,
   context: PromptContext = {},
+  now: Date = new Date(),
 ): { draft?: EntryDraft; error?: string; oversize?: string[] } {
   // Before the parse, not after: `JSON.parse` on a multi-megabyte paste blocks
   // the main thread long enough to read as a hung tab, and every check below
@@ -238,8 +240,11 @@ export function jsonToDraft(
   // drives the dashboard heatmap, so a wrong value is silent. Today is
   // always what a freshly imported note should start from — the same
   // default `emptyDraft` gives a note started by hand — and the field
-  // stays user-editable in the form afterwards.
-  draft.learnedOn = emptyDraft().learnedOn;
+  // stays user-editable in the form afterwards. `now` is taken as an
+  // argument rather than read here, so the clock is read once at the call
+  // boundary instead of a second time on top of the one `sanitizeDraft`'s
+  // own `emptyDraft()` fallback already did.
+  draft.learnedOn = dateKey(now);
 
   if (context.original?.trim()) draft.context.original = context.original.trim();
   if (context.source?.trim()) draft.source = context.source.trim();

--- a/tests/unit/jsonImport.test.ts
+++ b/tests/unit/jsonImport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { INPUT_LIMITS } from '@/domain/limits';
 import { buildPrompt, jsonToDraft, promptLanguageName, SCHEMA } from '@/lib/jsonImport';
 
@@ -212,6 +212,41 @@ describe('jsonToDraft — required fields', () => {
       related: [],
       tags: [],
     });
+  });
+});
+
+/**
+ * Nothing in `buildPrompt` tells the assistant today's date, so `learnedOn`
+ * in its reply is a guess dressed up as an answer: sometimes today, sometimes
+ * an empty string, sometimes a well-formed date that is neither — all three
+ * observed from real replies to the same prompt. `isoDate` in `sanitize.ts`
+ * only catches the malformed case; a syntactically valid but invented date
+ * passed straight through and was imported as if the reader had typed it.
+ * The reader cannot tell the difference on screen, and the field drives the
+ * dashboard's contribution heatmap, so a wrong value there is silent.
+ */
+describe('jsonToDraft — learnedOn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 7, 24));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('defaults to today when the assistant omits learnedOn', () => {
+    expect(jsonToDraft(JSON.stringify(minimal)).draft?.learnedOn).toBe('2026-08-24');
+  });
+
+  it('defaults to today when the assistant sends an empty learnedOn', () => {
+    const raw = JSON.stringify({ ...minimal, learnedOn: '' });
+    expect(jsonToDraft(raw).draft?.learnedOn).toBe('2026-08-24');
+  });
+
+  it('defaults to today rather than trusting a well-formed but invented learnedOn', () => {
+    const raw = JSON.stringify({ ...minimal, learnedOn: '2019-03-14' });
+    expect(jsonToDraft(raw).draft?.learnedOn).toBe('2026-08-24');
   });
 });
 

--- a/tests/unit/jsonImport.test.ts
+++ b/tests/unit/jsonImport.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { INPUT_LIMITS } from '@/domain/limits';
 import { buildPrompt, jsonToDraft, promptLanguageName, SCHEMA } from '@/lib/jsonImport';
 
@@ -226,27 +226,20 @@ describe('jsonToDraft — required fields', () => {
  * dashboard's contribution heatmap, so a wrong value there is silent.
  */
 describe('jsonToDraft — learnedOn', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(2026, 7, 24));
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+  const now = new Date(2026, 7, 24);
 
   it('defaults to today when the assistant omits learnedOn', () => {
-    expect(jsonToDraft(JSON.stringify(minimal)).draft?.learnedOn).toBe('2026-08-24');
+    expect(jsonToDraft(JSON.stringify(minimal), {}, now).draft?.learnedOn).toBe('2026-08-24');
   });
 
   it('defaults to today when the assistant sends an empty learnedOn', () => {
     const raw = JSON.stringify({ ...minimal, learnedOn: '' });
-    expect(jsonToDraft(raw).draft?.learnedOn).toBe('2026-08-24');
+    expect(jsonToDraft(raw, {}, now).draft?.learnedOn).toBe('2026-08-24');
   });
 
   it('defaults to today rather than trusting a well-formed but invented learnedOn', () => {
     const raw = JSON.stringify({ ...minimal, learnedOn: '2019-03-14' });
-    expect(jsonToDraft(raw).draft?.learnedOn).toBe('2026-08-24');
+    expect(jsonToDraft(raw, {}, now).draft?.learnedOn).toBe('2026-08-24');
   });
 });
 


### PR DESCRIPTION
## Summary
- The AI-import prompt never tells the assistant today's date, so its `learnedOn` reply is a guess — sometimes today, sometimes an empty string, sometimes a well-formed but invented date (e.g. `2019-03-14`).
- `sanitizeDraft`'s `isoDate` helper only rejects malformed values, so a plausible-looking wrong date passed straight through `jsonToDraft` and imported silently, with nothing on screen distinguishing it from a real one.
- `jsonToDraft` now always overrides `learnedOn` with today right after `sanitizeDraft`, the same default `emptyDraft()` gives a note started by hand. The field stays user-editable in the form afterwards.

## Test plan
- Layer: `tests/unit` — this is pure input→output behavior of `jsonToDraft`, no Firestore or DOM involved.
- Added `describe('jsonToDraft — learnedOn', …)` in `tests/unit/jsonImport.test.ts` covering three cases with a fixed system time: assistant omits `learnedOn`, sends `''`, and sends a well-formed but invented date. All expect today's date.
- Proved red first: ran the new tests against the pre-fix code — the first two already passed (via `sanitizeDraft`'s existing fallback for invalid/missing values), the third failed with `expected '2019-03-14' to be '2026-08-24'`, confirming the actual gap.
- `yarn test:unit` (810 tests) and `yarn typecheck` both pass after the fix.
- `yarn format` run, no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Imported drafts now receive the correct default “learned on” date when the date is missing, empty, or invalid.
  - Other imported draft data and validation behavior remain unchanged.

- **Documentation**
  - Updated release instructions with clearer version formatting, production deployment steps, commit selection guidance, and pull request validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->