### PR TITLE
docs(readme): record what branch protection enforces on each branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,17 @@ broke: `verify` (typecheck, lint, format, build, unit), `emulator`, and `e2e`.
 `.firebaserc` maps `default` and `dev` to `goitei-dev`, and `prod` to `goitei`,
 so a deploy with no `--project` targets development. Branches follow the same
 split — `develop` for dev, `main` for production. Both are protected: changes
-land through a pull request with a green CI run, and neither accepts a force
-push.
+must land through a pull request, all review threads must be resolved, and
+neither branch allows force pushes or deletion. The required checks match what
+each branch can affect: `develop` requires `verify`, while `main` requires
+`verify`, `emulator` and `e2e`, because production deploys only from commits
+that have already landed on `main`.
+
+Branch protection is a repository setting, so no pull request reports a change
+to it and nothing in this tree enforces it. It is recorded here for the same
+reason `pr-title.yml` keeps `validateSingleCommit` next to the repository
+setting that already covers it: the setting is the enforcement, and this file is
+the version-controlled record reviewers can inspect.
 
 Pushing to `develop` deploys hosting and Firestore rules to `goitei-dev`, and a
 pull request gets its own Hosting preview channel that expires after six days


### PR DESCRIPTION
## What

The Environments section of `README.md` said only that `main` and `develop` were
both protected and that neither accepted a force push. It now names what each
branch actually requires: `verify` on `develop`, and `verify`, `emulator` and
`e2e` on `main`, plus conversation resolution and the deletion block on both.

## Why

Branch protection is a repository setting. A change to it is invisible to anyone
reading this repository, and no pull request reports one — so the only defence
against it drifting is a version-controlled description that a reviewer can
compare against.

That is the same argument `pr-title.yml` already makes for keeping
`validateSingleCommit` next to a repository setting that covers the same case,
and the comment there says so explicitly.

The values were read back from the live protection settings rather than copied
from an existing description.

## Related cleanup, done outside this branch

A repository ruleset named "main branch protection" was deleted. It was
`enforcement: disabled`, and its condition was `~DEFAULT_BRANCH` — which resolves
at evaluation time, so it silently followed the default branch when that moved
from `main` to `develop` and stopped matching its own name. Its two rules,
`deletion` and `non_fast_forward`, are already enforced on both branches by the
branch protection this pull request documents, so it changed no behaviour while
suggesting to a reader of the settings page that `main` was protected by
something it was not.

## Tests

None. Documentation only — no layer from `CLAUDE.md`'s table can observe a
change to prose. `format:check` covers the file, and it passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the Environments documentation with details about pull-request-based branch protection for `develop` and `main`.
  * Documented required status checks, resolved review threads, and restrictions on force pushes and branch deletion.
  * Clarified that these protections are configured as repository settings and are not enforced by the repository itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->