### PR TITLE
fix(ai): read Gemini model name from Remote Config

### DIFF
--- a/src/infra/ai/entryDrafting.ts
+++ b/src/infra/ai/entryDrafting.ts
@@ -6,12 +6,19 @@ import {
   getGenerativeModel,
 } from 'firebase/ai';
 import {
+  ensureInitialized,
   fetchAndActivate,
   getRemoteConfig,
   getValue,
   type RemoteConfig,
 } from 'firebase/remote-config';
 import { EntryDraftingError, type EntryDraftingPort } from '@/domain/ports';
+import {
+  DEFAULT_GEMINI_MODEL,
+  GEMINI_MODEL_NAME_CONFIG_KEY,
+  GEMINI_REMOTE_CONFIG_FETCH_INTERVAL_MS,
+  GEMINI_REMOTE_CONFIG_FETCH_TIMEOUT_MS,
+} from '@/infra/ai/modelConfig';
 import { app } from '@/infra/firebase/client';
 
 /**
@@ -51,11 +58,6 @@ import { app } from '@/infra/firebase/client';
  * value instead of a deploy, while this constant keeps first load and failed
  * fetches working. Do not remove the log below to tidy up.
  */
-const DEFAULT_MODEL = 'gemini-3.6-flash';
-const MODEL_NAME_CONFIG_KEY = 'model_name';
-const REMOTE_CONFIG_FETCH_INTERVAL_MS = 5 * 60 * 1000;
-const REMOTE_CONFIG_FETCH_TIMEOUT_MS = 3_000;
-
 /**
  * `getAI` runs once, lazily, rather than at module scope.
  *
@@ -64,7 +66,7 @@ const REMOTE_CONFIG_FETCH_TIMEOUT_MS = 3_000;
  * before the reader had asked for anything. Failing at import time turns a
  * feature that should be quietly absent into an app that does not start.
  */
-let configuredModelName = DEFAULT_MODEL;
+let configuredModelName = DEFAULT_GEMINI_MODEL;
 let model: { instance: GenerativeModel; name: string } | undefined;
 let unavailable = false;
 let remoteConfig: RemoteConfig | undefined;
@@ -85,9 +87,9 @@ function ensureRemoteConfig(): RemoteConfig | undefined {
   if (remoteConfig) return remoteConfig;
   try {
     remoteConfig = getRemoteConfig(app);
-    remoteConfig.defaultConfig = { [MODEL_NAME_CONFIG_KEY]: DEFAULT_MODEL };
-    remoteConfig.settings.minimumFetchIntervalMillis = REMOTE_CONFIG_FETCH_INTERVAL_MS;
-    remoteConfig.settings.fetchTimeoutMillis = REMOTE_CONFIG_FETCH_TIMEOUT_MS;
+    remoteConfig.defaultConfig = { [GEMINI_MODEL_NAME_CONFIG_KEY]: DEFAULT_GEMINI_MODEL };
+    remoteConfig.settings.minimumFetchIntervalMillis = GEMINI_REMOTE_CONFIG_FETCH_INTERVAL_MS;
+    remoteConfig.settings.fetchTimeoutMillis = GEMINI_REMOTE_CONFIG_FETCH_TIMEOUT_MS;
   } catch (error) {
     // Remote Config is an upgrade path, not a prerequisite. The bundled model
     // default is still valid input to Firebase AI Logic when configuration
@@ -98,27 +100,41 @@ function ensureRemoteConfig(): RemoteConfig | undefined {
   return remoteConfig;
 }
 
+function applyRemoteConfigModelName(config: RemoteConfig): void {
+  setConfiguredModelName(getValue(config, GEMINI_MODEL_NAME_CONFIG_KEY).asString());
+}
+
 function refreshConfiguredModelName(): Promise<void> {
   const config = ensureRemoteConfig();
   if (!config) return Promise.resolve();
-  remoteConfigFetch ??= fetchAndActivate(config)
-    .then(() => {
-      setConfiguredModelName(getValue(config, MODEL_NAME_CONFIG_KEY).asString());
-    })
-    .catch((error) => {
+  remoteConfigFetch ??= (async () => {
+    try {
+      await ensureInitialized(config);
+    } catch (error) {
+      // A failed storage read should not block the bundled fallback below, and
+      // `getValue` still has the default config to answer from.
+      console.error('Gemini model Remote Config cache initialisation failed', error);
+    }
+
+    applyRemoteConfigModelName(config);
+
+    try {
+      await fetchAndActivate(config);
+      applyRemoteConfigModelName(config);
+    } catch (error) {
       // The fallback is the point: Remote Config must not turn drafting into a
       // feature that needs two network calls to succeed before the first model
-      // request can be made.
+      // request can be made. Cached activated values have already been applied
+      // above, so a failed fetch does not force the bundled default back in.
       console.error('Gemini model Remote Config fetch failed', error);
-    })
-    .finally(() => {
-      remoteConfigFetch = undefined;
-    });
+    }
+  })().finally(() => {
+    remoteConfigFetch = undefined;
+  });
   return remoteConfigFetch;
 }
 
-function ensureModel(refreshModelName = true): GenerativeModel | undefined {
-  if (refreshModelName) void refreshConfiguredModelName();
+function ensureModel(): GenerativeModel | undefined {
   if (unavailable) return undefined;
   if (model?.name === configuredModelName) return model.instance;
   try {
@@ -211,7 +227,7 @@ export const geminiEntryDrafting: EntryDraftingPort = {
 
   async draft(prompt) {
     await refreshConfiguredModelName();
-    const generative = ensureModel(false);
+    const generative = ensureModel();
     if (!generative) throw new EntryDraftingError('unavailable');
 
     let text: string;

--- a/src/infra/ai/entryDrafting.ts
+++ b/src/infra/ai/entryDrafting.ts
@@ -5,6 +5,12 @@ import {
   getAI,
   getGenerativeModel,
 } from 'firebase/ai';
+import {
+  fetchAndActivate,
+  getRemoteConfig,
+  getValue,
+  type RemoteConfig,
+} from 'firebase/remote-config';
 import { EntryDraftingError, type EntryDraftingPort } from '@/domain/ports';
 import { app } from '@/infra/firebase/client';
 
@@ -27,13 +33,13 @@ import { app } from '@/infra/firebase/client';
  */
 
 /**
- * Flash rather than Pro, named here rather than configured.
+ * Flash rather than Pro, kept here as the Remote Config default.
  *
  * The no-cost tier covers the Flash family only, and filling a fixed schema for
- * one word is not a task a larger model answers better. Moving off this string
+ * one word is not a task a larger model answers better. Moving off this family
  * is a decision about money, so it should be a diff somebody reads.
  *
- * **A stable model has a retirement date, so this line expires.** It was
+ * **A stable model has a retirement date, so this default expires.** It was
  * `gemini-2.5-flash` until 2026-08-23, when the proxy began answering
  * `404 … no longer available to new users`. Nothing in the build catches that:
  * the name is a string until it reaches the model, so a retired one compiles,
@@ -41,10 +47,14 @@ import { app } from '@/infra/firebase/client';
  *
  * What makes it recoverable is that the 404 names its own replacement — the
  * reply above said to use `gemini-3.6-flash` — and `classify` below logs the
- * cause before discarding it. So the fix instruction arrives in the console of
- * whoever hits it. Do not remove that log to tidy up.
+ * cause before discarding it. Remote Config makes that replacement a console
+ * value instead of a deploy, while this constant keeps first load and failed
+ * fetches working. Do not remove the log below to tidy up.
  */
-const MODEL = 'gemini-3.6-flash';
+const DEFAULT_MODEL = 'gemini-3.6-flash';
+const MODEL_NAME_CONFIG_KEY = 'model_name';
+const REMOTE_CONFIG_FETCH_INTERVAL_MS = 5 * 60 * 1000;
+const REMOTE_CONFIG_FETCH_TIMEOUT_MS = 3_000;
 
 /**
  * `getAI` runs once, lazily, rather than at module scope.
@@ -54,21 +64,77 @@ const MODEL = 'gemini-3.6-flash';
  * before the reader had asked for anything. Failing at import time turns a
  * feature that should be quietly absent into an app that does not start.
  */
-let model: GenerativeModel | undefined;
+let configuredModelName = DEFAULT_MODEL;
+let model: { instance: GenerativeModel; name: string } | undefined;
 let unavailable = false;
+let remoteConfig: RemoteConfig | undefined;
+let remoteConfigUnavailable = false;
+let remoteConfigFetch: Promise<void> | undefined;
 
-function ensureModel(): GenerativeModel | undefined {
-  if (unavailable) return undefined;
-  if (model) return model;
+function setConfiguredModelName(next: string): void {
+  const trimmed = next.trim();
+  if (!trimmed || trimmed === configuredModelName) return;
+  configuredModelName = trimmed;
+  model = undefined;
+  // A newer remote model name is the recovery path for a retired default.
+  unavailable = false;
+}
+
+function ensureRemoteConfig(): RemoteConfig | undefined {
+  if (remoteConfigUnavailable) return undefined;
+  if (remoteConfig) return remoteConfig;
   try {
-    model = getGenerativeModel(getAI(app, { backend: new GoogleAIBackend() }), { model: MODEL });
+    remoteConfig = getRemoteConfig(app);
+    remoteConfig.defaultConfig = { [MODEL_NAME_CONFIG_KEY]: DEFAULT_MODEL };
+    remoteConfig.settings.minimumFetchIntervalMillis = REMOTE_CONFIG_FETCH_INTERVAL_MS;
+    remoteConfig.settings.fetchTimeoutMillis = REMOTE_CONFIG_FETCH_TIMEOUT_MS;
+  } catch (error) {
+    // Remote Config is an upgrade path, not a prerequisite. The bundled model
+    // default is still valid input to Firebase AI Logic when configuration
+    // cannot initialise in this browser or project.
+    console.error('Gemini model Remote Config initialisation failed', error);
+    remoteConfigUnavailable = true;
+  }
+  return remoteConfig;
+}
+
+function refreshConfiguredModelName(): Promise<void> {
+  const config = ensureRemoteConfig();
+  if (!config) return Promise.resolve();
+  remoteConfigFetch ??= fetchAndActivate(config)
+    .then(() => {
+      setConfiguredModelName(getValue(config, MODEL_NAME_CONFIG_KEY).asString());
+    })
+    .catch((error) => {
+      // The fallback is the point: Remote Config must not turn drafting into a
+      // feature that needs two network calls to succeed before the first model
+      // request can be made.
+      console.error('Gemini model Remote Config fetch failed', error);
+    })
+    .finally(() => {
+      remoteConfigFetch = undefined;
+    });
+  return remoteConfigFetch;
+}
+
+function ensureModel(refreshModelName = true): GenerativeModel | undefined {
+  if (refreshModelName) void refreshConfiguredModelName();
+  if (unavailable) return undefined;
+  if (model?.name === configuredModelName) return model.instance;
+  try {
+    model = {
+      instance: getGenerativeModel(getAI(app, { backend: new GoogleAIBackend() }), {
+        model: configuredModelName,
+      }),
+      name: configuredModelName,
+    };
   } catch {
     // No AI Logic on this project, or the SDK refused to initialise. Recorded
     // rather than retried: it fails identically on every later attempt, and a
     // button that retries a permanent failure reads as a broken button.
     unavailable = true;
   }
-  return model;
+  return model?.instance;
 }
 
 /**
@@ -144,7 +210,8 @@ export const geminiEntryDrafting: EntryDraftingPort = {
   available: () => ensureModel() !== undefined,
 
   async draft(prompt) {
-    const generative = ensureModel();
+    await refreshConfiguredModelName();
+    const generative = ensureModel(false);
     if (!generative) throw new EntryDraftingError('unavailable');
 
     let text: string;

--- a/src/infra/ai/modelConfig.ts
+++ b/src/infra/ai/modelConfig.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_GEMINI_MODEL = 'gemini-3.6-flash';
+export const GEMINI_MODEL_NAME_CONFIG_KEY = 'model_name';
+export const GEMINI_REMOTE_CONFIG_FETCH_INTERVAL_MS = 5 * 60 * 1000;
+export const GEMINI_REMOTE_CONFIG_FETCH_TIMEOUT_MS = 3_000;

--- a/tests/unit/entryDrafting.test.ts
+++ b/tests/unit/entryDrafting.test.ts
@@ -2,14 +2,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const generateContent = vi.hoisted(() => vi.fn());
 const getGenerativeModel = vi.hoisted(() => vi.fn(() => ({ generateContent })));
+const remoteConfig = vi.hoisted<{
+  defaultConfig: Record<string, string | number | boolean>;
+  settings: { fetchTimeoutMillis: number; minimumFetchIntervalMillis: number };
+}>(() => ({
+  defaultConfig: {},
+  settings: { fetchTimeoutMillis: 60_000, minimumFetchIntervalMillis: 43_200_000 },
+}));
+const fetchAndActivate = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
+const getValue = vi.hoisted(() => vi.fn(() => ({ asString: () => 'gemini-4.0-flash' })));
 
 vi.mock('firebase/ai', () => ({
   AIError: class AIError extends Error {
     code = '';
   },
   GoogleAIBackend: class GoogleAIBackend {},
-  getAI: vi.fn(),
+  getAI: vi.fn(() => ({})),
   getGenerativeModel,
+}));
+vi.mock('firebase/remote-config', () => ({
+  fetchAndActivate,
+  getRemoteConfig: vi.fn(() => remoteConfig),
+  getValue,
 }));
 
 vi.mock('firebase/app', () => ({ initializeApp: vi.fn(() => ({})) }));
@@ -30,6 +44,10 @@ vi.mock('firebase/firestore', () => ({
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
+  remoteConfig.defaultConfig = {};
+  remoteConfig.settings = { fetchTimeoutMillis: 60_000, minimumFetchIntervalMillis: 43_200_000 };
+  fetchAndActivate.mockResolvedValue(true);
+  getValue.mockReturnValue({ asString: () => 'gemini-4.0-flash' });
   vi.stubEnv('VITE_FIREBASE_API_KEY', 'test');
   vi.stubEnv('VITE_FIREBASE_AUTH_DOMAIN', 'test');
   vi.stubEnv('VITE_FIREBASE_PROJECT_ID', 'test');
@@ -46,6 +64,42 @@ afterEach(() => {
 });
 
 describe('geminiEntryDrafting', () => {
+  it('uses the Remote Config model name before drafting', async () => {
+    generateContent.mockResolvedValueOnce({ response: { text: () => 'draft' } });
+    const { geminiEntryDrafting } = await import('@/infra/ai/entryDrafting');
+
+    await expect(geminiEntryDrafting.draft('prompt')).resolves.toBe('draft');
+
+    expect(fetchAndActivate).toHaveBeenCalledWith(remoteConfig);
+    expect(remoteConfig.defaultConfig).toEqual({ model_name: 'gemini-3.6-flash' });
+    expect(remoteConfig.settings).toEqual({
+      fetchTimeoutMillis: 3_000,
+      minimumFetchIntervalMillis: 5 * 60 * 1000,
+    });
+    expect(getGenerativeModel).toHaveBeenLastCalledWith(expect.anything(), {
+      model: 'gemini-4.0-flash',
+    });
+  });
+
+  it('falls back to the bundled model when Remote Config cannot fetch', async () => {
+    fetchAndActivate.mockRejectedValueOnce(new Error('remote config unavailable'));
+    generateContent.mockResolvedValueOnce({ response: { text: () => 'draft' } });
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const { geminiEntryDrafting } = await import('@/infra/ai/entryDrafting');
+
+      await expect(geminiEntryDrafting.draft('prompt')).resolves.toBe('draft');
+
+      expect(getValue).not.toHaveBeenCalled();
+      expect(getGenerativeModel).toHaveBeenLastCalledWith(expect.anything(), {
+        model: 'gemini-3.6-flash',
+      });
+    } finally {
+      error.mockRestore();
+    }
+  });
+
   it('becomes unavailable after a constructed model reports a permanent 404', async () => {
     generateContent.mockRejectedValueOnce(new Error('404 model no longer available'));
     const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);

--- a/tests/unit/entryDrafting.test.ts
+++ b/tests/unit/entryDrafting.test.ts
@@ -1,4 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_GEMINI_MODEL,
+  GEMINI_MODEL_NAME_CONFIG_KEY,
+  GEMINI_REMOTE_CONFIG_FETCH_INTERVAL_MS,
+  GEMINI_REMOTE_CONFIG_FETCH_TIMEOUT_MS,
+} from '@/infra/ai/modelConfig';
 
 const generateContent = vi.hoisted(() => vi.fn());
 const getGenerativeModel = vi.hoisted(() => vi.fn(() => ({ generateContent })));
@@ -9,8 +15,11 @@ const remoteConfig = vi.hoisted<{
   defaultConfig: {},
   settings: { fetchTimeoutMillis: 60_000, minimumFetchIntervalMillis: 43_200_000 },
 }));
+const cachedModel = vi.hoisted(() => ({ name: 'gemini-4.0-flash' }));
+const remoteModel = vi.hoisted(() => ({ name: 'gemini-4.0-flash' }));
+const ensureInitialized = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 const fetchAndActivate = vi.hoisted(() => vi.fn(() => Promise.resolve(true)));
-const getValue = vi.hoisted(() => vi.fn(() => ({ asString: () => 'gemini-4.0-flash' })));
+const getValue = vi.hoisted(() => vi.fn(() => ({ asString: () => remoteModel.name })));
 
 vi.mock('firebase/ai', () => ({
   AIError: class AIError extends Error {
@@ -21,6 +30,7 @@ vi.mock('firebase/ai', () => ({
   getGenerativeModel,
 }));
 vi.mock('firebase/remote-config', () => ({
+  ensureInitialized,
   fetchAndActivate,
   getRemoteConfig: vi.fn(() => remoteConfig),
   getValue,
@@ -46,8 +56,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   remoteConfig.defaultConfig = {};
   remoteConfig.settings = { fetchTimeoutMillis: 60_000, minimumFetchIntervalMillis: 43_200_000 };
+  cachedModel.name = 'gemini-4.0-flash';
+  remoteModel.name = 'gemini-4.0-flash';
+  ensureInitialized.mockResolvedValue(undefined);
   fetchAndActivate.mockResolvedValue(true);
-  getValue.mockReturnValue({ asString: () => 'gemini-4.0-flash' });
+  getValue.mockReturnValue({ asString: () => remoteModel.name });
   vi.stubEnv('VITE_FIREBASE_API_KEY', 'test');
   vi.stubEnv('VITE_FIREBASE_AUTH_DOMAIN', 'test');
   vi.stubEnv('VITE_FIREBASE_PROJECT_ID', 'test');
@@ -64,25 +77,52 @@ afterEach(() => {
 });
 
 describe('geminiEntryDrafting', () => {
+  it('checks availability without fetching Remote Config during render', async () => {
+    const { geminiEntryDrafting } = await import('@/infra/ai/entryDrafting');
+
+    expect(geminiEntryDrafting.available()).toBe(true);
+
+    // Availability is read during render, so it must not schedule network work
+    // while the reader is typing or opening the import form.
+    expect(ensureInitialized).not.toHaveBeenCalled();
+    expect(fetchAndActivate).not.toHaveBeenCalled();
+  });
+
   it('uses the Remote Config model name before drafting', async () => {
     generateContent.mockResolvedValueOnce({ response: { text: () => 'draft' } });
     const { geminiEntryDrafting } = await import('@/infra/ai/entryDrafting');
 
     await expect(geminiEntryDrafting.draft('prompt')).resolves.toBe('draft');
 
+    // Without the cached value first, a reader can restart offline and regress
+    // from a previously fixed model name to the retired bundled fallback.
+    expect(ensureInitialized).toHaveBeenCalledWith(remoteConfig);
+    // Without the fresh fetch, a console update cannot repair the next draft
+    // after the operator publishes a replacement model name.
     expect(fetchAndActivate).toHaveBeenCalledWith(remoteConfig);
-    expect(remoteConfig.defaultConfig).toEqual({ model_name: 'gemini-3.6-flash' });
-    expect(remoteConfig.settings).toEqual({
-      fetchTimeoutMillis: 3_000,
-      minimumFetchIntervalMillis: 5 * 60 * 1000,
+    // If this default drifts, first-load readers can hit a retired bundled
+    // model before the console value has ever reached their browser.
+    expect(remoteConfig.defaultConfig).toEqual({
+      [GEMINI_MODEL_NAME_CONFIG_KEY]: DEFAULT_GEMINI_MODEL,
     });
+    // If these settings drift, an emergency model-name change can take too long
+    // to reach readers, or a slow Remote Config call can block drafting.
+    expect(remoteConfig.settings).toEqual({
+      fetchTimeoutMillis: GEMINI_REMOTE_CONFIG_FETCH_TIMEOUT_MS,
+      minimumFetchIntervalMillis: GEMINI_REMOTE_CONFIG_FETCH_INTERVAL_MS,
+    });
+    // This is the user-visible recovery path: after the console parameter is
+    // published, the next draft must ask the replacement model, not the retired
+    // bundled default.
     expect(getGenerativeModel).toHaveBeenLastCalledWith(expect.anything(), {
-      model: 'gemini-4.0-flash',
+      model: remoteModel.name,
     });
   });
 
-  it('falls back to the bundled model when Remote Config cannot fetch', async () => {
+  it('uses the cached Remote Config model when a fresh fetch fails', async () => {
+    cachedModel.name = 'gemini-4.1-flash';
     fetchAndActivate.mockRejectedValueOnce(new Error('remote config unavailable'));
+    getValue.mockReturnValue({ asString: () => cachedModel.name });
     generateContent.mockResolvedValueOnce({ response: { text: () => 'draft' } });
     const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
@@ -91,9 +131,9 @@ describe('geminiEntryDrafting', () => {
 
       await expect(geminiEntryDrafting.draft('prompt')).resolves.toBe('draft');
 
-      expect(getValue).not.toHaveBeenCalled();
+      expect(getValue).toHaveBeenCalledWith(remoteConfig, GEMINI_MODEL_NAME_CONFIG_KEY);
       expect(getGenerativeModel).toHaveBeenLastCalledWith(expect.anything(), {
-        model: 'gemini-3.6-flash',
+        model: cachedModel.name,
       });
     } finally {
       error.mockRestore();


### PR DESCRIPTION
## Summary

Closes #101.

Read the Gemini model name from Firebase Remote Config so retiring a stable model can be handled by updating `model_name` in the Firebase console instead of shipping a deploy. The bundled default remains `gemini-3.6-flash` so first load and Remote Config fetch failures still work.

Operational note: the `model_name` client parameter is already configured in both development and production Firebase Remote Config projects.

## Changes

- Add Firebase Remote Config lookup for the Gemini `model_name` parameter in `geminiEntryDrafting`.
- Keep `gemini-3.6-flash` as the default config and fallback model.
- Set Remote Config to fetch at most every 5 minutes with a 3 second fetch timeout.
- Rebuild the cached Gemini model when the configured model name changes.
- Add direct unit coverage for using the remote model name and falling back when Remote Config fetch fails.

## Test Layer

Unit tests were chosen because the defect is in the Gemini adapter's configuration flow. The e2e build already substitutes `entryDraftingPort` through the backend seam, and `yarn build:e2e` verifies that build does not pull in the production Remote Config path.

## Verification

- Red check: temporarily prevented the remote model name from being applied and confirmed `geminiEntryDrafting > uses the Remote Config model name before drafting` failed with the bundled default `gemini-3.6-flash` instead of the remote `gemini-4.0-flash`.
- `yarn vitest run --project unit tests/unit/entryDrafting.test.ts`
- `yarn format`
- `yarn typecheck`
- `yarn lint` (passes with existing warnings)
- `yarn build:e2e`
- `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting the AI drafting model through remote configuration.
  - Automatically applies updated model settings when configuration changes.
- **Bug Fixes**
  - Improved reliability by falling back to the bundled default model if remote configuration is unavailable or fails to load.
- **Tests**
  - Added coverage for remote model selection, configuration settings, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->