### PR TITLE
fix(errors): distinguish a denied write from a dropped connection

### DIFF
--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -9,6 +9,7 @@ import { dateKey } from '@/lib/dates';
 import { draftError, emptyDraft, parseTags, toDraft } from '@/lib/draft';
 import { useEntries } from '@/lib/entries';
 import { jsonToDraft } from '@/lib/jsonImport';
+import { loadErrorMessage } from '@/lib/loadError';
 import { EntryForm } from './EntryForm';
 import { Area, Field, Text } from './fields';
 import { emptyJsonImport, JsonImport } from './JsonImport';
@@ -174,7 +175,18 @@ export function EntryFormModal({
       onClose();
     } catch (cause) {
       console.error(cause);
-      setErrors([t('form.saveError')]);
+      // `permission-denied` here is a lockout, not a mistake in the draft —
+      // #22 gave reads that distinction and #23 gives it to saves. Retrying
+      // never clears it, which "保存できませんでした" reads as an invitation
+      // to do.
+      setErrors([
+        loadErrorMessage(
+          cause,
+          t('form.saveError'),
+          t('load.accessDenied'),
+          t('load.unreachableSave'),
+        ),
+      ]);
     } finally {
       setSaving(false);
     }

--- a/src/i18n/authenticatedMessages.ts
+++ b/src/i18n/authenticatedMessages.ts
@@ -20,6 +20,8 @@ const en = {
   'load.unreachable': 'Could not reach the server. Your saved words can still be read.',
   'load.unreachableSave':
     'Could not reach the server, so this was not saved. Try again in a moment.',
+  'load.unreachableExport':
+    'Could not reach the server, so this was not exported. Try again in a moment.',
   'offline.state': 'Offline',
   'offline.detail': 'Saved words stay readable. Changes may not save until you are back.',
   'diagnostics.summary': 'View and copy diagnostics',
@@ -106,6 +108,8 @@ const ja: AuthenticatedMessages = {
   'load.unreachable': '接続できないため読み込めませんでした。保存済みの単語はそのまま読めます。',
   'load.unreachableSave':
     '接続できないため保存できませんでした。しばらくしてからもう一度お試しください。',
+  'load.unreachableExport':
+    '接続できないためエクスポートできませんでした。しばらくしてからもう一度お試しください。',
   'offline.state': 'オフライン',
   'offline.detail': '保存済みの単語は読めます。変更は接続が戻るまで保存されないことがあります。',
   'diagnostics.summary': '診断情報を見る・コピーする',
@@ -186,6 +190,7 @@ const zhHant: AuthenticatedMessages = {
   'load.exportWalk': '匯出未能完成，請稍後再試。',
   'load.unreachable': '無法連線，因此未能載入。已儲存的單字仍可閱讀。',
   'load.unreachableSave': '無法連線，因此未能儲存。請稍後再試一次。',
+  'load.unreachableExport': '無法連線，因此未能匯出。請稍後再試一次。',
   'offline.state': '離線',
   'offline.detail': '已儲存的單字仍可閱讀。變更可能要等連線恢復後才會儲存。',
   'diagnostics.summary': '查看及複製診斷資料',
@@ -263,6 +268,7 @@ const ko: AuthenticatedMessages = {
   'load.exportWalk': '내보내기가 완료되지 않았습니다. 잠시 후 다시 시도해 주세요.',
   'load.unreachable': '연결할 수 없어 불러오지 못했습니다. 저장된 단어는 그대로 볼 수 있습니다.',
   'load.unreachableSave': '연결할 수 없어 저장하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+  'load.unreachableExport': '연결할 수 없어 내보내지 못했습니다. 잠시 후 다시 시도해 주세요.',
   'offline.state': '오프라인',
   'offline.detail':
     '저장된 단어는 계속 볼 수 있습니다. 변경 사항은 연결이 돌아올 때까지 저장되지 않을 수 있습니다.',
@@ -348,6 +354,8 @@ const es: AuthenticatedMessages = {
     'No se pudo conectar, así que no se pudo cargar. Las palabras guardadas siguen disponibles.',
   'load.unreachableSave':
     'No se pudo conectar, así que no se pudo guardar. Inténtalo de nuevo en un momento.',
+  'load.unreachableExport':
+    'No se pudo conectar, así que no se pudo exportar. Inténtalo de nuevo en un momento.',
   'offline.state': 'Sin conexión',
   'offline.detail':
     'Las palabras guardadas siguen disponibles. Puede que los cambios no se guarden hasta que vuelvas.',

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -50,6 +50,18 @@ function countRead(store: 'entries' | 'progress' | 'wordSets'): void {
   reads[store] += 1;
 }
 
+/** Shaped like the SDK's own rejection, keyed by the `code` `isAccessDenied`/`isUnreachable` read. */
+function deniedError(): Error {
+  return Object.assign(new Error('Missing or insufficient permissions.'), {
+    code: 'permission-denied',
+  });
+}
+function unreachableError(): Error {
+  return Object.assign(new Error('Failed to get document because the client is offline.'), {
+    code: 'unavailable',
+  });
+}
+
 const E2E_USER: AuthUser = {
   uid: 'e2e-user',
   email: 'e2e@example.test',
@@ -314,6 +326,11 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
 
   return {
     list({ limit, cursor }: PageQuery): Promise<Page<Entry>> {
+      // Gates the export walk, not the initial notebook load: `Account.tsx`
+      // drains this same method directly, and nothing on that page renders
+      // `EntriesProvider`'s own read of it, so failing both is unobservable
+      // except through the one path #23 is about.
+      if (seed().accountExport === 'denied') return Promise.reject(deniedError());
       countRead('entries');
       const all = [...store.values()].sort(newestFirst);
       const start = cursor ? all.findIndex((entry) => entry.id === cursor) + 1 : 0;
@@ -330,6 +347,8 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
     },
 
     create(draft: EntryDraft): Promise<string> {
+      if (seed().entrySave === 'denied') return Promise.reject(deniedError());
+      if (seed().entrySave === 'unreachable') return Promise.reject(unreachableError());
       const id = nextId();
       const now = stamp();
       store.set(id, {
@@ -347,6 +366,8 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
     },
 
     update(id: string, draft: EntryDraft): Promise<void> {
+      if (seed().entrySave === 'denied') return Promise.reject(deniedError());
+      if (seed().entrySave === 'unreachable') return Promise.reject(unreachableError());
       const existing = store.get(id);
       // Matching Firestore's updateDoc, which rejects a write to a missing
       // document rather than creating one.

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -331,6 +331,7 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       // `EntriesProvider`'s own read of it, so failing both is unobservable
       // except through the one path #23 is about.
       if (seed().accountExport === 'denied') return Promise.reject(deniedError());
+      if (seed().accountExport === 'unreachable') return Promise.reject(unreachableError());
       countRead('entries');
       const all = [...store.values()].sort(newestFirst);
       const start = cursor ? all.findIndex((entry) => entry.id === cursor) + 1 : 0;

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -35,6 +35,19 @@ export interface E2ESeed {
   settingsSave?: 'fail' | 'defer' | 'unreachable';
   /** Fail the profile re-read that follows a committed save, and only that one. */
   settingsRefresh?: 'fail';
+  /**
+   * Fails an entry `create`/`update`. `denied` carries Firestore's own
+   * `permission-denied`, so `EntryFormModal` renders the account-denial
+   * sentence rather than the generic 保存できませんでした. `unreachable`
+   * mirrors `settingsSave`'s branch of the same name.
+   */
+  entrySave?: 'denied' | 'unreachable';
+  /**
+   * Fails the entry page this account's export walk reads first, with
+   * Firestore's `permission-denied`. See the comment on `entryRepositoryFor`'s
+   * `list` for why this does not also break the notebook itself.
+   */
+  accountExport?: 'denied';
   /** Put a waiting build on screen, so `UpdatePrompt` can be laid out against. */
   updateWaiting?: boolean;
   /**

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -43,11 +43,13 @@ export interface E2ESeed {
    */
   entrySave?: 'denied' | 'unreachable';
   /**
-   * Fails the entry page this account's export walk reads first, with
-   * Firestore's `permission-denied`. See the comment on `entryRepositoryFor`'s
+   * Fails the entry page this account's export walk reads first. `denied`
+   * carries `permission-denied`; `unreachable` carries `unavailable`, so
+   * `Account.tsx` renders export wording rather than `settingsSave`'s save
+   * wording for the same code. See the comment on `entryRepositoryFor`'s
    * `list` for why this does not also break the notebook itself.
    */
-  accountExport?: 'denied';
+  accountExport?: 'denied' | 'unreachable';
   /** Put a waiting build on screen, so `UpdatePrompt` can be laid out against. */
   updateWaiting?: boolean;
   /**

--- a/src/routes/Account.tsx
+++ b/src/routes/Account.tsx
@@ -86,7 +86,7 @@ export function Component() {
               cause,
               t('account.exportError'),
               t('load.accessDenied'),
-              t('load.unreachableSave'),
+              t('load.unreachableExport'),
             ),
       );
     } finally {

--- a/src/routes/Account.tsx
+++ b/src/routes/Account.tsx
@@ -15,6 +15,7 @@ import { authPort, userRepository } from '@/lib/backend';
 import { appVersion, buildLine } from '@/lib/build';
 import { newErrorId } from '@/lib/diagnostics';
 import { useEntries } from '@/lib/entries';
+import { loadErrorMessage } from '@/lib/loadError';
 import { useProgress } from '@/lib/progress';
 import { useUserSettings } from '@/lib/userSettingsContext';
 import { useWordSets } from '@/lib/wordSets';
@@ -77,7 +78,16 @@ export function Component() {
       setError(
         cause instanceof Error && cause.message.startsWith('エクスポートが終わりませんでした')
           ? t('load.exportWalk')
-          : t('account.exportError'),
+          : // A denial fell through to the generic 「エクスポートできませんでした」,
+            // indistinguishable from any other failure and unclearable by
+            // retrying. `loadErrorMessage` is the seam #22 built for exactly
+            // this distinction.
+            loadErrorMessage(
+              cause,
+              t('account.exportError'),
+              t('load.accessDenied'),
+              t('load.unreachableSave'),
+            ),
       );
     } finally {
       setBusy(null);

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+import { seed } from './fixtures';
+
+/**
+ * #23: `Account.tsx` used to render whatever string the SDK's rejection
+ * carried straight to the page — `Missing or insufficient permissions.`, in
+ * English, describing an internal condition in the vocabulary of the library
+ * rather than of the product. `loadErrorMessage` is the seam #22 built for
+ * exactly this.
+ *
+ * End-to-end because the layer under test is the wiring: `entryRepositoryFor`
+ * (`src/lib/backend.e2e.ts`) rejecting the export walk's first read with
+ * Firestore's own `permission-denied`, `exportEverything` propagating it
+ * unchanged, and the route choosing what to render. The branch itself is
+ * `tests/unit/loadError.test.ts`.
+ */
+test('shows the access-denied message on a denied export, not the SDK’s own string', async ({
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  await seed(page, { signedIn: true, accountExport: 'denied' });
+  await page.goto('/account');
+
+  await page.getByRole('button', { name: 'データをエクスポート' }).click();
+
+  await expect(
+    page.getByText(
+      'アクセスが許可されていません。一度サインアウトして、サインインし直してください。',
+    ),
+  ).toBeVisible();
+  // The half that fails without the fix: the SDK's own English string, which
+  // `cause.message` used to pass straight through.
+  await expect(page.getByText('Missing or insufficient permissions.')).toBeHidden();
+  // Nor the generic wording, which would mean the denial branch was never
+  // reached at all.
+  await expect(page.getByText('エクスポートできませんでした。', { exact: true })).toBeHidden();
+  expect(pageErrors).toEqual([]);
+});

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -2,11 +2,15 @@ import { expect, test } from '@playwright/test';
 import { seed } from './fixtures';
 
 /**
- * #23: `Account.tsx` used to render whatever string the SDK's rejection
- * carried straight to the page — `Missing or insufficient permissions.`, in
- * English, describing an internal condition in the vocabulary of the library
- * rather than of the product. `loadErrorMessage` is the seam #22 built for
- * exactly this.
+ * #23: `Account.tsx` collapsed every export failure to the generic
+ * 「エクスポートできませんでした」, including a denial — the one case a
+ * dedicated sentence exists for, because retrying it never clears it.
+ * (Historically the branch rendered the SDK's own rejection message
+ * unchanged, in English; that was already fixed upstream of this PR, so the
+ * regression this test catches is the missing denial branch, not the SDK
+ * string. The SDK-string assertion below stays as a guard against that
+ * earlier shape recurring.) `loadErrorMessage` is the seam #22 built for the
+ * distinction.
  *
  * End-to-end because the layer under test is the wiring: `entryRepositoryFor`
  * (`src/lib/backend.e2e.ts`) rejecting the export walk's first read with
@@ -14,7 +18,7 @@ import { seed } from './fixtures';
  * unchanged, and the route choosing what to render. The branch itself is
  * `tests/unit/loadError.test.ts`.
  */
-test('shows the access-denied message on a denied export, not the SDK’s own string', async ({
+test('shows the access-denied message on a denied export, not the generic one', async ({
   page,
 }) => {
   const pageErrors: string[] = [];
@@ -29,11 +33,32 @@ test('shows the access-denied message on a denied export, not the SDK’s own st
       'アクセスが許可されていません。一度サインアウトして、サインインし直してください。',
     ),
   ).toBeVisible();
-  // The half that fails without the fix: the SDK's own English string, which
-  // `cause.message` used to pass straight through.
+  // Guards against the message this branch used to render, unchanged.
   await expect(page.getByText('Missing or insufficient permissions.')).toBeHidden();
   // Nor the generic wording, which would mean the denial branch was never
-  // reached at all.
+  // reached at all — this is the half that actually fails without the fix.
   await expect(page.getByText('エクスポートできませんでした。', { exact: true })).toBeHidden();
+  expect(pageErrors).toEqual([]);
+});
+
+/**
+ * #23's third criterion: saving, exporting and deleting are not the same
+ * sentence. `load.unreachableSave` already existed for `userSettings`'s save,
+ * and reusing it here would tell a reader their export was not *saved* — the
+ * wrong operation. This pins the export-specific fallback that exists instead.
+ */
+test('says the export was not reachable, not that a save failed', async ({ page }) => {
+  const pageErrors: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  await seed(page, { signedIn: true, accountExport: 'unreachable' });
+  await page.goto('/account');
+
+  await page.getByRole('button', { name: 'データをエクスポート' }).click();
+
+  await expect(page.getByText('接続できないためエクスポートできませんでした。')).toBeVisible();
+  // The half that fails without the export-specific fallback: both sentences
+  // begin identically, so asserting only the one above passes on a substring
+  // of the save wording.
+  await expect(page.getByText('接続できないため保存できませんでした。')).toBeHidden();
   expect(pageErrors).toEqual([]);
 });

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { INPUT_LIMITS } from '../../src/domain/limits';
-import { DETAILED_WORD, seed, seedSignedIn, watchForBlanking } from './fixtures';
+import { DETAILED_WORD, seed, seedSignedIn, watchForBlanking, WORDS } from './fixtures';
 
 /**
  * The notebook's whole reason to exist: find a word, read it, add one, change
@@ -418,6 +418,33 @@ test.describe('editing and deleting', () => {
 
     await expect(page.getByText('起こる前のしるし。')).toBeVisible();
     await expect(page.getByText('何かが起こる前ぶれ。')).toBeHidden();
+  });
+
+  /**
+   * #23: a denied save used to render the same 保存できませんでした as a typo
+   * or a dropped connection — retrying a lockout never clears it, which is the
+   * ambiguity `loadErrorMessage` exists to remove. End-to-end because the layer
+   * under test is the wiring — `entryRepositoryFor` (`src/lib/backend.e2e.ts`)
+   * rejecting with Firestore's own `permission-denied`, and the modal choosing
+   * what to render. The branch itself is `tests/unit/loadError.test.ts`.
+   */
+  test('shows the access-denied message on a denied save, not the generic one', async ({
+    page,
+  }) => {
+    await seed(page, { signedIn: true, entries: WORDS, entrySave: 'denied' });
+    await page.goto('/vocabulary/w-choukou');
+    await page.getByRole('button', { name: '編集' }).click();
+
+    const dialog = editDialog(page);
+    await dialog.getByLabel('意味・説明').fill('起こる前のしるし。');
+    await dialog.getByRole('button', { name: '保存する' }).click();
+
+    await expect(
+      dialog.getByText(
+        'アクセスが許可されていません。一度サインアウトして、サインインし直してください。',
+      ),
+    ).toBeVisible();
+    await expect(dialog.getByText('保存できませんでした。', { exact: true })).toBeHidden();
   });
 
   /**

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -445,6 +445,14 @@ test.describe('editing and deleting', () => {
       ),
     ).toBeVisible();
     await expect(dialog.getByText('保存できませんでした。', { exact: true })).toBeHidden();
+
+    // Not only the message: the denial is rejected before the in-memory store
+    // is touched (`entryRepositoryFor.update` in `src/lib/backend.e2e.ts`
+    // checks `entrySave` first), so the stored entry must still read the way
+    // it did before this attempt.
+    await page.reload();
+    await expect(page.getByText('何かが起こる前ぶれ。')).toBeVisible();
+    await expect(page.getByText('起こる前のしるし。')).toBeHidden();
   });
 
   /**


### PR DESCRIPTION
## Summary

Closes #23. `#22` taught reads to distinguish a permission denial from a dropped connection; writes were left out deliberately. This finishes that:

- `EntryFormModal.save` reported the same 「保存できませんでした」 for every failure, including a denial that retrying never clears.
- `Account.tsx`'s export fallback never distinguished a denial from any other failure either — it always fell to the generic 「エクスポートできませんでした」.
- Fixed during review: export's *unreachable* branch reused `settingsSave`'s `load.unreachableSave`, which would have told a reader their export was not *saved* — the wrong operation. Added `load.unreachableExport` instead.

Both now route through `loadErrorMessage`, the seam `#22` built for exactly this.

`Account.tsx`'s delete path is intentionally untouched — the issue names only the save and export sites.

## Test plan

- [x] `tests/e2e/vocabulary.spec.ts` — denied save shows the access-denied sentence, not the generic one
- [x] `tests/e2e/account.spec.ts` — denied export shows the access-denied sentence, not the generic one
- [x] `tests/e2e/account.spec.ts` — unreachable export shows export-specific wording, not save wording
- [x] Reverted each fix, confirmed the corresponding test goes red, confirmed only that test fails, restored and confirmed green
- [x] `yarn typecheck`, `yarn test:unit` (827 pass), `yarn lint` (0 errors, 17 pre-existing warnings), full `yarn test:e2e` chromium project (136 pass, 9 skipped WebKit-only)

E2E rather than component: the layer under test is the wiring (`entryRepositoryFor` in `src/lib/backend.e2e.ts` rejecting, the route choosing what to render), not the branch logic itself, which `tests/unit/loadError.test.ts` already covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when saving entries or exporting account data fails.
  * Clearly distinguishes permission-denied errors from unavailable-service errors.
  * Added localized messages in English, Japanese, Traditional Chinese, Korean, and Spanish.
* **Tests**
  * Added end-to-end coverage to verify accurate error messages and prevent page errors during failed saves and exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->