### PR TITLE
test(e2e): wait for notices before measuring panels

### DIFF
--- a/tests/e2e/notices.spec.ts
+++ b/tests/e2e/notices.spec.ts
@@ -74,16 +74,15 @@ test.describe('the bottom of the viewport', () => {
 
       for (const width of WIDTHS) {
         await page.setViewportSize({ width, height: 900 });
+        const expectedPanels = [
+          'notice',
+          ...(updateWaiting ? ['prompt'] : []),
+          ...(width < 700 ? ['add'] : []),
+        ].sort();
+        await expect
+          .poll(async () => (await boxesOf(panels)).map(([name]) => name).sort())
+          .toEqual(expectedPanels);
         const boxes = await boxesOf(panels);
-
-        // Guards the measurement itself. Every assertion below passes
-        // vacuously against an empty list, and an empty list is exactly what a
-        // renamed string or a seed that stopped working would produce — the
-        // pill hid the add button for as long as it did partly because nothing
-        // had ever looked at the two together.
-        expect(boxes.map(([name]) => name)).toContain('notice');
-        if (updateWaiting) expect(boxes.map(([name]) => name)).toContain('prompt');
-        if (width < 700) expect(boxes.map(([name]) => name)).toContain('add');
 
         for (let i = 0; i < boxes.length; i++) {
           for (let j = i + 1; j < boxes.length; j++) {

--- a/tests/e2e/notices.spec.ts
+++ b/tests/e2e/notices.spec.ts
@@ -79,6 +79,9 @@ test.describe('the bottom of the viewport', () => {
           ...(updateWaiting ? ['prompt'] : []),
           ...(width < 700 ? ['add'] : []),
         ].sort();
+        // Wait until each visible UI panel can be measured; otherwise the
+        // overlap checks can run before the offline notice, update prompt, or
+        // mobile add button has rendered.
         await expect
           .poll(async () => (await boxesOf(panels)).map(([name]) => name).sort())
           .toEqual(expectedPanels);


### PR DESCRIPTION
## Summary
- wait for every expected fixed panel before taking geometry measurements
- remove the one-shot presence assertions now covered by the poll

## Why E2E
The regression depends on the offline browser event, the asynchronous update-port callback, viewport resizing, and fixed-position layout interacting in one page.

## Verification
- yarn playwright test tests/e2e/notices.spec.ts
- yarn format
- yarn typecheck
- yarn test:unit

Fixes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport testing reliability by waiting for all expected panels to appear before checking their layout and overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->