### PR TITLE
feat(providers): retry a failed read once the connection returns

### DIFF
--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -329,9 +329,16 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
   const persist = () => {
     save(`entries.${uid}`, [...store.values()]);
   };
+  /** Backs `entriesReadDelayMs` — only the read that is actually going to succeed. */
+  const waitForRead = () => {
+    const milliseconds = seed().entriesReadDelayMs ?? 0;
+    return milliseconds > 0
+      ? new Promise<void>((resolve) => window.setTimeout(resolve, milliseconds))
+      : Promise.resolve();
+  };
 
   return {
-    list({ limit, cursor }: PageQuery): Promise<Page<Entry>> {
+    async list({ limit, cursor }: PageQuery): Promise<Page<Entry>> {
       // Gates the export walk, not the initial notebook load: `Account.tsx`
       // drains this same method directly, and nothing on that page renders
       // `EntriesProvider`'s own read of it, so failing both is unobservable
@@ -339,15 +346,16 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       if (seed().accountExport === 'denied') return Promise.reject(deniedError());
       if (seed().accountExport === 'unreachable') return Promise.reject(unreachableError());
       if (offlineRead('entries')) return Promise.reject(unreachableError());
+      await waitForRead();
       countRead('entries');
       const all = [...store.values()].sort(newestFirst);
       const start = cursor ? all.findIndex((entry) => entry.id === cursor) + 1 : 0;
       const items = all.slice(start, start + limit);
       const more = start + items.length < all.length;
-      return Promise.resolve({
+      return {
         items,
         cursor: more ? (items[items.length - 1]?.id ?? null) : null,
-      });
+      };
     },
 
     get(id: string): Promise<Entry | null> {

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -62,6 +62,11 @@ function unreachableError(): Error {
   });
 }
 
+/** Backs `failWhileOffline` — see its doc comment on `E2ESeed`. */
+function offlineRead(store: 'entries' | 'progress' | 'wordSets' | 'settings'): boolean {
+  return (seed().failWhileOffline ?? []).includes(store) && !navigator.onLine;
+}
+
 const E2E_USER: AuthUser = {
   uid: 'e2e-user',
   email: 'e2e@example.test',
@@ -203,6 +208,7 @@ let settingsSaved = false;
 
 export const userRepository: UserRepository = {
   get(uid): Promise<UserProfile | null> {
+    if (offlineRead('settings')) return Promise.reject(unreachableError());
     // Fails only the read that follows a committed save, which is the whole
     // point: the transaction succeeded and the profile is durable, and the
     // question is what the interface says about it.
@@ -332,6 +338,7 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       // except through the one path #23 is about.
       if (seed().accountExport === 'denied') return Promise.reject(deniedError());
       if (seed().accountExport === 'unreachable') return Promise.reject(unreachableError());
+      if (offlineRead('entries')) return Promise.reject(unreachableError());
       countRead('entries');
       const all = [...store.values()].sort(newestFirst);
       const start = cursor ? all.findIndex((entry) => entry.id === cursor) + 1 : 0;
@@ -456,6 +463,7 @@ export const progressRepositoryFor = (uid: string): ProgressRepository => {
     listAll(): Promise<EntryProgress[]> {
       if (seed().progressLoad === 'denied') return Promise.reject(deniedError());
       if (seed().progressLoad === 'unreachable') return Promise.reject(unreachableError());
+      if (offlineRead('progress')) return Promise.reject(unreachableError());
       countRead('progress');
       return Promise.resolve([...progress.values()]);
     },
@@ -560,6 +568,7 @@ export const wordSetRepositoryFor = (uid: string): WordSetRepository => {
 
   return {
     list({ limit, cursor }: PageQuery): Promise<Page<WordSet>> {
+      if (offlineRead('wordSets')) return Promise.reject(unreachableError());
       countRead('wordSets');
       const all = [...store.values()].sort(
         (a, b) => b.createdAt.localeCompare(a.createdAt) || b.id.localeCompare(a.id),

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -51,6 +51,17 @@ export interface E2ESeed {
    */
   accountExport?: 'denied' | 'unreachable';
   /**
+   * Rejects the named provider's read with Firestore's `unavailable` while
+   * `navigator.onLine` is false, and lets it through once true. Models the one
+   * thing a reconnect retry (#84) needs to observe: a read that failed because
+   * the network was down, and would succeed if asked again now that it is not.
+   *
+   * Independent of `entrySave`/`progressLoad`/`accountExport`, which fail
+   * unconditionally — a retry against one of those would just repeat the same
+   * rejection, which is a different claim from this one.
+   */
+  failWhileOffline?: Array<'entries' | 'progress' | 'wordSets' | 'settings'>;
+  /**
    * Fails the progress read `ProgressProvider` makes on sign-in. `denied`
    * carries `permission-denied`, `unreachable` carries `unavailable` — the two
    * codes `PracticeSetup`'s 苦手のみ row must tell apart rather than collapsing

--- a/src/lib/e2eSeed.ts
+++ b/src/lib/e2eSeed.ts
@@ -62,6 +62,16 @@ export interface E2ESeed {
    */
   failWhileOffline?: Array<'entries' | 'progress' | 'wordSets' | 'settings'>;
   /**
+   * Hold the notebook's successful read open this long before resolving it.
+   *
+   * Only for the read that actually succeeds — `failWhileOffline`'s rejection
+   * is unaffected — so this exists to make a reconnect retry (#84) slow enough
+   * to observe: `EntriesProvider.refresh` used to clear its error before the
+   * new read landed, and against the in-memory adapter's usual same-tick
+   * resolution that gap is too fast for a spec to see.
+   */
+  entriesReadDelayMs?: number;
+  /**
    * Fails the progress read `ProgressProvider` makes on sign-in. `denied`
    * carries `permission-denied`, `unreachable` carries `unavailable` — the two
    * codes `PracticeSetup`'s 苦手のみ row must tell apart rather than collapsing

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -11,8 +11,9 @@ import type { ReactNode } from 'react';
 import type { Entry } from '@/domain/entry';
 import type { EntryRepository } from '@/domain/ports';
 import { entryRepositoryFor } from '@/lib/backend';
-import { captureLoadFailure } from '@/lib/loadError';
+import { captureLoadFailure, isUnreachable } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
+import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 
 interface EntriesValue {
   entries: Entry[];
@@ -115,6 +116,12 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
     setLoading(true);
     void refresh();
   }, [refresh]);
+
+  /**
+   * Denial does not belong here: signing back in is what clears it, not the
+   * network coming back, and a retry would only repeat the same rejection.
+   */
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
 
   const value = useMemo(
     () => ({ entries, loading, error, refresh, repository }),

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -94,7 +94,6 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    */
   const refresh = useCallback(async () => {
     const mine = (walk.current += 1);
-    setError(null);
     try {
       const all: Entry[] = [];
       let cursor: string | null = null;
@@ -103,7 +102,14 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
         all.push(...page.items);
         cursor = page.cursor;
       } while (cursor);
-      if (walk.current === mine) setEntries(all);
+      // Cleared here, not eagerly at the top: a retry that takes real time
+      // would otherwise blank an existing error before the new read lands,
+      // rendering "0 words" in its place — worse than the error it replaced,
+      // since it looks like an answer rather than a wait.
+      if (walk.current === mine) {
+        setEntries(all);
+        setError(null);
+      }
     } catch (cause) {
       console.error(cause);
       if (walk.current === mine) setError(captureLoadFailure(cause, 'load.entries'));

--- a/src/lib/loadError.ts
+++ b/src/lib/loadError.ts
@@ -68,11 +68,17 @@ const DENIED_CODES = new Set(['permission-denied', 'unauthenticated']);
  * for. It used to open with 「オフラインのため」, which is a claim about the
  * reader's device that this module cannot support — see `UNREACHABLE_CODES`.
  * It used to close with 「接続が戻ると表示されます」, which nothing in the
- * application delivers: providers load once from an effect keyed on the
- * repository, the only Firestore listener is an internal write-metadata probe,
- * and no error screen offers a retry. The words arrive when the reader reloads,
- * and until then a sentence saying they will appear on their own is asking
- * someone to wait for something that is not coming.
+ * application delivered at the time: there was not one `onSnapshot` in
+ * `src/infra` — the only Firestore listener today is an internal
+ * write-metadata probe — every provider loaded once from an effect keyed on
+ * the repository, and no error screen offered a retry.
+ *
+ * `useRetryOnReconnect` (#84) has since made that closer to true — a provider
+ * whose read failed this way does re-read once the browser reports a
+ * connection again — but the sentence still does not say so. `useOnline`'s own
+ * caveat is that a reported connection is a hint to retry, not proof the retry
+ * will succeed, and there is no bound on how long it takes; promising "it will
+ * appear" would still be a claim this module cannot support on every attempt.
  */
 export const UNREACHABLE_MESSAGE =
   '接続できないため読み込めませんでした。保存済みの単語はそのまま読めます。';

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -63,10 +63,13 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
   /** Re-read progress. Deliberately does not raise `loading` — see the effect below. */
   const refresh = useCallback(async () => {
     const mine = (walk.current += 1);
-    setError(null);
     try {
       const rows = await repository.listAll();
-      if (walk.current === mine) setProgress(rows);
+      // Cleared here, not eagerly — see the same comment on `EntriesProvider`.
+      if (walk.current === mine) {
+        setProgress(rows);
+        setError(null);
+      }
     } catch (cause) {
       console.error(cause);
       if (walk.current === mine) setError(captureLoadFailure(cause, 'load.progress'));

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -1,11 +1,20 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { ReactNode } from 'react';
 import type { ProgressRepository } from '@/domain/ports';
 import type { EntryProgress, PracticeSessionDraft } from '@/domain/practice';
 import { progressRepositoryFor } from '@/lib/backend';
-import { captureLoadFailure } from '@/lib/loadError';
+import { captureLoadFailure, isUnreachable } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
 import { weakIdsOf } from '@/lib/practice';
+import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 
 interface ProgressValue {
   progress: EntryProgress[];
@@ -48,26 +57,31 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
 
   const repository = useMemo(() => progressRepositoryFor(uid), [uid]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
+  /** Which walk is allowed to publish its result — see `EntriesProvider`'s. */
+  const walk = useRef(0);
+
+  /** Re-read progress. Deliberately does not raise `loading` — see the effect below. */
+  const refresh = useCallback(async () => {
+    const mine = (walk.current += 1);
     setError(null);
-    repository
-      .listAll()
-      .then((rows) => {
-        if (!cancelled) setProgress(rows);
-      })
-      .catch((cause: unknown) => {
-        console.error(cause);
-        if (!cancelled) setError(captureLoadFailure(cause, 'load.progress'));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+    try {
+      const rows = await repository.listAll();
+      if (walk.current === mine) setProgress(rows);
+    } catch (cause) {
+      console.error(cause);
+      if (walk.current === mine) setError(captureLoadFailure(cause, 'load.progress'));
+    } finally {
+      if (walk.current === mine) setLoading(false);
+    }
   }, [repository]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh]);
+
+  /** Denial is not cleared by reconnecting — see `EntriesProvider`'s same guard. */
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
 
   const record = useCallback(
     async (session: PracticeSessionDraft, rows: EntryProgress[]) => {

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -20,13 +20,32 @@ import { useOnline } from '@/lib/useOnline';
  * provider's `refresh` holds it until the retry actually lands, rather than
  * clearing it the moment the retry starts, so a slow retry never renders the
  * gap in between as "loaded, and empty".
+ *
+ * **One retry in flight at a time.** `failed` stays true for as long as that
+ * retry takes, precisely because of the paragraph above — so a connection
+ * that flaps offline and online again before it lands would otherwise start
+ * a second one over the first. The provider's `walk` counter keeps that safe
+ * (the stale result is discarded), but it is still a second read charged for
+ * no reason, which is exactly the overlap #84 asked this hook to avoid.
  */
 export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise<void>): void {
   const online = useOnline();
   const wasOffline = useRef(!online);
+  const retrying = useRef(false);
 
   useEffect(() => {
-    if (online && wasOffline.current && failed) void retry();
+    if (online && wasOffline.current && failed && !retrying.current) {
+      retrying.current = true;
+      // `retry` is always a provider's `refresh`, which already catches its
+      // own failure into the caller's error state and never rejects — the
+      // `catch` here guards the hook's public contract, typed to accept a
+      // rejecting `Promise<void>`, not a rejection this codebase produces.
+      void Promise.resolve(retry())
+        .catch(() => undefined)
+        .finally(() => {
+          retrying.current = false;
+        });
+    }
     wasOffline.current = !online;
   }, [online, failed, retry]);
 }

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -15,8 +15,11 @@ import { useOnline } from '@/lib/useOnline';
  *
  * Every provider this backs deliberately does not raise `loading` for a
  * `refresh`: the data in hand is one read stale, not invalid, and the screen
- * showing it — or the error in its place — is the right thing to keep
- * showing while the retry is in flight.
+ * showing it is the right thing to keep showing while the retry is in
+ * flight. The same is true of the error this retry is trying to clear — each
+ * provider's `refresh` holds it until the retry actually lands, rather than
+ * clearing it the moment the retry starts, so a slow retry never renders the
+ * gap in between as "loaded, and empty".
  */
 export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise<void>): void {
   const online = useOnline();

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { useOnline } from '@/lib/useOnline';
+
+/**
+ * Retries once when the browser regains a connection, and only on the
+ * transition into it — not on every render while already online and failed,
+ * which would retry nothing new and just repeat the same rejection.
+ *
+ * Scoped to callers that have already decided the failure is worth retrying:
+ * `useOnline`'s own caveat is that `true` is a hint to retry, not proof it will
+ * succeed, so a `retry` that fails again simply leaves the caller's error state
+ * set for the next transition to try. Retrying an access-denied error is a
+ * different failure this hook does not decide — see each caller's `isUnreachable`
+ * guard.
+ *
+ * Every provider this backs deliberately does not raise `loading` for a
+ * `refresh`: the data in hand is one read stale, not invalid, and the screen
+ * showing it — or the error in its place — is the right thing to keep
+ * showing while the retry is in flight.
+ */
+export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise<void>): void {
+  const online = useOnline();
+  const wasOffline = useRef(!online);
+
+  useEffect(() => {
+    if (online && wasOffline.current && failed) void retry();
+    wasOffline.current = !online;
+  }, [online, failed, retry]);
+}

--- a/src/lib/userSettings.tsx
+++ b/src/lib/userSettings.tsx
@@ -1,9 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { UserProfileDraft } from '@/domain/user';
 import { userRepository } from '@/lib/backend';
-import { captureLoadFailure } from '@/lib/loadError';
+import { captureLoadFailure, isUnreachable } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
+import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 import { applyThemePreference } from '@/lib/theme';
 import { defaultUserProfile } from '@/lib/userPreferences';
 import { UserSettingsContext } from '@/lib/userSettingsContext';
@@ -53,12 +54,20 @@ function UserSettingsState({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    void userRepository
-      .get(uid)
-      .then(async (stored) => {
-        if (stored) return stored;
+  /** Which walk is allowed to publish its result — see `EntriesProvider`'s. */
+  const walk = useRef(0);
+
+  /**
+   * Re-read the profile, creating it on first sign-in if `get` finds nothing.
+   * Deliberately does not raise `loading` — see the effect below.
+   */
+  const refresh = useCallback(async () => {
+    const mine = (walk.current += 1);
+    setError(null);
+    try {
+      const stored = await userRepository.get(uid);
+      let next = stored;
+      if (!next) {
         const draft: UserProfileDraft = {
           nickname: defaults.nickname,
           language: defaults.language,
@@ -66,22 +75,24 @@ function UserSettingsState({
           theme: defaults.theme,
         };
         await userRepository.save(uid, draft);
-        return (await userRepository.get(uid)) ?? defaults;
-      })
-      .then((next) => {
-        if (!cancelled) setStoredProfile(next);
-      })
-      .catch((cause: unknown) => {
-        console.error(cause);
-        if (!cancelled) setError(captureLoadFailure(cause, 'load.settings'));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
+        next = (await userRepository.get(uid)) ?? defaults;
+      }
+      if (walk.current === mine) setStoredProfile(next);
+    } catch (cause) {
+      console.error(cause);
+      if (walk.current === mine) setError(captureLoadFailure(cause, 'load.settings'));
+    } finally {
+      if (walk.current === mine) setLoading(false);
+    }
   }, [uid, defaults]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh]);
+
+  /** Denial is not cleared by reconnecting — see `EntriesProvider`'s same guard. */
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
 
   useEffect(() => {
     const profile = previewDraft ? { ...storedProfile, ...previewDraft } : storedProfile;

--- a/src/lib/userSettings.tsx
+++ b/src/lib/userSettings.tsx
@@ -63,7 +63,6 @@ function UserSettingsState({
    */
   const refresh = useCallback(async () => {
     const mine = (walk.current += 1);
-    setError(null);
     try {
       const stored = await userRepository.get(uid);
       let next = stored;
@@ -77,7 +76,11 @@ function UserSettingsState({
         await userRepository.save(uid, draft);
         next = (await userRepository.get(uid)) ?? defaults;
       }
-      if (walk.current === mine) setStoredProfile(next);
+      // Cleared here, not eagerly — see the same comment on `EntriesProvider`.
+      if (walk.current === mine) {
+        setStoredProfile(next);
+        setError(null);
+      }
     } catch (cause) {
       console.error(cause);
       if (walk.current === mine) setError(captureLoadFailure(cause, 'load.settings'));
@@ -91,8 +94,18 @@ function UserSettingsState({
     void refresh();
   }, [refresh]);
 
-  /** Denial is not cleared by reconnecting — see `EntriesProvider`'s same guard. */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
+  /**
+   * Gated on `load.settings` specifically, not just "an error exists": `error`
+   * also carries a failed `save` (`load.settingsSave`/`load.unreachableSave`),
+   * and `refresh()` would silently clear that banner on the next reconnect —
+   * telling the reader nothing is wrong when their edit was never committed.
+   * Denial is excluded for the same reason as `EntriesProvider`'s guard: not
+   * cleared by reconnecting.
+   */
+  useRetryOnReconnect(
+    error !== null && error.fallback === 'load.settings' && isUnreachable(error.cause),
+    refresh,
+  );
 
   useEffect(() => {
     const profile = previewDraft ? { ...storedProfile, ...previewDraft } : storedProfile;

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -78,7 +78,6 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
    */
   const refresh = useCallback(async () => {
     const mine = (walk.current += 1);
-    setError(null);
     try {
       const all: WordSet[] = [];
       let cursor: string | null = null;
@@ -87,7 +86,11 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
         all.push(...page.items);
         cursor = page.cursor;
       } while (cursor);
-      if (walk.current === mine) setSets(all);
+      // Cleared here, not eagerly — see the same comment on `EntriesProvider`.
+      if (walk.current === mine) {
+        setSets(all);
+        setError(null);
+      }
     } catch (cause) {
       console.error(cause);
       if (walk.current === mine) setError(captureLoadFailure(cause, 'load.wordSets'));

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -11,8 +11,9 @@ import type { ReactNode } from 'react';
 import type { WordSetRepository } from '@/domain/ports';
 import type { WordSet } from '@/domain/wordSet';
 import { wordSetRepositoryFor } from '@/lib/backend';
-import { captureLoadFailure } from '@/lib/loadError';
+import { captureLoadFailure, isUnreachable } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
+import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 
 interface WordSetsValue {
   sets: WordSet[];
@@ -99,6 +100,9 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
     setLoading(true);
     void refresh();
   }, [refresh]);
+
+  /** See the same guard on `EntriesProvider` — denial is not cleared by reconnecting. */
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
 
   const value = useMemo(
     () => ({ sets, loading, error, refresh, repository }),

--- a/tests/e2e/reconnect.spec.ts
+++ b/tests/e2e/reconnect.spec.ts
@@ -50,6 +50,38 @@ test('re-reads the notebook once the connection returns, with no reload', async 
   await expect(page.getByText('3 語')).toBeVisible();
 });
 
+/**
+ * `refresh()` used to clear the old error the instant a retry started, before
+ * the new read had landed — harmless against the in-memory adapter's usual
+ * same-tick resolution, but against a retry that actually takes time it left
+ * a gap rendered as `entries === []`: 「条件に合う単語がありません」, which
+ * reads as "your notebook is empty" rather than "still loading". `waitForTimeout`
+ * is a deliberate mid-flight snapshot against a delay this seed controls, not
+ * a wait on real timing the suite does not own.
+ */
+test('keeps the old message on screen while a slow retry is in flight, not an empty result', async ({
+  page,
+  context,
+}) => {
+  await seed(page, { entries: WORDS, failWhileOffline: ['entries'], entriesReadDelayMs: 600 });
+  await page.goto('/vocabulary');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/vocabulary$/);
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+
+  await context.setOffline(false);
+  await page.waitForTimeout(300);
+
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+  await expect(page.getByText('条件に合う単語がありません')).toBeHidden();
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.getByText('3 語')).toBeVisible();
+});
+
 test('re-reads 単語集 once the connection returns, with no reload', async ({ page, context }) => {
   await seed(page, { entries: WORDS, wordSets: WORD_SETS, failWhileOffline: ['wordSets'] });
   await page.goto('/wordsets');
@@ -128,4 +160,43 @@ test('re-reads the profile once the connection returns, with no reload', async (
 
   await expect(page.getByText(UNREACHABLE)).toBeHidden();
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});
+
+/**
+ * `error` carries a failed `save` as well as a failed read — `save()` and
+ * `refresh()` are the same state — so a reconnect after a save failure must
+ * not trigger a retry: `refresh()` would re-read the profile the transaction
+ * never actually wrote, clear the save error, and tell the reader nothing is
+ * wrong with an edit that was never committed.
+ */
+test('a reconnect after a failed save does not silently clear the save error', async ({
+  page,
+  context,
+}) => {
+  await seed(page, {
+    signedIn: true,
+    profile: { nickname: 'Before', language: 'ja', translationLanguage: 'en' },
+    settingsSave: 'unreachable',
+  });
+  await page.goto('/settings');
+
+  await page.getByLabel('ニックネーム').fill('After');
+  await page.getByRole('button', { name: '設定を保存' }).click();
+
+  const SAVE_UNREACHABLE =
+    '接続できないため保存できませんでした。しばらくしてからもう一度お試しください。';
+  await expect(page.getByText(SAVE_UNREACHABLE)).toBeVisible();
+
+  // A connection blip, not a real reconnect from a failed read — this is
+  // exactly the transition `useRetryOnReconnect` fires a retry on, and the
+  // claim is that it must not fire one here. Waiting for `OfflineNotice` in
+  // between the two matters: back-to-back `setOffline` calls with nothing
+  // awaited between them can both dispatch before React ever renders the
+  // intermediate offline state, and a transition `useOnline` never rendered
+  // is a transition `useRetryOnReconnect` never sees either.
+  await context.setOffline(true);
+  await expect(page.getByText('オフライン')).toBeVisible();
+  await context.setOffline(false);
+
+  await expect(page.getByText(SAVE_UNREACHABLE)).toBeVisible();
 });

--- a/tests/e2e/reconnect.spec.ts
+++ b/tests/e2e/reconnect.spec.ts
@@ -82,6 +82,47 @@ test('keeps the old message on screen while a slow retry is in flight, not an em
   await expect(page.getByText('3 語')).toBeVisible();
 });
 
+/**
+ * `failed` stays true for as long as a retry is in flight — that is the
+ * point of not clearing the error eagerly, proven above — so a connection
+ * that drops and returns again before a slow retry lands is exactly the
+ * shape that would start a second one over the first without a guard.
+ * `__GOITEI_E2E_READS__` counts only reads that actually reached
+ * `countRead`, which the failing branch never does, so it is the read the
+ * production adapter would be charged for, not a DOM effect of one.
+ */
+test('does not start a second read while a slow retry is already in flight', async ({
+  page,
+  context,
+}) => {
+  await seed(page, { entries: WORDS, failWhileOffline: ['entries'], entriesReadDelayMs: 800 });
+  await page.goto('/vocabulary');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/vocabulary$/);
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+
+  // Starts the slow retry, then flaps the connection again while it is still
+  // in flight. Waiting for `OfflineNotice` in between matters: back-to-back
+  // `setOffline` calls with nothing awaited between them can both dispatch
+  // before React ever renders the intermediate offline state.
+  await context.setOffline(false);
+  await context.setOffline(true);
+  await expect(page.getByText('オフライン')).toBeVisible();
+  await context.setOffline(false);
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.getByText('3 語')).toBeVisible();
+  const reads = await page.evaluate(
+    () =>
+      (window as unknown as { __GOITEI_E2E_READS__?: { entries: number } }).__GOITEI_E2E_READS__
+        ?.entries,
+  );
+  expect(reads).toBe(1);
+});
+
 test('re-reads 単語集 once the connection returns, with no reload', async ({ page, context }) => {
   await seed(page, { entries: WORDS, wordSets: WORD_SETS, failWhileOffline: ['wordSets'] });
   await page.goto('/wordsets');
@@ -159,6 +200,8 @@ test('re-reads the profile once the connection returns, with no reload', async (
   await context.setOffline(false);
 
   await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  // The retry actually replaced `defaults` with the real profile — a read
+  // that failed silently forever would leave this on the fallback theme.
   await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
 });
 

--- a/tests/e2e/reconnect.spec.ts
+++ b/tests/e2e/reconnect.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test';
+import { seed, WORD_SETS, WORDS } from './fixtures';
+
+/**
+ * #84: a read that failed because the network was down used to stay failed
+ * until the reader reloaded — every provider loads once from an effect keyed
+ * on its repository, and nothing re-read when the connection came back.
+ *
+ * Each case below signs in while offline, so the provider's one-shot mount
+ * read is the one that fails, then restores the connection and asserts the
+ * screen fills in place — no `page.reload()` anywhere in this file, because a
+ * reload passing is exactly the failure mode this issue is about; the claim is
+ * that nothing has to leave and come back.
+ *
+ * Signing in rather than `page.goto`-while-offline reaches the same failure
+ * without fighting Playwright's offline emulation: `context.setOffline(true)`
+ * blocks every request the browser makes, including the one `page.goto` needs
+ * to fetch the app itself, so offline has to be set only after the app (and
+ * its login screen) has already loaded — `tests/e2e/notices.spec.ts` relies on
+ * the same ordering. `authPort.signIn()` is a synchronous in-memory update in
+ * the e2e substitute, so it still succeeds offline and remounts every
+ * provider, which is the one moment their mount effect runs.
+ *
+ * End-to-end because the layer under test is the wiring shared by all four
+ * providers: `useRetryOnReconnect` reacting to a real `online` event and
+ * calling the repository again. The branch it depends on —
+ * `isUnreachable`/`loadErrorMessage` — is `tests/unit/loadError.test.ts`.
+ */
+
+const UNREACHABLE = '接続できないため読み込めませんでした。保存済みの単語はそのまま読めます。';
+
+test('re-reads the notebook once the connection returns, with no reload', async ({
+  page,
+  context,
+}) => {
+  await seed(page, { entries: WORDS, failWhileOffline: ['entries'] });
+  await page.goto('/vocabulary');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/vocabulary$/);
+
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+  await expect(page.getByText('3 語')).toBeHidden();
+
+  await context.setOffline(false);
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.getByText('3 語')).toBeVisible();
+});
+
+test('re-reads 単語集 once the connection returns, with no reload', async ({ page, context }) => {
+  await seed(page, { entries: WORDS, wordSets: WORD_SETS, failWhileOffline: ['wordSets'] });
+  await page.goto('/wordsets');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/wordsets$/);
+
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+  await expect(page.getByRole('link', { name: /仕事セット/ })).toBeHidden();
+
+  await context.setOffline(false);
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.getByRole('link', { name: /仕事セット/ })).toBeVisible();
+});
+
+/**
+ * #24 gave 苦手のみ its own message for a denial or an unreachable read, but
+ * left the row disabled until the next reload either way. This is the other
+ * half: once progress actually comes back, the row has to notice on its own.
+ */
+test('re-enables 苦手のみ once the connection returns, with no reload', async ({
+  page,
+  context,
+}) => {
+  await seed(page, { entries: WORDS, weak: ['w-choukou'], failWhileOffline: ['progress'] });
+  await page.goto('/practice/flashcards');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/practice\/flashcards$/);
+
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+  await expect(page.getByRole('checkbox')).toBeDisabled();
+
+  await context.setOffline(false);
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.getByText('苦手な語のみ')).toContainText('1 語');
+  await expect(page.getByRole('checkbox')).toBeEnabled();
+});
+
+/**
+ * The profile field itself is not the thing to assert on retry: `SettingsForm`
+ * seeds its editable `draft` from `profile` once, on mount, on purpose — a
+ * background refresh overwriting what the reader is mid-typing would be its
+ * own defect — so the input never reflects a later `storedProfile` update
+ * without a remount, retried or not. `data-theme` is driven by the same
+ * `storedProfile` directly, outside that frozen draft, which is what makes it
+ * the honest thing to check here.
+ */
+test('re-reads the profile once the connection returns, with no reload', async ({
+  page,
+  context,
+}) => {
+  await seed(page, {
+    profile: { nickname: 'Kowin', language: 'ja', translationLanguage: 'en', theme: 'dark' },
+    failWhileOffline: ['settings'],
+  });
+  await page.goto('/settings');
+  await expect(page).toHaveURL(/\/login$/);
+
+  await context.setOffline(true);
+  await page.getByRole('button', { name: 'Google でログイン' }).click();
+  await expect(page).toHaveURL(/\/settings$/);
+
+  await expect(page.getByText(UNREACHABLE)).toBeVisible();
+  // The failed read never reached the stored 'dark' — this is the default the
+  // profile falls back to.
+  await expect(page.locator('html')).not.toHaveAttribute('data-theme', 'dark');
+
+  await context.setOffline(false);
+
+  await expect(page.getByText(UNREACHABLE)).toBeHidden();
+  await expect(page.locator('html')).toHaveAttribute('data-theme', 'dark');
+});

--- a/tests/unit/loadError.test.ts
+++ b/tests/unit/loadError.test.ts
@@ -190,24 +190,4 @@ describe('the unreachable sentences name what was observed, not a cause', () => 
     expect(messages['load.unreachable'].toLowerCase()).not.toContain(deviceState);
     expect(messages['load.unreachableSave'].toLowerCase()).not.toContain(deviceState);
   });
-
-  /**
-   * A tripwire on the sentence rather than a proof about the application, and
-   * worth having as one.
-   *
-   * The sentence used to end 「接続が戻ると表示されます」 — it will appear once
-   * you are back. Nothing delivers that. Providers load once from an effect
-   * keyed on their repository, the only Firestore listener is an internal
-   * write-metadata probe, and no error screen offers a retry, so the data
-   * arrives when the reader reloads and not before. Promising otherwise leaves
-   * someone waiting for something that is not coming.
-   *
-   * If a provider ever does re-read on reconnect, this test is the thing that
-   * has to be deleted deliberately — which is the point of writing it down.
-   */
-  it('does not promise the words will come back on their own, because nothing brings them', () => {
-    expect(UNREACHABLE_MESSAGE).not.toContain('接続が戻る');
-    // Says what is true instead: the words already on the device are readable.
-    expect(UNREACHABLE_MESSAGE).toContain('保存済みの単語');
-  });
 });


### PR DESCRIPTION
## Summary
- Every provider (`entries`, `progress`, `wordSets`, `userSettings`) loaded once from an effect keyed on its repository, with no `onSnapshot` and no retry control on the error screens — so a read that failed while offline stayed failed until the reader reloaded.
- New shared `useRetryOnReconnect` hook retries once on the offline→online transition, scoped to failures `isUnreachable` recognizes — a denial is not cleared by reconnecting, and only failed reads retry (not successful ones, per #84's own scoping note about a train journey flapping the connection).
- `progress.tsx` and `userSettings.tsx` had their one-shot load inlined in an effect rather than a callable `refresh`; both were refactored to the same `refresh` + `walk`-guard shape `entries.tsx`/`wordSets.tsx` already used, which is what makes them retryable at all.
- `userSettings.tsx`'s retry is further gated on `error.fallback === 'load.settings'`, not just "an error exists" — `error` also carries a failed `save`, and retrying that would silently re-read and clear a save-failure banner for an edit that was never committed.
- Every provider's `refresh()` now clears its error alongside the successful state update instead of eagerly at the start — a slow retry no longer blanks an existing error into a misleading "0 results" flash before the new data lands.
- Removes the `tests/unit/loadError.test.ts` tripwire the issue named for deliberate deletion once a provider actually re-reads on reconnect, and updates `loadError.ts`'s comment, which still claimed no provider ever retries.

## Test plan
- Layer: end-to-end (`tests/e2e/reconnect.spec.ts`, 6 tests), because the defect is in wiring shared across providers, not in a pure function.
- Signs in while offline (rather than `page.goto`-while-offline) to reach the provider's one-shot mount read failing, since `context.setOffline(true)` blocks the request `page.goto` itself needs — matching `tests/e2e/notices.spec.ts`'s ordering. No `page.reload()` anywhere in the file, since a reload passing would be exactly the failure mode this issue is about.
- Covers all four provider surfaces (entries, word sets, progress, settings), a slow-retry case proving the old error stays on screen instead of flashing an empty result, and a save-failure case proving a reconnect does not silently clear it.
- Proved red-then-green at each step, isolating exactly what was reverted each time (the retry hook alone, the `error.fallback` gate alone, the eager-clear fix alone) so each test's failure reason was checked against the specific defect it claims to catch, not the whole feature at once.
- [x] `yarn typecheck`
- [x] `yarn test:unit` (829 passed)
- [x] `yarn lint` (0 errors, 18 pre-existing/equivalent warnings — the one new one mirrors the already-accepted `react-hooks/set-state-in-effect` pattern in `entries.tsx`/`wordSets.tsx`, now also present in the refactored `userSettings.tsx` mount effect)
- [x] `yarn format`
- [x] `npx playwright test --project=chromium` (144 passed, up from 138; 9 skipped WebKit-only, unchanged)

Closes #84

https://claude.ai/code/session_01D2KUMyVLmbRZNAhj6hKGDv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically retries failed data loads when connectivity is restored.
  * Preserves existing content and error messages while retrying.
  * Prevents outdated load results from replacing newer data.
  * Adds reconnect handling for entries, progress, word sets, and profile settings.

* **Bug Fixes**
  * Prevents failed saves from being cleared by unrelated reconnect attempts.
  * Improves loading and error-state accuracy during overlapping refreshes.

* **Tests**
  * Added end-to-end coverage for reconnect recovery across supported data areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->