### PR TITLE
fix(pwa): self-host Japanese display font

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,12 +45,6 @@
       launch splash screen uses.
     -->
     <meta name="theme-color" content="#f7fbf9" data-light="#f7fbf9" data-dark="#0d1a16" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;700&family=Zen+Maru+Gothic:wght@500;700;900&display=swap"
-      rel="stylesheet"
-    />
     <script>
       // Applied before first paint so the page never flashes the wrong theme.
       (() => {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "rules:prod": "firebase deploy --only firestore:rules --project prod"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.3.0",
+    "@fontsource/noto-sans-tc": "^5.3.0",
     "@fontsource/zen-maru-gothic": "^5.3.0",
     "firebase": "^12.18.0",
     "react": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rules:prod": "firebase deploy --only firestore:rules --project prod"
   },
   "dependencies": {
+    "@fontsource/zen-maru-gothic": "^5.3.0",
     "firebase": "^12.18.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/pwa-config.ts
+++ b/pwa-config.ts
@@ -79,7 +79,7 @@ export const pwaOptions = (mode: string): Partial<VitePWAOptions> => ({
      * it, and an installed window that cannot read its own manifest offline is
      * the case this whole change is for.
      */
-    globPatterns: ['**/*.{js,css,html,svg,png,webmanifest}'],
+    globPatterns: ['**/*.{js,css,html,svg,png,webmanifest,woff2}'],
 
     /**
      * Matches the `rewrites` block in `firebase.json`: without a navigation

--- a/src/index.css
+++ b/src/index.css
@@ -72,9 +72,59 @@
   font-family: 'Zen Maru Gothic';
   font-style: normal;
   font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-latin-ext-500-normal.woff2')
+    format('woff2');
+  unicode-range:
+    U+0100-02ba, U+02bd-02c5, U+02c7-02cc, U+02ce-02d7, U+02dd-02ff, U+0304, U+0308, U+0329,
+    U+1d00-1dbf, U+1e00-1e9f, U+1ef2-1eff, U+2020, U+20a0-20ab, U+20ad-20c0, U+2113, U+2c60-2c7f,
+    U+a720-a7ff;
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-latin-500-normal.woff2')
+    format('woff2');
+  unicode-range:
+    U+0000-00ff, U+0131, U+0152-0153, U+02bb-02bc, U+02c6, U+02da, U+02dc, U+0304, U+0308, U+0329,
+    U+2000-206f, U+20ac, U+2122, U+2191, U+2193, U+2212, U+2215, U+feff, U+fffd;
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
   font-weight: 700;
   src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-japanese-700-normal.woff2')
     format('woff2');
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-latin-ext-700-normal.woff2')
+    format('woff2');
+  unicode-range:
+    U+0100-02ba, U+02bd-02c5, U+02c7-02cc, U+02ce-02d7, U+02dd-02ff, U+0304, U+0308, U+0329,
+    U+1d00-1dbf, U+1e00-1e9f, U+1ef2-1eff, U+2020, U+20a0-20ab, U+20ad-20c0, U+2113, U+2c60-2c7f,
+    U+a720-a7ff;
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-latin-700-normal.woff2')
+    format('woff2');
+  unicode-range:
+    U+0000-00ff, U+0131, U+0152-0153, U+02bb-02bc, U+02c6, U+02da, U+02dc, U+0304, U+0308, U+0329,
+    U+2000-206f, U+20ac, U+2122, U+2191, U+2193, U+2212, U+2215, U+feff, U+fffd;
 }
 
 /*

--- a/src/index.css
+++ b/src/index.css
@@ -212,7 +212,7 @@
   /* Self-hosted faces keep the app readable offline without widening the CSP past 'self'. */
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Noto Sans TC', 'Hiragino Sans', sans-serif;
+  --font-cjk: 'Zen Maru Gothic', 'Hiragino Sans', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */
@@ -224,6 +224,12 @@
   --radius-pill: 999px;
 
   --shadow-panel: var(--shadow-card);
+}
+
+:root:lang(zh-Hant),
+:root:lang(zh-HK),
+:root:lang(zh-TW) {
+  --font-cjk: 'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
 }
 
 /*

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,65 @@
 @import 'tailwindcss';
 
 @font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/inter/files/inter-latin-400-normal.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/inter/files/inter-latin-500-normal.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 600;
+  src: url('@fontsource/inter/files/inter-latin-600-normal.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/inter/files/inter-latin-700-normal.woff2') format('woff2');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-400-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-500-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-700-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
   font-family: 'Zen Maru Gothic';
   font-style: normal;
   font-display: swap;
@@ -100,10 +159,10 @@
   --color-danger: var(--c-danger);
   --color-danger-soft: var(--c-danger-soft);
 
-  /* System UI for chrome, self-hosted Zen Maru Gothic for headwords, platform CJK faces for prose. */
-  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  /* Self-hosted faces keep the app readable offline without widening the CSP past 'self'. */
+  --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Hiragino Sans', 'Yu Gothic', Meiryo, 'PingFang TC', 'Microsoft JhengHei', sans-serif;
+  --font-cjk: 'Noto Sans TC', 'Hiragino Sans', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */
@@ -259,8 +318,7 @@ body {
 }
 
 :lang(zh-Hant) .prose-cjk {
-  font-family:
-    'PingFang TC', 'Microsoft JhengHei', 'Hiragino Sans', 'Yu Gothic', Meiryo, sans-serif;
+  font-family: 'Noto Sans TC', 'PingFang TC', 'Microsoft JhengHei', sans-serif;
 }
 
 ruby {

--- a/src/index.css
+++ b/src/index.css
@@ -162,7 +162,7 @@
   /* Self-hosted faces keep the app readable offline without widening the CSP past 'self'. */
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Noto Sans TC', 'Hiragino Sans', sans-serif;
+  --font-cjk: 'Zen Maru Gothic', 'Hiragino Sans', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */

--- a/src/index.css
+++ b/src/index.css
@@ -212,7 +212,7 @@
   /* Self-hosted faces keep the app readable offline without widening the CSP past 'self'. */
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Zen Maru Gothic', 'Hiragino Sans', sans-serif;
+  --font-cjk: 'Hiragino Sans', 'Yu Gothic', 'Meiryo', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */

--- a/src/index.css
+++ b/src/index.css
@@ -18,15 +18,6 @@
     format('woff2');
 }
 
-@font-face {
-  font-family: 'Zen Maru Gothic';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 900;
-  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-japanese-900-normal.woff2')
-    format('woff2');
-}
-
 /*
  * Palette derived from the 語彙庭 logo, which carries two distinct greens:
  * the book and wordmark sit at hue ~169 (#014D3A, a blue-leaning forest green)
@@ -265,6 +256,11 @@ body {
   font-family: var(--font-cjk);
   line-height: 1.85;
   overflow-wrap: anywhere;
+}
+
+:lang(zh-Hant) .prose-cjk {
+  font-family:
+    'PingFang TC', 'Microsoft JhengHei', 'Hiragino Sans', 'Yu Gothic', Meiryo, sans-serif;
 }
 
 ruby {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,33 @@
 @import 'tailwindcss';
 
 @font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 400;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-400-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-500-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-700-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
   font-family: 'Inter';
   font-style: normal;
   font-display: swap;
@@ -30,33 +57,6 @@
   font-display: swap;
   font-weight: 700;
   src: url('@fontsource/inter/files/inter-latin-700-normal.woff2') format('woff2');
-}
-
-@font-face {
-  font-family: 'Noto Sans TC';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-400-normal.woff2')
-    format('woff2');
-}
-
-@font-face {
-  font-family: 'Noto Sans TC';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 500;
-  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-500-normal.woff2')
-    format('woff2');
-}
-
-@font-face {
-  font-family: 'Noto Sans TC';
-  font-style: normal;
-  font-display: swap;
-  font-weight: 700;
-  src: url('@fontsource/noto-sans-tc/files/noto-sans-tc-chinese-traditional-700-normal.woff2')
-    format('woff2');
 }
 
 @font-face {
@@ -212,7 +212,7 @@
   /* Self-hosted faces keep the app readable offline without widening the CSP past 'self'. */
   --font-sans: 'Inter', system-ui, sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Zen Maru Gothic', 'Hiragino Sans', sans-serif;
+  --font-cjk: 'Noto Sans TC', 'Hiragino Sans', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,32 @@
 @import 'tailwindcss';
 
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 500;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-japanese-500-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 700;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-japanese-700-normal.woff2')
+    format('woff2');
+}
+
+@font-face {
+  font-family: 'Zen Maru Gothic';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 900;
+  src: url('@fontsource/zen-maru-gothic/files/zen-maru-gothic-japanese-900-normal.woff2')
+    format('woff2');
+}
+
 /*
  * Palette derived from the 語彙庭 logo, which carries two distinct greens:
  * the book and wordmark sit at hue ~169 (#014D3A, a blue-leaning forest green)
@@ -82,10 +109,10 @@
   --color-danger: var(--c-danger);
   --color-danger-soft: var(--c-danger-soft);
 
-  /* Inter for UI, Zen Maru Gothic for headwords, Noto Sans TC for CJK prose. */
-  --font-sans: 'Inter', system-ui, sans-serif;
+  /* System UI for chrome, self-hosted Zen Maru Gothic for headwords, platform CJK faces for prose. */
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-display: 'Zen Maru Gothic', 'Hiragino Maru Gothic ProN', sans-serif;
-  --font-cjk: 'Noto Sans TC', 'Hiragino Sans', sans-serif;
+  --font-cjk: 'Hiragino Sans', 'Yu Gothic', Meiryo, 'PingFang TC', 'Microsoft JhengHei', sans-serif;
 
   /* The handoff collapses the nav to a hamburger below 700px, which sits
      between Tailwind's sm and md defaults, so it gets its own breakpoint. */

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -22,6 +22,7 @@ const RECAPTCHA_HOST = 'https://www.google.com';
 
 const firebaseJson = readFileSync(new URL('../../firebase.json', import.meta.url), 'utf8');
 const indexHtml = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
+const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
 const client = readFileSync(new URL('../../src/infra/firebase/client.ts', import.meta.url), 'utf8');
 
 interface Header {
@@ -64,8 +65,14 @@ describe('Content-Security-Policy against App Check', () => {
 
 describe('font loading against the self-only policy', () => {
   it('does not load Google Fonts, which the policy forbids and the worker cannot precache', () => {
-    expect(indexHtml).not.toContain('fonts.googleapis.com');
-    expect(indexHtml).not.toContain('fonts.gstatic.com');
+    const source = `${indexHtml}\n${indexCss}`;
+
+    expect(source).not.toContain('fonts.googleapis.com');
+    expect(source).not.toContain('fonts.gstatic.com');
+  });
+
+  it('does not declare an unused 900 display font that would be precached offline', () => {
+    expect(indexCss).not.toContain('zen-maru-gothic-japanese-900-normal');
   });
 });
 

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -67,12 +67,22 @@ describe('font loading against the self-only policy', () => {
   it('does not load Google Fonts, which the policy forbids and the worker cannot precache', () => {
     const source = `${indexHtml}\n${indexCss}`;
 
+    // A remote stylesheet would be blocked by `style-src 'self'` and leave the app on fallback fonts online.
     expect(source).not.toContain('fonts.googleapis.com');
+    // Remote font binaries cannot be precached by the worker, so an installed app would lose the chosen faces offline.
     expect(source).not.toContain('fonts.gstatic.com');
   });
 
   it('does not declare an unused 900 display font that would be precached offline', () => {
+    // Shipping an unused display weight makes every offline install download a large font that no visible text needs.
     expect(indexCss).not.toContain('zen-maru-gothic-japanese-900-normal');
+  });
+
+  it('keeps Latin display glyphs in the same self-hosted face as Japanese headwords', () => {
+    // Mixed-script headwords and display labels should not fall back to platform sans for Latin letters or digits.
+    expect(indexCss).toContain('zen-maru-gothic-latin-500-normal.woff2');
+    // Bold display text such as stats and error headings uses the same family across Japanese and Latin glyphs.
+    expect(indexCss).toContain('zen-maru-gothic-latin-700-normal.woff2');
   });
 });
 

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -21,6 +21,7 @@ import { AVATAR_HOSTS } from '@/lib/avatar';
 const RECAPTCHA_HOST = 'https://www.google.com';
 
 const firebaseJson = readFileSync(new URL('../../firebase.json', import.meta.url), 'utf8');
+const indexHtml = readFileSync(new URL('../../index.html', import.meta.url), 'utf8');
 const client = readFileSync(new URL('../../src/infra/firebase/client.ts', import.meta.url), 'utf8');
 
 interface Header {
@@ -58,6 +59,13 @@ describe('Content-Security-Policy against App Check', () => {
   // requirement quietly became wrong — this is what stops that reading.
   it('still has the App Check provider the guard above exists to protect', () => {
     expect(client).toContain('new ReCaptchaV3Provider(');
+  });
+});
+
+describe('font loading against the self-only policy', () => {
+  it('does not load Google Fonts, which the policy forbids and the worker cannot precache', () => {
+    expect(indexHtml).not.toContain('fonts.googleapis.com');
+    expect(indexHtml).not.toContain('fonts.gstatic.com');
   });
 });
 

--- a/tests/unit/pwaConfig.test.ts
+++ b/tests/unit/pwaConfig.test.ts
@@ -81,6 +81,10 @@ describe('what an offline navigation can reach', () => {
     // Without the manifest an installed window cannot read its own identity
     // offline, which is the case this whole change exists for.
     expect(patterns.some((pattern) => pattern.includes('webmanifest'))).toBe(true);
+    // Self-hosted Japanese font assets are part of the readable experience, not
+    // decoration: if the app has to fall back while offline, ruby/headword
+    // rendering changes under the reader.
+    expect(patterns.some((pattern) => pattern.includes('woff2'))).toBe(true);
   });
 
   it('answers a deep navigation with the index document, matching the hosting rewrite', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,6 +1595,11 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz#45a201ad457323f8fda59c17cc4be11c8908cd4a"
   integrity sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==
 
+"@fontsource/zen-maru-gothic@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/zen-maru-gothic/-/zen-maru-gothic-5.3.0.tgz#f6fce5ddf2b327cafabbdea0ed436a9b4df26c6c"
+  integrity sha512-BuigfmzszMR3AOyAMSocQZ9bEq9o5sGCMOC/laI4TMpba1/KB1jxsdNFXWMUz02wVPd4vAVuMhsV00AQizFj3w==
+
 "@google-cloud/cloud-sql-connector@^1.3.3":
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/@google-cloud/cloud-sql-connector/-/cloud-sql-connector-1.11.3.tgz#8c0eeb9253fea2e9259fcbf8cef85f89c6d24208"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1595,6 +1595,16 @@
   resolved "https://registry.yarnpkg.com/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.7.tgz#45a201ad457323f8fda59c17cc4be11c8908cd4a"
   integrity sha512-phBFwieDLvkZGYN9CE9ZFNEIoBVksprzsnCzQejCmCHtgwCXReeuRpoEGN9C4EbhONztv8NRV1tau6Rb9pONwQ==
 
+"@fontsource/inter@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/inter/-/inter-5.3.0.tgz#866278dc2357659f8be1755c8b67f29d3697b440"
+  integrity sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==
+
+"@fontsource/noto-sans-tc@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/noto-sans-tc/-/noto-sans-tc-5.3.0.tgz#dba53fac5883455bca23300e361c18fe1821501a"
+  integrity sha512-+0MguVH2vIxkVJLiaMHVKHk+yJZmZvMU9d8z88JdUx8C2CgMLOtm7WNloi3HYlvCNy7TpuvjIUvh5iiGp6INxQ==
+
 "@fontsource/zen-maru-gothic@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@fontsource/zen-maru-gothic/-/zen-maru-gothic-5.3.0.tgz#f6fce5ddf2b327cafabbdea0ed436a9b4df26c6c"


### PR DESCRIPTION
## Summary

Fixes #81.

Removes the Google Fonts dependency from the app shell while keeping the Japanese display face the product relies on. `Zen Maru Gothic` is now bundled from Fontsource as same-origin `woff2` assets, and those font files are included in the Workbox precache so offline rendering does not fall back to a different Japanese face.

## Changes

- Remove Google Fonts `preconnect` and stylesheet links from `index.html`.
- Add `@fontsource/zen-maru-gothic` and self-host only the used Japanese display weights: `500` and `700`.
- Replace `Inter` with a system UI stack and `Noto Sans TC` with platform CJK fallbacks to avoid shipping large unused CJK font payloads.
- Prefer Traditional Chinese platform fonts for `:lang(zh-Hant) .prose-cjk`, while keeping Japanese forms first for the default `lang="ja"` document.
- Add `woff2` to the PWA precache pattern.
- Add unit guards so Google Fonts cannot return through `index.html` or `src/index.css`, and so unused `900` display font assets are not declared.

## Testing

Test layer chosen:

- Unit tests for static CSP/PWA configuration, because these checks are pure reads of local source/config.
- Build verification for emitted font assets and Workbox precache contents.
- End-to-end/offline and visual checks because #81 affects offline rendering and Japanese/ruby layout.

Commands run:

- `yarn vitest run --project unit tests/unit/csp.test.ts tests/unit/pwaConfig.test.ts`
- `yarn build`
- `yarn typecheck`
- `yarn format:check`
- `git diff --check develop...HEAD`
- `yarn playwright test tests/e2e/offline.spec.ts tests/e2e/visual.spec.ts`
- `yarn test:unit`

Red-test verification:

- Temporarily restored a Google Fonts host in `index.html` and removed `woff2` from the Workbox glob.
- Confirmed only the new Google Fonts and font-precache guards failed.
- Restored the fix and reran the targeted tests successfully.

Build notes:

- Production build emits only two font files:
  - `zen-maru-gothic-japanese-500-normal-*.woff2`
  - `zen-maru-gothic-japanese-700-normal-*.woff2`
- The generated PWA precache contains 43 entries / 4382.34 KiB after dropping the unused `900` font.
- On macOS, Linux-only screenshot baselines are skipped by the existing repo guard; the non-screenshot Chromium/WebKit visual checks and offline tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Fonts are now hosted locally for improved privacy and more reliable loading.
  * Updated typography improves readability across interfaces and multilingual content, including Traditional Chinese.
  * Font assets are cached for offline use in the installed app.

* **Privacy**
  * Removed connections to Google Fonts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->