### PR TITLE
fix(profile): bound a persisted nickname by the product limit, not the rules limit

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -11,6 +11,7 @@ import type {
   Sense,
   UsageNotes,
 } from '@/domain/entry';
+import { USER_LIMITS } from '@/domain/limits';
 import { PRACTICE_MODES } from '@/domain/practice';
 import type { EntryProgress, PracticeSession } from '@/domain/practice';
 import { THEME_PREFERENCES, TRANSLATION_LANGUAGES, UI_LANGUAGES } from '@/domain/user';
@@ -252,7 +253,11 @@ export function sanitizeUserProfile(uid: string, data: unknown): UserProfile {
   const raw = record(data);
   return {
     uid,
-    nickname: str(raw.nickname).trim().slice(0, 50),
+    // The rules bound this at 50, deliberately wider than the product's own
+    // limit, so a longer value can already be stored. Everything downstream —
+    // the avatar initial, the header, the settings field — assumes the product
+    // limit, so this is where the two have to agree.
+    nickname: str(raw.nickname).trim().slice(0, USER_LIMITS.nickname),
     language: oneOf(raw.language, UI_LANGUAGES, 'en'),
     translationLanguage: oneOf(raw.translationLanguage, TRANSLATION_LANGUAGES, 'en'),
     theme: oneOf(raw.theme, THEME_PREFERENCES, 'system'),

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -257,7 +257,15 @@ export function sanitizeUserProfile(uid: string, data: unknown): UserProfile {
     // limit, so a longer value can already be stored. Everything downstream —
     // the avatar initial, the header, the settings field — assumes the product
     // limit, so this is where the two have to agree.
-    nickname: str(raw.nickname).trim().slice(0, USER_LIMITS.nickname),
+    //
+    // The slice is by UTF-16 code unit, same as the limit, so a cut landing
+    // inside a surrogate pair leaves a lone high surrogate — not a character,
+    // and unencodable as UTF-8 — as the last unit. `ellipsise` in practice.ts
+    // drops the same orphan for the same reason.
+    nickname: str(raw.nickname)
+      .trim()
+      .slice(0, USER_LIMITS.nickname)
+      .replace(/[\uD800-\uDBFF]$/u, ''),
     language: oneOf(raw.language, UI_LANGUAGES, 'en'),
     translationLanguage: oneOf(raw.translationLanguage, TRANSLATION_LANGUAGES, 'en'),
     theme: oneOf(raw.theme, THEME_PREFERENCES, 'system'),

--- a/src/lib/userPreferences.ts
+++ b/src/lib/userPreferences.ts
@@ -45,8 +45,14 @@ export function defaultUserProfile(
       before the user has opened the form. Truncated rather than refused,
       because refusing would mean an account that cannot be created over a name
       the user did not choose and is free to change.
+      A provider display name can end in an emoji outside the BMP, so the slice
+      below drops a trailing lone high surrogate the same way `sanitizeUserProfile`
+      does, rather than leaving one behind at the cut.
     */
-    nickname: nickname.trim().slice(0, USER_LIMITS.nickname),
+    nickname: nickname
+      .trim()
+      .slice(0, USER_LIMITS.nickname)
+      .replace(/[\uD800-\uDBFF]$/u, ''),
     language,
     translationLanguage: language,
     theme,

--- a/tests/unit/userSettings.test.ts
+++ b/tests/unit/userSettings.test.ts
@@ -47,6 +47,19 @@ describe('defaultUserProfile', () => {
       USER_LIMITS.nickname,
     );
   });
+
+  /**
+   * A provider display name that ends in an emoji can have that emoji straddle
+   * the truncation boundary. `slice` counts UTF-16 code units, so cutting
+   * inside the pair leaves a lone high surrogate — not a character, and not
+   * encodable as UTF-8 — as the last unit of a name shown right after sign-in.
+   */
+  it('drops a trailing lone high surrogate instead of splitting an astral display name', () => {
+    const straddling = `${'ゆ'.repeat(USER_LIMITS.nickname - 1)}😀`;
+    expect(defaultUserProfile('u1', straddling, ['ja'], null).nickname).toBe(
+      'ゆ'.repeat(USER_LIMITS.nickname - 1),
+    );
+  });
 });
 
 describe('sanitizeUserProfile', () => {
@@ -85,6 +98,19 @@ describe('sanitizeUserProfile', () => {
     const stored = 'ゆ'.repeat(USER_LIMITS.nickname + 15);
     expect(sanitizeUserProfile('u1', { nickname: stored }).nickname).toBe(
       stored.slice(0, USER_LIMITS.nickname),
+    );
+  });
+
+  /**
+   * Same hazard as `defaultUserProfile`, reached through the persisted path
+   * instead of the provider display name: a stored nickname ending in an emoji
+   * that straddles the product limit must not come back with a lone high
+   * surrogate as its last unit.
+   */
+  it('drops a trailing lone high surrogate instead of splitting an astral nickname', () => {
+    const straddling = `${'ゆ'.repeat(USER_LIMITS.nickname - 1)}😀`;
+    expect(sanitizeUserProfile('u1', { nickname: straddling }).nickname).toBe(
+      'ゆ'.repeat(USER_LIMITS.nickname - 1),
     );
   });
 

--- a/tests/unit/userSettings.test.ts
+++ b/tests/unit/userSettings.test.ts
@@ -83,8 +83,8 @@ describe('sanitizeUserProfile', () => {
    */
   it('brings a stored nickname the rules still allow down to the product limit', () => {
     const stored = 'ゆ'.repeat(USER_LIMITS.nickname + 15);
-    expect(sanitizeUserProfile('u1', { nickname: stored }).nickname).toHaveLength(
-      USER_LIMITS.nickname,
+    expect(sanitizeUserProfile('u1', { nickname: stored }).nickname).toBe(
+      stored.slice(0, USER_LIMITS.nickname),
     );
   });
 

--- a/tests/unit/userSettings.test.ts
+++ b/tests/unit/userSettings.test.ts
@@ -72,6 +72,22 @@ describe('sanitizeUserProfile', () => {
     ).toMatchObject({ language: 'en', translationLanguage: 'yue-Hant' });
   });
 
+  /**
+   * `firestore.rules` bounds a nickname at 50 characters, deliberately wider
+   * than the product's own 30, so a 31-50 character value can already be in
+   * the database — written before this limit existed, or by any path that is
+   * not the settings form. Reading one back has to bring it down to the limit
+   * every other part of the app assumes, or the avatar initial, the header and
+   * the settings field are all working from a ceiling the sanitizer does not
+   * actually hold.
+   */
+  it('brings a stored nickname the rules still allow down to the product limit', () => {
+    const stored = 'ゆ'.repeat(USER_LIMITS.nickname + 15);
+    expect(sanitizeUserProfile('u1', { nickname: stored }).nickname).toHaveLength(
+      USER_LIMITS.nickname,
+    );
+  });
+
   it('coerces stale or unsupported settings without admitting Simplified Chinese', () => {
     expect(
       sanitizeUserProfile('u1', {


### PR DESCRIPTION
## Summary
- `sanitizeUserProfile` truncated a persisted nickname to 50 characters (the Firestore rules bound), not `USER_LIMITS.nickname` (30, the product limit). A 31-50 character value — written before this limit existed, or by any path other than the settings form — loaded into application state as "valid" while every other surface (avatar initial, header, settings field) assumes 30.
- Now slices to `USER_LIMITS.nickname`, matching the product's own constant. The rules bound stays wider deliberately.

## Test plan
- Layer: `tests/unit`, per CLAUDE.md — the claim is a function of its inputs.
- Added a test reproducing the defect (nickname stored at 45 chars, rules-allowed but over the product limit); confirmed it failed against the old code (`expected length 30 but got 45`) before applying the fix.
- `yarn test:unit` — 819 passed.
- `yarn typecheck` — clean.
- `yarn format` — no drift.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2KUMyVLmbRZNAhj6hKGDv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nicknames are now consistently truncated to the product’s defined character limit, preventing overly long stored nicknames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->