### PR TITLE
fix(update): surface a failed activation instead of discarding the rejection

### DIFF
--- a/src/components/UpdatePrompt.tsx
+++ b/src/components/UpdatePrompt.tsx
@@ -19,7 +19,7 @@ import { useAppUpdate } from '@/lib/appUpdateContext';
  */
 export function UpdatePrompt() {
   const { t } = useI18n();
-  const { updateReady, activate } = useAppUpdate();
+  const { updateReady, activate, activateFailed } = useAppUpdate();
   const [dismissed, setDismissed] = useState(false);
 
   if (!updateReady || dismissed) return null;
@@ -35,6 +35,13 @@ export function UpdatePrompt() {
     >
       <p className="text-sm font-semibold text-ink">{t('update.available')}</p>
       <p className="prose-cjk mt-1 text-xs text-muted">{t('update.hint')}</p>
+      {/*
+        The one path a failed `activate()` has to reach the reader. It does not
+        replace the page, so without this the banner stays exactly as it was
+        before the click — offering the same button, with nothing to say it was
+        already tried and failed.
+      */}
+      {activateFailed && <p className="prose-cjk mt-1 text-xs text-danger">{t('update.failed')}</p>}
       <div className="mt-3 flex items-center justify-end gap-2">
         <button
           type="button"

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -63,6 +63,7 @@ const en = {
   'update.hint': 'Updating reloads the app, so finish anything you are typing first.',
   'update.action': 'Update now',
   'update.later': 'Later',
+  'update.failed': 'Could not update automatically. Reload the page to get the new version.',
 } as const;
 
 type BaseMessageKey = keyof typeof en;
@@ -126,6 +127,8 @@ const ja: Messages = {
   'update.hint': '更新するとアプリを読み込み直します。入力中の内容は先に保存してください。',
   'update.action': '今すぐ更新',
   'update.later': 'あとで',
+  'update.failed':
+    '自動更新に失敗しました。ページを再読み込みして新しいバージョンを取得してください。',
 };
 
 const zhHant: Messages = {
@@ -185,6 +188,7 @@ const zhHant: Messages = {
   'update.hint': '更新會重新載入應用程式，請先完成正在輸入的內容。',
   'update.action': '立即更新',
   'update.later': '稍後',
+  'update.failed': '無法自動更新，請重新載入頁面以取得新版本。',
 };
 
 const ko: Messages = {
@@ -245,6 +249,7 @@ const ko: Messages = {
   'update.hint': '업데이트하면 앱을 다시 불러옵니다. 입력 중인 내용을 먼저 저장하세요.',
   'update.action': '지금 업데이트',
   'update.later': '나중에',
+  'update.failed': '자동 업데이트에 실패했습니다. 페이지를 새로고침하여 새 버전을 받아오세요.',
 };
 
 const es: Messages = {
@@ -305,6 +310,8 @@ const es: Messages = {
   'update.hint': 'Al actualizar se recarga la aplicación. Termina antes lo que estés escribiendo.',
   'update.action': 'Actualizar ahora',
   'update.later': 'Más tarde',
+  'update.failed':
+    'No se pudo actualizar automáticamente. Recarga la página para obtener la nueva versión.',
 };
 
 const allMessages = {

--- a/src/lib/appUpdate.tsx
+++ b/src/lib/appUpdate.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import type { AppUpdatePort } from '@/domain/ports';
 import { AppUpdateContext } from './appUpdateContext';
 
@@ -34,6 +34,12 @@ export function AppUpdateProvider({
 }) {
   const [updateReady, setUpdateReady] = useState(false);
   const [activateFailed, setActivateFailed] = useState(false);
+  // The button is not disabled between clicks, so a second attempt can start
+  // before the first has settled — and, being a `Promise`, has no guarantee of
+  // settling in the order the attempts were made. A late rejection from a
+  // superseded attempt must not overwrite the outcome of a later one, so each
+  // attempt is tagged and a rejection only counts if its tag is still current.
+  const activationAttempt = useRef(0);
 
   useEffect(() => {
     // `onWaiting` replays a build that was already waiting when this mounted,
@@ -42,10 +48,12 @@ export function AppUpdateProvider({
   }, [port]);
 
   const activate = useCallback(() => {
+    const attempt = ++activationAttempt.current;
     // Cleared up front rather than only on success, so a second click retries
     // cleanly instead of a transient failure staying on screen forever.
     setActivateFailed(false);
     port.activate().catch((error: unknown) => {
+      if (attempt !== activationAttempt.current) return;
       // The page was never replaced, so this is the one place a failed
       // activation is observable at all — nothing else logs it.
       console.error('AppUpdateProvider: activation failed', error);

--- a/src/lib/appUpdate.tsx
+++ b/src/lib/appUpdate.tsx
@@ -33,6 +33,7 @@ export function AppUpdateProvider({
   children: ReactNode;
 }) {
   const [updateReady, setUpdateReady] = useState(false);
+  const [activateFailed, setActivateFailed] = useState(false);
 
   useEffect(() => {
     // `onWaiting` replays a build that was already waiting when this mounted,
@@ -41,11 +42,19 @@ export function AppUpdateProvider({
   }, [port]);
 
   const activate = useCallback(() => {
-    void port.activate();
+    // Cleared up front rather than only on success, so a second click retries
+    // cleanly instead of a transient failure staying on screen forever.
+    setActivateFailed(false);
+    port.activate().catch((error: unknown) => {
+      // The page was never replaced, so this is the one place a failed
+      // activation is observable at all — nothing else logs it.
+      console.error('AppUpdateProvider: activation failed', error);
+      setActivateFailed(true);
+    });
   }, [port]);
 
   return (
-    <AppUpdateContext.Provider value={{ updateReady, activate }}>
+    <AppUpdateContext.Provider value={{ updateReady, activate, activateFailed }}>
       {children}
     </AppUpdateContext.Provider>
   );

--- a/src/lib/appUpdateContext.ts
+++ b/src/lib/appUpdateContext.ts
@@ -10,6 +10,12 @@ export interface AppUpdateValue {
   updateReady: boolean;
   /** Hand over to it. The page is replaced, so nothing follows this. */
   activate: () => void;
+  /**
+   * The most recent `activate()` call rejected instead of replacing the page.
+   * Cleared at the start of the next attempt, so a retry that succeeds does
+   * not leave a stale failure on screen.
+   */
+  activateFailed: boolean;
 }
 
 export const AppUpdateContext = createContext<AppUpdateValue | null>(null);

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -1,5 +1,5 @@
-import { act, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { UpdatePrompt } from '@/components/UpdatePrompt';
 import type { AppUpdatePort } from '@/domain/ports';
 import { AppUpdateProvider } from '@/lib/appUpdate';
@@ -32,6 +32,28 @@ function testPort() {
   };
 }
 
+/**
+ * A worker whose `activate()` rejects a fixed number of times before
+ * succeeding — 0 for "always succeeds", `Infinity` for "always fails".
+ */
+function unreliablePort(failuresBeforeSuccess: number) {
+  const listeners = new Set<() => void>();
+  let attempts = 0;
+  const port: AppUpdatePort = {
+    onWaiting(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    activate() {
+      attempts += 1;
+      return attempts <= failuresBeforeSuccess
+        ? Promise.reject(new Error('activation failed'))
+        : Promise.resolve();
+    },
+  };
+  return { port, announceWaitingBuild: () => act(() => listeners.forEach((fn) => fn())) };
+}
+
 const mount = (port: AppUpdatePort) =>
   render(
     <AppUpdateProvider port={port}>
@@ -40,6 +62,7 @@ const mount = (port: AppUpdatePort) =>
   );
 
 const updateButton = () => screen.getByRole('button', { name: '今すぐ更新' });
+const FAILED = '自動更新に失敗しました。ページを再読み込みして新しいバージョンを取得してください。';
 
 describe('UpdatePrompt', () => {
   it('says nothing until a build is actually waiting, so nobody is offered the build they are already on', () => {
@@ -110,5 +133,47 @@ describe('UpdatePrompt', () => {
     // if someone reaches for `alert` — cuts into the dictation answer being
     // typed, which is the one moment this can arrive.
     expect(screen.getByRole('status')).toHaveTextContent('新しいバージョンがあります');
+  });
+
+  /**
+   * `activate()` never replaces the page on this path — the rejection is the
+   * only thing that happened — so a reader who clicked and got nothing back
+   * needs the banner itself to say so, or the click reads as having done
+   * nothing at all.
+   */
+  it('tells the reader activation failed instead of leaving the button looking inert', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const worker = unreliablePort(Infinity);
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    act(() => updateButton().click());
+
+    expect(await screen.findByText(FAILED)).toBeInTheDocument();
+  });
+
+  /**
+   * The failure is cleared at the start of the next attempt, not only on
+   * success, so a reader who retries and this time gets through is not left
+   * looking at an error banner above a page that is about to reload anyway.
+   */
+  it('clears the failure message on the next attempt', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const worker = unreliablePort(1);
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    act(() => updateButton().click());
+    expect(await screen.findByText(FAILED)).toBeInTheDocument();
+
+    act(() => updateButton().click());
+
+    await waitFor(() => expect(screen.queryByText(FAILED)).not.toBeInTheDocument());
+  });
+
+  // Restores unconditionally, so a failed assertion above can't leak the
+  // `console.error` mock into whichever test runs next.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 });

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -2,6 +2,7 @@ import { act, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { UpdatePrompt } from '@/components/UpdatePrompt';
 import type { AppUpdatePort } from '@/domain/ports';
+import { messages } from '@/i18n/messages';
 import { AppUpdateProvider } from '@/lib/appUpdate';
 import { renderWithI18n as render } from '../fixtures/renderWithI18n';
 
@@ -94,7 +95,9 @@ const mount = (port: AppUpdatePort) =>
   );
 
 const updateButton = () => screen.getByRole('button', { name: '今すぐ更新' });
-const FAILED = '自動更新に失敗しました。ページを再読み込みして新しいバージョンを取得してください。';
+// From the catalogue rather than spelled out, so a reworded translation moves
+// this test with it instead of failing it over copy nobody here changed.
+const FAILED = messages.ja['update.failed'];
 
 describe('UpdatePrompt', () => {
   it('says nothing until a build is actually waiting, so nobody is offered the build they are already on', () => {

--- a/tests/component/UpdatePrompt.test.tsx
+++ b/tests/component/UpdatePrompt.test.tsx
@@ -54,6 +54,38 @@ function unreliablePort(failuresBeforeSuccess: number) {
   return { port, announceWaitingBuild: () => act(() => listeners.forEach((fn) => fn())) };
 }
 
+/**
+ * A worker whose `activate()` never settles on its own — the caller settles
+ * each call in turn, in whatever order the test needs.
+ */
+function deferredPort() {
+  const listeners = new Set<() => void>();
+  const pending: { resolve: () => void; reject: (error: Error) => void }[] = [];
+  const port: AppUpdatePort = {
+    onWaiting(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    activate() {
+      return new Promise<void>((resolve, reject) => {
+        pending.push({ resolve, reject });
+      });
+    },
+  };
+  return { port, pending, announceWaitingBuild: () => act(() => listeners.forEach((fn) => fn())) };
+}
+
+/**
+ * `noUncheckedIndexedAccess` makes `pending[i]` possibly `undefined`. A silent
+ * `?.` would let the test pass vacuously if a click somehow failed to reach
+ * the port, so this throws instead of hiding that.
+ */
+function nth<T>(items: readonly T[], index: number): T {
+  const item = items[index];
+  if (!item) throw new Error(`expected an item at index ${index}, got ${items.length} total`);
+  return item;
+}
+
 const mount = (port: AppUpdatePort) =>
   render(
     <AppUpdateProvider port={port}>
@@ -169,6 +201,34 @@ describe('UpdatePrompt', () => {
     act(() => updateButton().click());
 
     await waitFor(() => expect(screen.queryByText(FAILED)).not.toBeInTheDocument());
+  });
+
+  /**
+   * The button is not disabled between clicks, so a reader who clicks twice
+   * starts a second attempt before the first has settled — and a `Promise`
+   * carries no guarantee it settles in the order it was created. A late
+   * rejection from the first click must not overwrite the outcome of the
+   * second, already-successful one.
+   */
+  it('ignores a stale rejection from an attempt a later one has already superseded', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const worker = deferredPort();
+    mount(worker.port);
+    worker.announceWaitingBuild();
+
+    act(() => updateButton().click());
+    act(() => updateButton().click());
+
+    await act(async () => {
+      nth(worker.pending, 1).resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      nth(worker.pending, 0).reject(new Error('stale, superseded activation'));
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(FAILED)).not.toBeInTheDocument();
   });
 
   // Restores unconditionally, so a failed assertion above can't leak the


### PR DESCRIPTION
## Summary
- `AppUpdateProvider.activate` called `port.activate()` with `void`, discarding the returned promise. A rejected activation produced an unhandled rejection and `updateReady` stayed `true` — the prompt kept offering the same button with nothing to say it had already been tried and failed.
- `activate` now catches the rejection, logs it, and reflects it as `activateFailed` on the context. `UpdatePrompt` renders that as an error message (new `update.failed` i18n key, all 5 locales) telling the reader to reload manually. The failure clears at the start of the next attempt, so a retry that succeeds doesn't leave a stale error on screen.

## Test plan
- Layer: `tests/component`, per CLAUDE.md — the claim is about what `UpdatePrompt` renders.
- Added two regression tests: activation failure surfaces the error message, and a successful retry clears it. Confirmed both failed against the unfixed code first — including the exact unhandled-rejection error this issue describes — with the pre-existing 5 tests unaffected, before restoring the fix.
- `yarn test:unit` — 824 passed.
- `yarn typecheck` — clean (also confirms all 5 locales carry the new `update.failed` key, enforced by the `Messages` type).
- `yarn lint` — 0 errors.
- `yarn format` — no drift.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D2KUMyVLmbRZNAhj6hKGDv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a localized error message when an automatic update fails to activate.
  * Users are instructed to reload the page after an activation failure.
  * Retrying an update clears the previous failure message.
  * Existing update activation and dismissal controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->