### PR TITLE
fix(admin): set ADC quota project for allow

### DIFF
--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -77,7 +77,7 @@ export function describeCredentialSource(env: CredentialEnv): string {
   if (env.GOOGLE_APPLICATION_CREDENTIALS) {
     return `GOOGLE_APPLICATION_CREDENTIALS=${env.GOOGLE_APPLICATION_CREDENTIALS}`;
   }
-  const quotaProject = env.GOOGLE_CLOUD_QUOTA_PROJECT ?? 'unset';
+  const quotaProject = env.GOOGLE_CLOUD_QUOTA_PROJECT?.trim() || 'unset';
   if (env.CLOUDSDK_CONFIG) {
     return `applicationDefault() with CLOUDSDK_CONFIG=${env.CLOUDSDK_CONFIG}, GOOGLE_CLOUD_QUOTA_PROJECT=${quotaProject}`;
   }
@@ -85,7 +85,9 @@ export function describeCredentialSource(env: CredentialEnv): string {
 }
 
 export function ensureAdcQuotaProject(env: CredentialEnv, projectId: string): void {
-  env.GOOGLE_CLOUD_QUOTA_PROJECT ??= projectId;
+  if (!env.GOOGLE_CLOUD_QUOTA_PROJECT?.trim()) {
+    env.GOOGLE_CLOUD_QUOTA_PROJECT = projectId;
+  }
 }
 
 export function lookupErrorCode(cause: unknown): string | undefined {

--- a/admin/allow-user.shared.ts
+++ b/admin/allow-user.shared.ts
@@ -1,6 +1,7 @@
 type CredentialEnv = {
   CLOUDSDK_CONFIG?: string;
   GOOGLE_APPLICATION_CREDENTIALS?: string;
+  GOOGLE_CLOUD_QUOTA_PROJECT?: string;
 };
 
 export type ParsedAllowUserArgs =
@@ -76,10 +77,15 @@ export function describeCredentialSource(env: CredentialEnv): string {
   if (env.GOOGLE_APPLICATION_CREDENTIALS) {
     return `GOOGLE_APPLICATION_CREDENTIALS=${env.GOOGLE_APPLICATION_CREDENTIALS}`;
   }
+  const quotaProject = env.GOOGLE_CLOUD_QUOTA_PROJECT ?? 'unset';
   if (env.CLOUDSDK_CONFIG) {
-    return `applicationDefault() with CLOUDSDK_CONFIG=${env.CLOUDSDK_CONFIG}`;
+    return `applicationDefault() with CLOUDSDK_CONFIG=${env.CLOUDSDK_CONFIG}, GOOGLE_CLOUD_QUOTA_PROJECT=${quotaProject}`;
   }
-  return 'applicationDefault() with CLOUDSDK_CONFIG unset';
+  return `applicationDefault() with CLOUDSDK_CONFIG unset, GOOGLE_CLOUD_QUOTA_PROJECT=${quotaProject}`;
+}
+
+export function ensureAdcQuotaProject(env: CredentialEnv, projectId: string): void {
+  env.GOOGLE_CLOUD_QUOTA_PROJECT ??= projectId;
 }
 
 export function lookupErrorCode(cause: unknown): string | undefined {

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -1,6 +1,11 @@
 import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
 import { getAuth, type UserRecord } from 'firebase-admin/auth';
-import { lookupErrorCode, lookupFailureLines, parseAllowUserArgs } from './allow-user.shared';
+import {
+  ensureAdcQuotaProject,
+  lookupErrorCode,
+  lookupFailureLines,
+  parseAllowUserArgs,
+} from './allow-user.shared';
 
 /**
  * Grant or revoke access, by custom claim.
@@ -39,6 +44,7 @@ const { email, revoke, projectId } = parsed;
 
 if (getApps().length === 0) {
   const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!key) ensureAdcQuotaProject(process.env, projectId);
   initializeApp({
     credential: key ? cert(key) : applicationDefault(),
     projectId,

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -109,6 +109,15 @@ describe('allow-user helpers', () => {
     );
   });
 
+  it('describeCredentialSource reports an empty quota project as unset', () => {
+    expect(
+      describeCredentialSource({
+        CLOUDSDK_CONFIG: '.gcloud',
+        GOOGLE_CLOUD_QUOTA_PROJECT: '',
+      }),
+    ).toBe('applicationDefault() with CLOUDSDK_CONFIG=.gcloud, GOOGLE_CLOUD_QUOTA_PROJECT=unset');
+  });
+
   it('describeCredentialSource reports when no gcloud directory is configured', () => {
     expect(describeCredentialSource({})).toBe(
       'applicationDefault() with CLOUDSDK_CONFIG unset, GOOGLE_CLOUD_QUOTA_PROJECT=unset',
@@ -117,6 +126,14 @@ describe('allow-user helpers', () => {
 
   it('ensureAdcQuotaProject defaults user ADC billing to the target project', () => {
     const env: { GOOGLE_CLOUD_QUOTA_PROJECT?: string } = {};
+
+    ensureAdcQuotaProject(env, 'goitei-dev');
+
+    expect(env.GOOGLE_CLOUD_QUOTA_PROJECT).toBe('goitei-dev');
+  });
+
+  it('ensureAdcQuotaProject treats an empty quota project as missing billing configuration', () => {
+    const env = { GOOGLE_CLOUD_QUOTA_PROJECT: '' };
 
     ensureAdcQuotaProject(env, 'goitei-dev');
 

--- a/tests/unit/allowUser.test.ts
+++ b/tests/unit/allowUser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   describeCredentialSource,
+  ensureAdcQuotaProject,
   lookupErrorCode,
   lookupFailureLines,
   parseAllowUserArgs,
@@ -93,12 +94,41 @@ describe('allow-user helpers', () => {
 
   it('describeCredentialSource falls back to a configured CLOUDSDK_CONFIG directory', () => {
     expect(describeCredentialSource({ CLOUDSDK_CONFIG: '.gcloud' })).toBe(
-      'applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
+      'applicationDefault() with CLOUDSDK_CONFIG=.gcloud, GOOGLE_CLOUD_QUOTA_PROJECT=unset',
+    );
+  });
+
+  it('describeCredentialSource reports the quota project used by user ADC credentials', () => {
+    expect(
+      describeCredentialSource({
+        CLOUDSDK_CONFIG: '.gcloud',
+        GOOGLE_CLOUD_QUOTA_PROJECT: 'goitei-dev',
+      }),
+    ).toBe(
+      'applicationDefault() with CLOUDSDK_CONFIG=.gcloud, GOOGLE_CLOUD_QUOTA_PROJECT=goitei-dev',
     );
   });
 
   it('describeCredentialSource reports when no gcloud directory is configured', () => {
-    expect(describeCredentialSource({})).toBe('applicationDefault() with CLOUDSDK_CONFIG unset');
+    expect(describeCredentialSource({})).toBe(
+      'applicationDefault() with CLOUDSDK_CONFIG unset, GOOGLE_CLOUD_QUOTA_PROJECT=unset',
+    );
+  });
+
+  it('ensureAdcQuotaProject defaults user ADC billing to the target project', () => {
+    const env: { GOOGLE_CLOUD_QUOTA_PROJECT?: string } = {};
+
+    ensureAdcQuotaProject(env, 'goitei-dev');
+
+    expect(env.GOOGLE_CLOUD_QUOTA_PROJECT).toBe('goitei-dev');
+  });
+
+  it('ensureAdcQuotaProject preserves an operator supplied quota project', () => {
+    const env = { GOOGLE_CLOUD_QUOTA_PROJECT: 'billing-project' };
+
+    ensureAdcQuotaProject(env, 'goitei-dev');
+
+    expect(env.GOOGLE_CLOUD_QUOTA_PROJECT).toBe('billing-project');
   });
 
   it('lookupFailureLines keeps auth/user-not-found failures on the signed-in-once guidance', () => {
@@ -122,7 +152,7 @@ describe('allow-user helpers', () => {
       ),
     ).toEqual([
       'failed to look up reader@example.com in goitei (app/invalid-credential).',
-      'credential configuration: applicationDefault() with CLOUDSDK_CONFIG=.gcloud',
+      'credential configuration: applicationDefault() with CLOUDSDK_CONFIG=.gcloud, GOOGLE_CLOUD_QUOTA_PROJECT=unset',
     ]);
   });
 


### PR DESCRIPTION
## Summary

Fixes #133.

`yarn allow` now sets `GOOGLE_CLOUD_QUOTA_PROJECT` to the target Firebase project before initializing Admin SDK with user ADC. Service-account credentials still use `cert()` unchanged, and an operator-supplied quota project is preserved.

## Changes

- Default `GOOGLE_CLOUD_QUOTA_PROJECT` on the `applicationDefault()` path only.
- Include `GOOGLE_CLOUD_QUOTA_PROJECT` in credential diagnostics for non-`auth/user-not-found` lookup failures.
- Add unit coverage for quota project diagnostics, defaulting, and preserving an explicit quota project.

## Testing

Test layer chosen: unit tests, because the new defaulting and diagnostic behavior are pure functions of environment input.

- `yarn vitest run --project unit tests/unit/allowUser.test.ts`
- `yarn typecheck`
- `yarn test:unit`
- `yarn format`

Red-test verification:

- Temporarily removed the `ensureAdcQuotaProject()` assignment.
- Confirmed only `ensureAdcQuotaProject defaults user ADC billing to the target project` failed.
- Restored the implementation and reran the targeted test successfully.

Live ADC verification:

- Ran `env -u GOOGLE_CLOUD_QUOTA_PROJECT CLOUDSDK_CONFIG=.gcloud yarn allow codex-nonexistent-allow-user-probe-20260825@example.invalid --project goitei-dev` after the fix.
- The command reached the expected `has never signed in to goitei-dev` lookup guidance, which means the Identity Toolkit call succeeded far enough to return `auth/user-not-found` instead of failing on missing quota project.
- I did not run a pre-fix live repro against the current `firebase-admin`; the pre-fix failure mode was covered by the red unit test above, and the fixed live path was verified with repo-local user ADC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application-default credential handling by automatically setting the Google Cloud quota project when it is not provided.
  * Credential diagnostics now display the configured quota project, or `unset` when unavailable.
  * Existing operator-supplied quota project values are preserved.

* **Tests**
  * Added coverage for quota-project defaults, preservation, diagnostics, and credential lookup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->