### PR TITLE
fix(dashboard): re-pin heatmap after viewport shrink

### DIFF
--- a/src/components/dashboard/Heatmap.tsx
+++ b/src/components/dashboard/Heatmap.tsx
@@ -132,6 +132,14 @@ export function Heatmap({
     return result;
   }, [countsByDay]);
 
+  const pinLatestWeek = useCallback(() => {
+    const node = scrollerRef.current;
+    if (!node || pinned.current) return;
+    if (node.scrollWidth <= node.clientWidth) return;
+    node.scrollLeft = node.scrollWidth;
+    pinned.current = true;
+  }, []);
+
   /**
    * The year runs oldest to newest, so on a viewport too narrow to show all
    * fifty-three columns the browser opens on the *oldest* weeks and today sits
@@ -141,15 +149,24 @@ export function Heatmap({
    * Before paint, so the reader never sees last August first. Once per mount:
    * `weeks` is rebuilt whenever an entry is added, and re-pinning there would
    * yank someone who had deliberately scrolled back into their history. When
-   * nothing overflows, `scrollLeft` clamps to 0 and this is a no-op.
+   * nothing overflows, leave the scroller unpinned so a later viewport shrink
+   * can still move the newly overflowing year to today.
    */
   useLayoutEffect(() => {
+    pinLatestWeek();
+  }, [pinLatestWeek, weeks]);
+
+  useEffect(() => {
     const node = scrollerRef.current;
     if (!node || pinned.current) return;
-    if (node.scrollWidth <= node.clientWidth) return;
-    node.scrollLeft = node.scrollWidth;
-    pinned.current = true;
-  }, [weeks]);
+
+    const observer = new ResizeObserver(() => {
+      pinLatestWeek();
+      if (pinned.current) observer.disconnect();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [pinLatestWeek, weeks]);
 
   return (
     <section className="rounded-card bg-card p-5 shadow-panel">

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -43,4 +43,73 @@ test.describe('dashboard', () => {
     expect(cell!.x).toBeGreaterThanOrEqual(box!.x);
     expect(cell!.x + cell!.width).toBeLessThanOrEqual(box!.x + box!.width);
   });
+
+  test('re-pins the heatmap to today when a wide viewport becomes narrow', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await seedSignedIn(page);
+    await page.goto('/');
+
+    const today = page.getByRole('button', { name: /2026年6月24日/ });
+    await expect(today).toBeVisible();
+
+    const scroller = page.locator('section div.overflow-x-auto').first();
+    await expect
+      .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth))
+      .toBeLessThanOrEqual(0);
+
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    await expect
+      .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth), {
+        message: 'the resize must make the year overflow, or nothing is being tested',
+      })
+      .toBeGreaterThan(0);
+
+    await expect
+      .poll(async () => {
+        const [cell, box] = await Promise.all([today.boundingBox(), scroller.boundingBox()]);
+        if (!cell || !box) return false;
+        return cell.x >= box.x && cell.x + cell.width <= box.x + box.width;
+      })
+      .toBe(true);
+  });
+
+  test('keeps a manually scrolled heatmap on older weeks during later resize', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await seedSignedIn(page);
+    await page.goto('/');
+
+    const today = page.getByRole('button', { name: /2026年6月24日/ });
+    await expect(today).toBeVisible();
+
+    const scroller = page.locator('section div.overflow-x-auto').first();
+    await expect
+      .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth))
+      .toBeGreaterThan(0);
+
+    const pinnedOffset = await scroller.evaluate((node) => node.scrollLeft);
+    expect(
+      pinnedOffset,
+      'the narrow viewport must initially pin to the newest week',
+    ).toBeGreaterThan(0);
+
+    await scroller.evaluate((node) => {
+      node.scrollLeft = 0;
+    });
+    await expect.poll(async () => scroller.evaluate((node) => node.scrollLeft)).toBe(0);
+
+    const clientWidth = await scroller.evaluate((node) => node.clientWidth);
+    await scroller.evaluate((node) => {
+      node.style.maxWidth = `${Math.max(1, node.clientWidth - 24)}px`;
+    });
+    await expect
+      .poll(async () => scroller.evaluate((node) => node.clientWidth))
+      .toBeLessThan(clientWidth);
+
+    await expect
+      .poll(async () => scroller.evaluate((node) => node.scrollLeft), {
+        message: "a later reflow must not undo the reader's manual scroll",
+      })
+      .toBe(0);
+  });
 });

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -53,18 +53,24 @@ test.describe('dashboard', () => {
     await expect(today).toBeVisible();
 
     const scroller = page.locator('section div.overflow-x-auto').first();
+    // Start from the desktop state that hides the bug from users: the whole
+    // year fits, so the heatmap has no reason to pin itself yet.
     await expect
       .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth))
       .toBeLessThanOrEqual(0);
 
     await page.setViewportSize({ width: 375, height: 667 });
 
+    // Prove the viewport change creates the user-visible risk: today can now
+    // sit off-screen to the right unless the heatmap pins itself.
     await expect
       .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth), {
         message: 'the resize must make the year overflow, or nothing is being tested',
       })
       .toBeGreaterThan(0);
 
+    // The user-facing outcome is today being visible without manually dragging
+    // the horizontal scroller after rotating or narrowing the viewport.
     await expect
       .poll(async () => {
         const [cell, box] = await Promise.all([today.boundingBox(), scroller.boundingBox()]);
@@ -83,11 +89,15 @@ test.describe('dashboard', () => {
     await expect(today).toBeVisible();
 
     const scroller = page.locator('section div.overflow-x-auto').first();
+    // The preservation check only matters in the phone-width layout where a
+    // reader can scroll away from today into older weeks.
     await expect
       .poll(async () => scroller.evaluate((node) => node.scrollWidth - node.clientWidth))
       .toBeGreaterThan(0);
 
     const pinnedOffset = await scroller.evaluate((node) => node.scrollLeft);
+    // First prove the normal mobile load still opens on today; otherwise the
+    // manual scroll below would not represent a reader leaving the latest week.
     expect(
       pinnedOffset,
       'the narrow viewport must initially pin to the newest week',
@@ -96,16 +106,22 @@ test.describe('dashboard', () => {
     await scroller.evaluate((node) => {
       node.scrollLeft = 0;
     });
+    // This models a reader deliberately inspecting old history, which must not
+    // be undone by incidental layout work after the first automatic pin.
     await expect.poll(async () => scroller.evaluate((node) => node.scrollLeft)).toBe(0);
 
     const clientWidth = await scroller.evaluate((node) => node.clientWidth);
     await scroller.evaluate((node) => {
       node.style.maxWidth = `${Math.max(1, node.clientWidth - 24)}px`;
     });
+    // Trigger the kind of reflow ResizeObserver sees so the test covers the
+    // same path that would otherwise yank the reader back to today.
     await expect
       .poll(async () => scroller.evaluate((node) => node.clientWidth))
       .toBeLessThan(clientWidth);
 
+    // The user-visible guarantee is that older weeks stay put after the reader
+    // scrolls there; a resize must not turn history into today again.
     await expect
       .poll(async () => scroller.evaluate((node) => node.scrollLeft), {
         message: "a later reflow must not undo the reader's manual scroll",


### PR DESCRIPTION
## Summary

Fixes #106.

- Keep the dashboard heatmap pinned to the newest week when it first becomes horizontally overflowing after a viewport/container shrink.
- Preserve the existing once-per-mount guarantee so readers who manually scroll back to older weeks are not pulled back to today during later resize/reflow.
- Add focused Playwright coverage for both the wide-to-narrow resize path and the manual-scroll preservation path.

## Test Layer

End-to-end tests are the right layer here because the defect is horizontal scroll position after real browser layout and resize/reflow. Component tests and snapshots can see the rendered cells, but not whether the heatmap scroller opens on the newest week or preserves a manual scroll position.

## Red Proof

- Before the production fix, `yarn playwright test tests/e2e/dashboard.spec.ts` failed on the new wide-to-narrow regression test because today's cell stayed outside the scroller after resize.
- For the manual-scroll guard, I temporarily broke the once-only observer behavior; `yarn playwright test tests/e2e/dashboard.spec.ts -g "keeps a manually scrolled heatmap"` failed with `scrollLeft` pulled from `0` to `422`. I restored the implementation before committing.

## Verification

- `yarn playwright test tests/e2e/dashboard.spec.ts`
- `yarn format`
- `yarn typecheck`
- `yarn lint` exits 0 with existing warnings only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard heatmap positioning when the viewport changes size.
  - Keeps the latest week visible when the heatmap begins overflowing.
  - Preserves manually selected older weeks during later layout updates.

- **Tests**
  - Added coverage for responsive resizing and horizontal-scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->