### PR TITLE
feat(vocab): show the whole note in the word dialog, with an edit button

### DIFF
--- a/src/components/VocabDialog.tsx
+++ b/src/components/VocabDialog.tsx
@@ -1,22 +1,30 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { EntryBody } from '@/components/detail/EntryBody';
+import { EntryHeadline } from '@/components/detail/EntryHeadline';
+import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
 import { Modal } from '@/components/Modal';
-import { PitchAccent } from '@/components/PitchAccent';
-import { Ruby } from '@/components/Ruby';
 import { SpeakButton, SpeechStatusNote } from '@/components/SpeakButton';
 import { useI18n } from '@/i18n/context';
-import { useEntryLabel } from '@/i18n/useEntryLabel';
 import { useEntries } from '@/lib/entries';
-import { accentKana } from '@/lib/mora';
 import { spokenForm, useJapaneseSpeech } from '@/lib/speech';
 import { useVocabDialog } from '@/lib/vocabDialog';
 
 /**
  * A word, looked at without leaving the page that mentioned it.
  *
- * A peek, not the detail page: meaning, the senses and one example, and a way
- * through to everything else. Editing and deleting are deliberately absent —
- * they change what other screens are showing, and the page underneath this one
- * has no idea it happened.
+ * The whole note, not a summary of it: `EntryHeadline` and `EntryBody` are the
+ * same two components the detail page renders, so a word opened from a list and
+ * the same word opened by its address say the same things in the same order.
+ * The only difference is `surface="panel"` — the dialog body is already
+ * `bg-card`, so the sections are separated by a border instead of by a card.
+ *
+ * Editing is here and deleting is not, and the two are not the same call.
+ * Both write through `EntriesProvider`, which every screen reads from, so a
+ * saved edit reaches the page underneath on the next render rather than leaving
+ * it stale. A delete would leave this dialog sitting over a word that no longer
+ * exists, showing 「単語が見つかりません」 above the list it was deleted from;
+ * that belongs on the detail page, which can navigate away afterwards.
  *
  * Read out of `EntriesProvider` rather than fetched, because every screen that
  * can open this already holds the whole notebook. A word that is not there is
@@ -25,12 +33,20 @@ import { useVocabDialog } from '@/lib/vocabDialog';
  */
 export function VocabDialog() {
   const { t } = useI18n();
-  const entryLabel = useEntryLabel();
   const { openId, close } = useVocabDialog();
   const { entries } = useEntries();
   // Above the early return, because hooks are: this component is mounted for
   // the whole session and renders nothing until a word is asked for.
   const { status: speechStatus, speak } = useJapaneseSpeech();
+  /**
+   * Which word the edit form is open for, rather than whether it is open.
+   *
+   * A boolean survives the dialog being closed with the form up, and the next
+   * word opened from any list would then arrive already in a form nobody asked
+   * to fill in. Comparing against `openId` makes a stale value inert without an
+   * effect having to reset it.
+   */
+  const [editingId, setEditingId] = useState<string | null>(null);
 
   if (openId === null) return null;
   const entry = entries.find((item) => item.id === openId);
@@ -43,8 +59,18 @@ export function VocabDialog() {
     );
   }
 
-  const meanings = entry.senses.map((sense) => sense.description).filter(Boolean);
-  const example = entry.senses.find((sense) => sense.example)?.example ?? entry.examples[0]?.ja;
+  /**
+   * The form replaces the preview rather than opening on top of it.
+   *
+   * Two `Modal`s open at once are two focus traps and two Escape listeners
+   * competing over the same keystroke, and the second one also re-runs the
+   * `inert` bookkeeping the first is relying on. Swapping keeps one dialog on
+   * screen at a time; closing the form returns to the preview, which by then is
+   * reading the entry the save refreshed.
+   */
+  if (editingId === entry.id) {
+    return <EntryFormModal open entry={entry} onClose={() => setEditingId(null)} />;
+  }
 
   return (
     <Modal
@@ -69,58 +95,25 @@ export function VocabDialog() {
       }
     >
       <div className="min-w-0 space-y-4">
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-3">
-            <Ruby
-              headword={entry.headword}
-              reading={entry.reading}
-              className="has-ruby block min-w-0 font-display text-3xl font-bold [overflow-wrap:anywhere]"
-            />
-            <SpeakButton status={speechStatus} onSpeak={() => speak(spokenForm(entry))} />
-          </div>
-          <SpeechStatusNote status={speechStatus} className="mt-2" />
-          {entry.pitchAccent !== null && (
-            <PitchAccent
-              kana={accentKana(entry.headword, entry.reading)}
-              pitchAccent={entry.pitchAccent}
-              className="mt-2 block font-display text-base"
-            />
-          )}
-          <div className="mt-2 flex flex-wrap items-center gap-2 text-xs">
-            <span className="rounded-pill bg-accent-soft px-2.5 py-1 font-semibold text-accent">
-              {entry.jlpt}
-            </span>
-            {entry.pos.map((part) => (
-              <span key={part} className="rounded-pill bg-bg-alt px-2.5 py-1 text-muted">
-                {entryLabel(part)}
-              </span>
-            ))}
-            <span className="text-muted tabular-nums">{entry.learnedOn}</span>
-          </div>
-        </div>
+        <EntryHeadline
+          entry={entry}
+          compact
+          actions={
+            <>
+              <SpeakButton status={speechStatus} onSpeak={() => speak(spokenForm(entry))} />
+              <button
+                type="button"
+                onClick={() => setEditingId(entry.id)}
+                className="min-h-9 rounded-pill bg-bg-alt px-4 text-xs font-semibold text-ink"
+              >
+                {t('common.edit')}
+              </button>
+            </>
+          }
+        />
+        <SpeechStatusNote status={speechStatus} />
 
-        {(meanings.length > 0 || entry.definition) && (
-          <ul className="prose-cjk space-y-1 text-sm">
-            {(meanings.length ? meanings : [entry.definition]).map((meaning, position) => (
-              <li key={position} className="flex gap-2">
-                <span className="text-muted">・</span>
-                <span>{meaning}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-
-        {example && <p className="prose-cjk rounded-panel bg-bg-alt p-3 text-sm">{example}</p>}
-
-        {entry.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
-            {entry.tags.map((tag) => (
-              <span key={tag} className="text-xs text-accent">
-                #{tag}
-              </span>
-            ))}
-          </div>
-        )}
+        <EntryBody entry={entry} surface="panel" />
       </div>
     </Modal>
   );

--- a/src/components/detail/EntryBody.tsx
+++ b/src/components/detail/EntryBody.tsx
@@ -1,0 +1,162 @@
+import { KeyValueTable, Section } from '@/components/detail/Section';
+import type { SectionSurface } from '@/components/detail/Section';
+import type { Entry } from '@/domain/entry';
+import { useI18n } from '@/i18n/context';
+import { useEntryLabel } from '@/i18n/useEntryLabel';
+import { circled, stars } from '@/lib/entryFormat';
+
+/**
+ * Everything recorded about a word below its headword.
+ *
+ * One implementation, rendered by the detail page and by the dialog. It used to
+ * exist only on the page, and the dialog showed a summary of it — one meaning,
+ * one example, no context, no usage notes, no related words — so a word opened
+ * from a list looked emptier than the same word opened by its address. The
+ * dialog is a different amount of room, not a different amount of the note, so
+ * the only thing it varies is `surface`.
+ *
+ * Every section is conditional on having something to say, which is why a
+ * sparse entry does not render a column of empty headings.
+ */
+export function EntryBody({ entry, surface = 'card' }: { entry: Entry; surface?: SectionSurface }) {
+  const { t } = useI18n();
+  const entryLabel = useEntryLabel();
+
+  const manifest = [
+    { label: t('vocabulary.partOfSpeech'), value: entry.pos.map(entryLabel).join('／') },
+    { label: t('vocabulary.jlptLevel'), value: entryLabel(entry.jlpt) },
+    { label: t('vocabulary.origin'), value: entryLabel(entry.origin) },
+    { label: t('vocabulary.style'), value: entryLabel(entry.style) },
+    { label: t('vocabulary.politeness'), value: entryLabel(entry.politeness) },
+    { label: t('vocabulary.frequency'), value: stars(entry.freq) },
+    { label: t('vocabulary.citationForm'), value: entry.citationForm },
+  ].filter((row) => row.value);
+
+  const usageRows = [
+    { label: t('vocabulary.whenUsed'), value: entry.usage.when },
+    { label: t('vocabulary.translationEquivalent'), value: entry.usage.translation },
+    { label: t('vocabulary.caution'), value: entry.usage.caution },
+  ].filter((row) => row.value);
+
+  return (
+    <>
+      <Section emoji="📋" title={t('vocabulary.manifest')} surface={surface}>
+        <KeyValueTable rows={manifest} />
+      </Section>
+
+      {entry.posInfo && (
+        <Section emoji="🔧" title={entry.posInfo.title} surface={surface}>
+          <KeyValueTable rows={entry.posInfo.rows} />
+        </Section>
+      )}
+
+      {/* The sentence the word was met in comes before the dictionary meaning,
+          matching the markdown notes: 23 of the 24 that record a context put it
+          first. Reading the encounter before the definition is also the order
+          the word was actually learned in. */}
+      {entry.context.original && (
+        <Section emoji="📌" title={t('vocabulary.context')} surface={surface}>
+          <blockquote className="prose-cjk rounded-panel border-l-4 border-accent bg-bg-alt px-4 py-3 text-sm">
+            {entry.context.original}
+          </blockquote>
+          {entry.context.ja && (
+            <p className="prose-cjk mt-4 text-sm whitespace-pre-line">{entry.context.ja}</p>
+          )}
+          {entry.context.translation && (
+            <p className="prose-cjk mt-3 text-sm whitespace-pre-line text-muted">
+              {entry.context.translation}
+            </p>
+          )}
+        </Section>
+      )}
+
+      {(entry.definition || entry.definitionSub) && (
+        <Section emoji="📖" title={t('vocabulary.definition')} surface={surface}>
+          {entry.definition && (
+            <p className="prose-cjk text-sm whitespace-pre-line">{entry.definition}</p>
+          )}
+          {entry.definitionSub && (
+            <p className="prose-cjk mt-4 border-t border-line pt-4 text-sm whitespace-pre-line">
+              {entry.definitionSub}
+            </p>
+          )}
+        </Section>
+      )}
+
+      {entry.senses.length > 0 && (
+        <Section emoji="🌐" title={t('vocabulary.senses')} surface={surface}>
+          <ol className="divide-y divide-line">
+            {entry.senses.map((sense, index) => (
+              <li key={index} className="py-4 first:pt-0 last:pb-0">
+                <h3 className="text-sm font-semibold">
+                  <span className="mr-1.5 text-accent">{circled(index)}</span>
+                  {sense.label}
+                </h3>
+                {sense.description && <p className="prose-cjk mt-2 text-sm">{sense.description}</p>}
+                {sense.example && (
+                  <blockquote className="prose-cjk mt-3 border-l-2 border-line pl-3 text-sm">
+                    {sense.example}
+                    {sense.exampleGloss && (
+                      <span className="block text-xs text-muted">
+                        {t('vocabulary.gloss', { value: sense.exampleGloss })}
+                      </span>
+                    )}
+                  </blockquote>
+                )}
+                {sense.translation && <p className="prose-cjk mt-2 text-sm">{sense.translation}</p>}
+                {sense.usage && (
+                  <p className="prose-cjk mt-2 text-xs text-muted">
+                    {t('vocabulary.usageSituation', { value: sense.usage })}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
+        </Section>
+      )}
+
+      {entry.examples.length > 0 && (
+        <Section emoji="📝" title={t('vocabulary.examples')} surface={surface}>
+          <ol className="divide-y divide-line">
+            {entry.examples.map((example, index) => (
+              <li key={index} className="py-3 first:pt-0 last:pb-0">
+                <p className="prose-cjk text-sm">
+                  <span className="mr-1.5 text-accent">{circled(index)}</span>
+                  {example.ja}
+                </p>
+                {example.translation && (
+                  <p className="prose-cjk mt-1 pl-6 text-sm text-muted">{example.translation}</p>
+                )}
+              </li>
+            ))}
+          </ol>
+        </Section>
+      )}
+
+      {usageRows.length > 0 && (
+        <Section emoji="🗣️" title={t('vocabulary.usage')} surface={surface}>
+          <KeyValueTable rows={usageRows} />
+        </Section>
+      )}
+
+      {entry.related.length > 0 && (
+        <Section emoji="🔗" title={t('vocabulary.related')} surface={surface}>
+          <ul className="divide-y divide-line text-sm">
+            {entry.related.map((related, index) => (
+              <li key={index} className="py-2.5 first:pt-0 last:pb-0">
+                <span className="font-display font-bold">{related.headword}</span>
+                <span className="prose-cjk text-muted"> — {related.note}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      )}
+
+      {entry.source && (
+        <p className="px-1 text-xs text-muted">
+          {t('vocabulary.sourceLine', { source: entry.source })}
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/components/detail/EntryHeadline.tsx
+++ b/src/components/detail/EntryHeadline.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { PitchAccent } from '@/components/PitchAccent';
 import { Ruby } from '@/components/Ruby';
@@ -28,7 +29,7 @@ export function EntryHeadline({
   entry: Entry;
   /** Dialog scale: a smaller headword and tighter spacing. */
   compact?: boolean;
-  actions?: React.ReactNode;
+  actions?: ReactNode;
 }) {
   const { t } = useI18n();
   const entryLabel = useEntryLabel();

--- a/src/components/detail/EntryHeadline.tsx
+++ b/src/components/detail/EntryHeadline.tsx
@@ -1,0 +1,92 @@
+import { Link } from 'react-router-dom';
+import { PitchAccent } from '@/components/PitchAccent';
+import { Ruby } from '@/components/Ruby';
+import type { Entry } from '@/domain/entry';
+import { useI18n } from '@/i18n/context';
+import { useEntryLabel } from '@/i18n/useEntryLabel';
+import { stars } from '@/lib/entryFormat';
+import { accentKana } from '@/lib/mora';
+
+/**
+ * Who the word is: the headword, how it is read and said, and the handful of
+ * attributes that identify it at a glance.
+ *
+ * Shared by the detail page and the dialog so the two cannot drift — the dialog
+ * used to show a shorter set, which made the same word look like two different
+ * records depending on how it was opened. Only the type scale differs, because
+ * a sheet on a phone has less room for a 40px headword than a page does.
+ *
+ * The action buttons are *not* here. The page carries edit and delete beside
+ * the headword and the dialog carries edit alone, in a different arrangement,
+ * so each renders its own cluster and passes it in.
+ */
+export function EntryHeadline({
+  entry,
+  compact = false,
+  actions,
+}: {
+  entry: Entry;
+  /** Dialog scale: a smaller headword and tighter spacing. */
+  compact?: boolean;
+  actions?: React.ReactNode;
+}) {
+  const { t } = useI18n();
+  const entryLabel = useEntryLabel();
+
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4">
+      <div className="max-w-full min-w-0">
+        <Ruby
+          headword={entry.headword}
+          reading={entry.reading}
+          className={
+            compact
+              ? 'has-ruby block font-display text-3xl font-bold [overflow-wrap:anywhere]'
+              : 'has-ruby block font-display text-[34px] font-bold [overflow-wrap:anywhere] sm:text-[40px]'
+          }
+        />
+        {entry.pitchAccent !== null && (
+          <PitchAccent
+            kana={accentKana(entry.headword, entry.reading)}
+            pitchAccent={entry.pitchAccent}
+            className={`mt-2 block font-display ${compact ? 'text-base' : 'text-lg'}`}
+          />
+        )}
+        <div className={`${compact ? 'mt-2' : 'mt-3'} flex flex-wrap items-center gap-2 text-xs`}>
+          <span className="rounded-pill bg-accent-soft px-2.5 py-1 font-semibold text-accent">
+            {entry.jlpt}
+          </span>
+          {entry.pos.map((part) => (
+            <span key={part} className="rounded-pill bg-bg-alt px-2.5 py-1 text-muted">
+              {entryLabel(part)}
+            </span>
+          ))}
+          <span className="text-accent" title={`${t('vocabulary.frequency')} ${entry.freq}/5`}>
+            {stars(entry.freq)}
+          </span>
+          <span className="text-muted tabular-nums">{entry.learnedOn}</span>
+        </div>
+        {entry.tags.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {entry.tags.map((tag) => (
+              <Link
+                key={tag}
+                to={`/vocabulary?tag=${encodeURIComponent(tag)}`}
+                className="text-xs text-accent"
+              >
+                #{tag}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Playing the word sits with edit and delete rather than beside the
+          headword: the heading is a block that fills its column, and moving
+          it into a row with a button next to it re-flows the box that
+          `tests/e2e/visual.spec.ts` crops to prove furigana lands above the
+          word it reads. */}
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/src/components/detail/Section.tsx
+++ b/src/components/detail/Section.tsx
@@ -1,20 +1,40 @@
 import type { ReactNode } from 'react';
 
 /**
+ * Where a section is being rendered, which decides how it is separated from
+ * what is around it.
+ *
+ * `card` is the page: a raised card on the page background. `panel` is the
+ * dialog, whose body is already `bg-card` — a second card on top of it has no
+ * edge at all, so the boundary is drawn with a border instead. The background
+ * stays transparent either way, so the `bg-bg-alt` blockquotes inside keep the
+ * contrast they were chosen for.
+ */
+export type SectionSurface = 'card' | 'panel';
+
+/**
  * The emoji headers mirror the original markdown notes (📋🔧📌🌐📝🗣️🔗) and are
  * kept deliberately — they are how these notes have always been scanned.
  */
 export function Section({
   emoji,
   title,
+  surface = 'card',
   children,
 }: {
   emoji: string;
   title: string;
+  surface?: SectionSurface;
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-card bg-card p-5 shadow-panel sm:p-6">
+    <section
+      className={
+        surface === 'panel'
+          ? 'rounded-panel border border-line p-4'
+          : 'rounded-card bg-card p-5 shadow-panel sm:p-6'
+      }
+    >
       <h2 className="mb-4 flex items-center gap-2 text-sm font-semibold">
         <span aria-hidden>{emoji}</span>
         {title}

--- a/src/lib/entryFormat.ts
+++ b/src/lib/entryFormat.ts
@@ -1,0 +1,14 @@
+/**
+ * Two ways the notes have always been written, kept out of the components that
+ * render them so the page and the dialog cannot disagree about either.
+ */
+
+/** ①②③… for sense and example numbering, matching the notes. */
+export function circled(index: number): string {
+  return index < 20 ? String.fromCharCode(0x2460 + index) : `${index + 1}`;
+}
+
+/** 1 (rare) – 5 (everyday), as ★×freq + ☆×(5−freq). */
+export function stars(freq: number): string {
+  return '★'.repeat(freq) + '☆'.repeat(Math.max(0, 5 - freq));
+}

--- a/src/routes/EntryDetail.tsx
+++ b/src/routes/EntryDetail.tsx
@@ -1,32 +1,19 @@
 import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { KeyValueTable, Section } from '@/components/detail/Section';
+import { EntryBody } from '@/components/detail/EntryBody';
+import { EntryHeadline } from '@/components/detail/EntryHeadline';
 import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
-import { PitchAccent } from '@/components/PitchAccent';
-import { Ruby } from '@/components/Ruby';
 import { SpeakButton, SpeechStatusNote } from '@/components/SpeakButton';
 import { useI18n } from '@/i18n/context';
-import { useEntryLabel } from '@/i18n/useEntryLabel';
 import { useLoadErrorMessage } from '@/i18n/useLoadErrorMessage';
 import { useEntries } from '@/lib/entries';
-import { accentKana } from '@/lib/mora';
 import { spokenForm, useJapaneseSpeech } from '@/lib/speech';
-
-/** ①②③… for sense and example numbering, matching the notes. */
-function circled(index: number): string {
-  return index < 20 ? String.fromCharCode(0x2460 + index) : `${index + 1}`;
-}
-
-function stars(freq: number): string {
-  return '★'.repeat(freq) + '☆'.repeat(Math.max(0, 5 - freq));
-}
 
 export function Component() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { t } = useI18n();
-  const entryLabel = useEntryLabel();
   const { entries, loading, error, refresh, repository } = useEntries();
   const errorMessage = useLoadErrorMessage(error);
   const [editing, setEditing] = useState(false);
@@ -72,215 +59,39 @@ export function Component() {
     );
   }
 
-  const manifest = [
-    { label: t('vocabulary.partOfSpeech'), value: entry.pos.map(entryLabel).join('／') },
-    { label: t('vocabulary.jlptLevel'), value: entryLabel(entry.jlpt) },
-    { label: t('vocabulary.origin'), value: entryLabel(entry.origin) },
-    { label: t('vocabulary.style'), value: entryLabel(entry.style) },
-    { label: t('vocabulary.politeness'), value: entryLabel(entry.politeness) },
-    { label: t('vocabulary.frequency'), value: stars(entry.freq) },
-    { label: t('vocabulary.citationForm'), value: entry.citationForm },
-  ].filter((row) => row.value);
-
-  const usageRows = [
-    { label: t('vocabulary.whenUsed'), value: entry.usage.when },
-    { label: t('vocabulary.translationEquivalent'), value: entry.usage.translation },
-    { label: t('vocabulary.caution'), value: entry.usage.caution },
-  ].filter((row) => row.value);
-
   return (
     <article className="space-y-4">
       {/* Header */}
       <header className="rounded-card bg-card p-5 shadow-panel sm:p-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-full min-w-0">
-            <Ruby
-              headword={entry.headword}
-              reading={entry.reading}
-              className="has-ruby block font-display text-[34px] font-bold [overflow-wrap:anywhere] sm:text-[40px]"
-            />
-            {entry.pitchAccent !== null && (
-              <PitchAccent
-                kana={accentKana(entry.headword, entry.reading)}
-                pitchAccent={entry.pitchAccent}
-                className="mt-2 block font-display text-lg"
-              />
-            )}
-            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
-              <span className="rounded-pill bg-accent-soft px-2.5 py-1 font-semibold text-accent">
-                {entry.jlpt}
-              </span>
-              {entry.pos.map((part) => (
-                <span key={part} className="rounded-pill bg-bg-alt px-2.5 py-1 text-muted">
-                  {entryLabel(part)}
-                </span>
-              ))}
-              <span className="text-accent" title={`${t('vocabulary.frequency')} ${entry.freq}/5`}>
-                {stars(entry.freq)}
-              </span>
-              <span className="text-muted tabular-nums">{entry.learnedOn}</span>
-            </div>
-            {entry.tags.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1.5">
-                {entry.tags.map((tag) => (
-                  <Link
-                    key={tag}
-                    to={`/vocabulary?tag=${encodeURIComponent(tag)}`}
-                    className="text-xs text-accent"
-                  >
-                    #{tag}
-                  </Link>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* Playing the word sits with edit and delete rather than beside the
-              headword: the heading is a block that fills its column, and moving
-              it into a row with a button next to it re-flows the box that
-              `tests/e2e/visual.spec.ts` crops to prove furigana lands above the
-              word it reads. */}
-          <div className="flex shrink-0 items-center gap-2">
-            <SpeakButton status={speechStatus} onSpeak={() => speak(spokenForm(entry))} />
-            <button
-              type="button"
-              onClick={() => setEditing(true)}
-              className="min-h-9 rounded-pill bg-bg-alt px-4 text-xs font-semibold text-ink"
-            >
-              {t('common.edit')}
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirmingDelete(true)}
-              className="min-h-9 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger"
-            >
-              {t('common.delete')}
-            </button>
-          </div>
-        </div>
+        <EntryHeadline
+          entry={entry}
+          actions={
+            <>
+              <SpeakButton status={speechStatus} onSpeak={() => speak(spokenForm(entry))} />
+              <button
+                type="button"
+                onClick={() => setEditing(true)}
+                className="min-h-9 rounded-pill bg-bg-alt px-4 text-xs font-semibold text-ink"
+              >
+                {t('common.edit')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(true)}
+                className="min-h-9 rounded-pill bg-danger-soft px-4 text-xs font-semibold text-danger"
+              >
+                {t('common.delete')}
+              </button>
+            </>
+          }
+        />
 
         {/* Under the whole row rather than under the button: it is a sentence,
             and the button sits in a column sized for pills. */}
         <SpeechStatusNote status={speechStatus} className="mt-3" />
       </header>
 
-      <Section emoji="📋" title={t('vocabulary.manifest')}>
-        <KeyValueTable rows={manifest} />
-      </Section>
-
-      {entry.posInfo && (
-        <Section emoji="🔧" title={entry.posInfo.title}>
-          <KeyValueTable rows={entry.posInfo.rows} />
-        </Section>
-      )}
-
-      {/* The sentence the word was met in comes before the dictionary meaning,
-          matching the markdown notes: 23 of the 24 that record a context put it
-          first. Reading the encounter before the definition is also the order
-          the word was actually learned in. */}
-      {entry.context.original && (
-        <Section emoji="📌" title={t('vocabulary.context')}>
-          <blockquote className="prose-cjk rounded-panel border-l-4 border-accent bg-bg-alt px-4 py-3 text-sm">
-            {entry.context.original}
-          </blockquote>
-          {entry.context.ja && (
-            <p className="prose-cjk mt-4 text-sm whitespace-pre-line">{entry.context.ja}</p>
-          )}
-          {entry.context.translation && (
-            <p className="prose-cjk mt-3 text-sm whitespace-pre-line text-muted">
-              {entry.context.translation}
-            </p>
-          )}
-        </Section>
-      )}
-
-      {(entry.definition || entry.definitionSub) && (
-        <Section emoji="📖" title={t('vocabulary.definition')}>
-          {entry.definition && (
-            <p className="prose-cjk text-sm whitespace-pre-line">{entry.definition}</p>
-          )}
-          {entry.definitionSub && (
-            <p className="prose-cjk mt-4 border-t border-line pt-4 text-sm whitespace-pre-line">
-              {entry.definitionSub}
-            </p>
-          )}
-        </Section>
-      )}
-
-      {entry.senses.length > 0 && (
-        <Section emoji="🌐" title={t('vocabulary.senses')}>
-          <ol className="divide-y divide-line">
-            {entry.senses.map((sense, index) => (
-              <li key={index} className="py-4 first:pt-0 last:pb-0">
-                <h3 className="text-sm font-semibold">
-                  <span className="mr-1.5 text-accent">{circled(index)}</span>
-                  {sense.label}
-                </h3>
-                {sense.description && <p className="prose-cjk mt-2 text-sm">{sense.description}</p>}
-                {sense.example && (
-                  <blockquote className="prose-cjk mt-3 border-l-2 border-line pl-3 text-sm">
-                    {sense.example}
-                    {sense.exampleGloss && (
-                      <span className="block text-xs text-muted">
-                        {t('vocabulary.gloss', { value: sense.exampleGloss })}
-                      </span>
-                    )}
-                  </blockquote>
-                )}
-                {sense.translation && <p className="prose-cjk mt-2 text-sm">{sense.translation}</p>}
-                {sense.usage && (
-                  <p className="prose-cjk mt-2 text-xs text-muted">
-                    {t('vocabulary.usageSituation', { value: sense.usage })}
-                  </p>
-                )}
-              </li>
-            ))}
-          </ol>
-        </Section>
-      )}
-
-      {entry.examples.length > 0 && (
-        <Section emoji="📝" title={t('vocabulary.examples')}>
-          <ol className="divide-y divide-line">
-            {entry.examples.map((example, index) => (
-              <li key={index} className="py-3 first:pt-0 last:pb-0">
-                <p className="prose-cjk text-sm">
-                  <span className="mr-1.5 text-accent">{circled(index)}</span>
-                  {example.ja}
-                </p>
-                {example.translation && (
-                  <p className="prose-cjk mt-1 pl-6 text-sm text-muted">{example.translation}</p>
-                )}
-              </li>
-            ))}
-          </ol>
-        </Section>
-      )}
-
-      {usageRows.length > 0 && (
-        <Section emoji="🗣️" title={t('vocabulary.usage')}>
-          <KeyValueTable rows={usageRows} />
-        </Section>
-      )}
-
-      {entry.related.length > 0 && (
-        <Section emoji="🔗" title={t('vocabulary.related')}>
-          <ul className="divide-y divide-line text-sm">
-            {entry.related.map((related, index) => (
-              <li key={index} className="py-2.5 first:pt-0 last:pb-0">
-                <span className="font-display font-bold">{related.headword}</span>
-                <span className="prose-cjk text-muted"> — {related.note}</span>
-              </li>
-            ))}
-          </ul>
-        </Section>
-      )}
-
-      {entry.source && (
-        <p className="px-1 text-xs text-muted">
-          {t('vocabulary.sourceLine', { source: entry.source })}
-        </p>
-      )}
+      <EntryBody entry={entry} />
 
       <EntryFormModal open={editing} entry={entry} onClose={() => setEditing(false)} />
 

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -79,6 +79,73 @@ export const WORDS = [
 ] satisfies SeedEntry[];
 
 /**
+ * One word with every optional part of a note filled in.
+ *
+ * **Deliberately not in `WORDS`**, for the same reason `OVERSIZE_WORDS` is not:
+ * every committed screenshot is taken against that array.
+ *
+ * `WORDS` records nothing but a definition, so a summary of a note and the whole
+ * note render identically against it — which is how the dialog spent its life
+ * showing one sense and one example with no test able to see the difference.
+ * This is the shape that tells them apart: two senses, two examples, the
+ * sentence the word was met in, the usage notes and a related word.
+ */
+export const DETAILED_WORD = {
+  id: 'w-choukou',
+  headword: '兆候',
+  reading: 'ちょうこう',
+  pitchAccent: 0,
+  definition: '何かが起こる前ぶれ。',
+  definitionSub: '徵兆',
+  citationForm: '兆候',
+  source: 'NHK News',
+  pos: ['名詞'],
+  jlpt: 'N1',
+  origin: '漢語',
+  style: '書き言葉',
+  politeness: '普通',
+  freq: 4,
+  posInfo: { title: '名詞情報', rows: [{ label: 'する動詞化', value: 'しない' }] },
+  context: {
+    original: '景気回復の兆候が見えてきた。',
+    ja: '景気がよくなりはじめた様子が見える。',
+    translation: '經濟復甦的跡象開始浮現。',
+  },
+  senses: [
+    {
+      label: '前触れ',
+      description: '何かが起こる前に現れるしるし。',
+      example: '地震の兆候をとらえる。',
+      exampleGloss: '捕捉地震的前兆',
+      translation: '徵兆',
+      usage: 'ニュースや報告書で',
+    },
+    {
+      label: '症状',
+      description: '病気のはじまりを示すしるし。',
+      example: '回復の兆候が見られる。',
+      exampleGloss: '',
+      translation: '跡象',
+      usage: '',
+    },
+  ],
+  examples: [
+    { ja: '不況の兆候が現れる。', translation: '出現不景氣的徵兆。' },
+    { ja: '春の兆候を感じる。', translation: '感受到春天的氣息。' },
+  ],
+  usage: {
+    when: '悪いことの前触れに使うことが多い。',
+    translation: 'sign, indication',
+    caution: '「症状」とは違い、病気そのものを指さない。',
+  },
+  related: [{ headword: '前兆', note: 'ほぼ同義。より文語的。' }],
+  tags: ['ニュース'],
+  learnedOn: '2026-06-22',
+  createdAt: '2026-06-22T01:00:00.000Z',
+  updatedAt: '2026-06-22T01:00:00.000Z',
+} satisfies SeedEntry;
+
+/**
  * A note whose fields are long enough to break the layout, in the two ways that
  * actually did.
  *

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { INPUT_LIMITS } from '../../src/domain/limits';
-import { seedSignedIn, watchForBlanking } from './fixtures';
+import { DETAILED_WORD, seed, seedSignedIn, watchForBlanking } from './fixtures';
 
 /**
  * The notebook's whole reason to exist: find a word, read it, add one, change
@@ -25,6 +25,12 @@ test.beforeEach(async ({ page }) => {
  */
 const addDialog = (page: Page) => page.getByRole('dialog', { name: '単語を追加' });
 const editDialog = (page: Page) => page.getByRole('dialog', { name: '単語を編集' });
+/**
+ * `exact`, unlike the two above. Playwright matches an accessible name by
+ * substring, so a bare 「単語」 also matches 「単語を編集」 — and an assertion
+ * that the preview is showing would then pass while the edit form is on screen.
+ */
+const previewDialog = (page: Page) => page.getByRole('dialog', { name: '単語', exact: true });
 
 test.describe('browsing', () => {
   test('lists every word, then narrows on a substring', async ({ page }) => {
@@ -136,6 +142,90 @@ test.describe('browsing', () => {
     await page.goBack();
     await expect(page).toHaveURL(/\/vocabulary$/);
     await expect(page.getByText('3 語')).toBeVisible();
+  });
+
+  /**
+   * What the dialog is *for*, seeded against a note that has more than a
+   * definition in it.
+   *
+   * The dialog used to render its own summary — the sense descriptions, one
+   * example, and nothing else — so a word opened from a list dropped the
+   * sentence it was met in, its second meaning, its usage notes and its related
+   * words, all without saying anything was missing. Against `WORDS`, which
+   * record a definition and no more, a summary and the whole note look the
+   * same; `DETAILED_WORD` is what tells them apart.
+   */
+  test('shows the whole note in the dialog, not a summary of it', async ({ page }) => {
+    await seed(page, { signedIn: true, entries: [DETAILED_WORD] });
+    await page.goto('/vocabulary');
+    await page.getByRole('link', { name: /兆候/ }).click();
+
+    const dialog = previewDialog(page);
+    await expect(dialog.getByRole('heading', { name: '概要' })).toBeVisible();
+    // The sentence the word was met in, which the summary had no place for.
+    await expect(dialog.getByText('景気回復の兆候が見えてきた。')).toBeVisible();
+    // The *second* sense and the second example: the summary showed one of each.
+    await expect(dialog.getByText('病気のはじまりを示すしるし。')).toBeVisible();
+    await expect(dialog.getByText('春の兆候を感じる。')).toBeVisible();
+    await expect(dialog.getByText('「症状」とは違い、病気そのものを指さない。')).toBeVisible();
+    // `exact`, or it also matches 「意味：捕捉地震的前兆」 in the sense above it.
+    await expect(dialog.getByText('前兆', { exact: true })).toBeVisible();
+
+    // Still a dialog over the list, not a navigation to the page.
+    await expect(page.getByText('1 語')).toBeVisible();
+    await expect(page).toHaveURL(/\/vocabulary\/w-choukou$/);
+  });
+
+  /**
+   * Editing was deliberately absent here on the grounds that a write would
+   * leave the page underneath stale. It does not: both screens read the same
+   * `EntriesProvider`, and every save ends in its `refresh()`. This is that
+   * claim, measured — the list behind the dialog counts the change without
+   * being navigated to.
+   */
+  test('edits the word from the dialog and the list behind it agrees', async ({ page }) => {
+    await page.goto('/vocabulary');
+    await page.getByRole('link', { name: /兆候/ }).click();
+    await previewDialog(page).getByRole('button', { name: '編集' }).click();
+
+    const form = editDialog(page);
+    // One dialog at a time: the form replaces the preview rather than stacking
+    // a second focus trap and a second Escape listener on top of it.
+    await expect(previewDialog(page)).toBeHidden();
+    await form.getByLabel('意味・説明').fill('起こる前のしるし。');
+    await form.getByRole('button', { name: '保存する' }).click();
+
+    // Back to the preview, reading the entry the save refreshed.
+    await expect(previewDialog(page).getByText('起こる前のしるし。')).toBeVisible();
+
+    // And the list underneath, which was never navigated away from.
+    await page.keyboard.press('Escape');
+    await expect(previewDialog(page)).toBeHidden();
+    await expect(page.getByText('起こる前のしるし。')).toBeVisible();
+    await expect(page.getByText('何かが起こる前ぶれ。')).toBeHidden();
+  });
+
+  /**
+   * Whether the form is open is a fact about *which word* it was opened for,
+   * not a flag. Held as a boolean it survives the dialog closing, and the next
+   * word opened from any list arrives already inside a form nobody asked for.
+   */
+  test('opening another word after leaving the form lands on the preview', async ({ page }) => {
+    await page.goto('/vocabulary');
+    await page.getByRole('link', { name: /兆候/ }).click();
+    await previewDialog(page).getByRole('button', { name: '編集' }).click();
+    await expect(editDialog(page)).toBeVisible();
+
+    // Away from the word entirely, without cancelling the form first.
+    await page.goBack();
+    await expect(editDialog(page)).toBeHidden();
+
+    // ちょっと and not 切り分け: a card's accessible name interleaves the ruby
+    // reading with the word, so 切り分け reads as 「切きりり分わけ」 and no
+    // regex over the headword alone matches it.
+    await page.getByRole('link', { name: /ちょっと/ }).click();
+    await expect(previewDialog(page)).toBeVisible();
+    await expect(editDialog(page)).toBeHidden();
   });
 
   test('says so plainly when nothing matches', async ({ page }) => {


### PR DESCRIPTION
## Summary
- The preview dialog rendered its own summary of a word — sense descriptions, one
  example, and nothing else — so a word opened from a list silently dropped the
  sentence it was met in, its second meaning, its usage notes, its related words
  and its source. It now renders the same content the detail page does.
- `EntryHeadline` and `EntryBody` are extracted from `EntryDetail.tsx` and used
  by both screens, so the two cannot drift apart again. The only thing the dialog
  varies is `Section`'s new `surface="panel"`: the dialog body is already
  `bg-card`, so a card-on-card has no visible edge and the boundary is drawn with
  a border instead. `circled` and `stars` move to `src/lib/entryFormat.ts`.
- The dialog gains an edit button. The comment that said editing was deliberately
  absent rested on a premise that does not hold: both screens read the same
  `EntriesProvider` and every save ends in its `refresh()`, so the list underneath
  reflects the change. Deleting is still absent — it would leave the dialog over a
  word that no longer exists.
- The form replaces the preview rather than opening on top of it: two `Modal`s
  are two focus traps and two Escape listeners over one keystroke. Which word the
  form is open for is held as an id rather than a boolean, so a form left open
  when the dialog closes cannot greet the next word opened from any list.

## Test layer and why
End-to-end (`tests/e2e/vocabulary.spec.ts`). The claims span the router, the URL
the dialog pushes by hand, `EntriesProvider` and the form — and a component test
cannot render `EntriesProvider` at all, since it resolves its repository through
`@/lib/backend` and tests may not import `@/infra/*`. Nothing here is pure logic.

That blocker covers all three cases, including the least obvious one. The
edit-state reset test looks like a claim about one component's state, but the
state is only reachable through `VocabDialog`, which calls `useEntries()` — and
what makes it wrong is a `popstate` closing the dialog while the form is up,
which needs real history. Router, provider and form again, not one component.

A new fixture, `DETAILED_WORD`, carries two senses, two examples, a context
sentence, usage notes and a related word. It is deliberately **not** added to
`WORDS`: every committed screenshot is taken against that array. Against `WORDS`,
which record a definition and no more, a summary and the whole note render
identically — which is how this defect survived.

## Proving the tests fail
Reverted `src/components/VocabDialog.tsx` alone to its previous state, keeping the
extracted components so the detail page still built, and re-ran. Exactly the three
new tests went red and only those:
- `shows the whole note in the dialog, not a summary of it` — no `概要` heading in
  the dialog
- `edits the word from the dialog and the list behind it agrees` — no `編集` button
- `opening another word after leaving the form lands on the preview` — same

The four pre-existing dialog tests stayed green. Restored and re-ran: all pass.

## Test plan
- [x] `yarn test:unit` — 807 passed
- [x] `yarn test:emulator` — 81 passed
- [x] `yarn test:e2e` — 154 passed, 18 skipped (screenshot baselines are Linux-only)
- [x] `yarn typecheck`, `yarn lint` (0 errors), `yarn format` — no drift
- [x] Screenshotted the dialog at both scroll positions and read the images: furigana
      above the headword, pitch line, JLPT/part-of-speech/frequency/date row, tag,
      speak and 編集 buttons, then the bordered panels down to `出典：NHK News`.

No screenshot baseline is added or changed. The detail page's markup is unchanged
by the extraction — same elements, same classes, same nesting — so
`furigana-heading.png` and `pitch-accent.png` compare against the same rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2KUMyVLmbRZNAhj6hKGDv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent vocabulary entry layout across detail pages and preview dialogs.
  - Entry views now display richer information, including definitions, examples, usage notes, related entries, metadata, tags, and source details.
  - Added editing directly from vocabulary preview dialogs, with clear transitions between viewing and editing.
  - Improved dialog layouts with compact headings, action controls, and adaptable section styling.

- **Improvements**
  - Standardized note numbering and frequency-star display for clearer, more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
