### PR TITLE
test(e2e): wait for row additions to settle

### DIFF
--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -225,13 +225,10 @@ test.describe('word sets', () => {
     await page.mouse.click(first.x + first.width / 2, first.y + first.height / 2);
     await page.mouse.click(second.x + second.width / 2, second.y + second.height / 2);
 
-    await expect
-      .poll(async () => ({
-        count: (await memberHrefs(page)).length,
-        writeComplete: await addButtons.first().isEnabled(),
-      }))
-      .toEqual({ count: 2, writeComplete: true });
+    await expect(addButtons.first()).toBeEnabled();
     const hrefs = await memberHrefs(page);
+    expect(hrefs.length).toBeGreaterThanOrEqual(1);
+    expect(hrefs.length).toBeLessThanOrEqual(2);
     expect(new Set(hrefs).size).toBe(hrefs.length);
 
     await page.reload();

--- a/tests/e2e/wordsets.spec.ts
+++ b/tests/e2e/wordsets.spec.ts
@@ -225,11 +225,14 @@ test.describe('word sets', () => {
     await page.mouse.click(first.x + first.width / 2, first.y + first.height / 2);
     await page.mouse.click(second.x + second.width / 2, second.y + second.height / 2);
 
-    await expect.poll(async () => (await memberHrefs(page)).length).toBeGreaterThanOrEqual(1);
+    await expect
+      .poll(async () => ({
+        count: (await memberHrefs(page)).length,
+        writeComplete: await addButtons.first().isEnabled(),
+      }))
+      .toEqual({ count: 2, writeComplete: true });
     const hrefs = await memberHrefs(page);
-    expect(hrefs.length).toBeLessThanOrEqual(2);
     expect(new Set(hrefs).size).toBe(hrefs.length);
-    await expect(addButtons.first()).toBeEnabled();
 
     await page.reload();
     await expect(memberOrder(page)).toHaveCount(hrefs.length);


### PR DESCRIPTION
Fixes #111

## Summary

Wait for both delayed row-add writes to finish and refresh before capturing the member list for the reload durability assertion.

## Changes

- Poll for both expected members and an enabled row-add button, which represents the write queue returning to idle.
- Capture the member list only after the settled state, then compare the reloaded list against it.

## Testing

**End-to-end:**

- `yarn playwright test tests/e2e/wordsets.spec.ts --grep 'keeps rapid row additions unique and durable'` (not run: local Chromium browser binary is not installed)\n- `yarn format`\n- `yarn typecheck`\n\nThis is an end-to-end test because the regression spans delayed repository writes, the busy UI state, provider refresh, and persistence across reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the rapid row-addition end-to-end test to use exactly two unique members.
  * Improved test reliability by waiting for the add operation to complete before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->