### PR TITLE
feat(history): record every word a session deals, with its own copy of each

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -239,9 +239,13 @@ service cloud.firestore {
       ];
     }
 
+    // `missed` is here for documents already written, not for new ones. A
+    // session records `words` — the whole run — and the wrong answers are
+    // derived from it on read, so nothing has written `missed` since. Removing
+    // it would refuse an update to a session written before that change.
     function sessionFields() {
       return [
-        'ownerUid', 'mode', 'filterLabel', 'total', 'correct', 'missed',
+        'ownerUid', 'mode', 'filterLabel', 'total', 'correct', 'missed', 'words',
         'startedAt', 'finishedAt'
       ];
     }
@@ -378,9 +382,12 @@ service cloud.firestore {
         && d.get('correct', 0) is int && d.get('correct', 0) >= 0
         && d.get('correct', 0) <= d.get('total', 0)
         // Element count only. Rules can index a known position, but cannot
-        // iterate across all 2,000 missed ids; see the `validWordSet` note for
-        // the accepted client-only tradeoff.
+        // iterate across all 2,000 recorded words; see the `validWordSet` note
+        // for the accepted client-only tradeoff. Both fields are bounded at the
+        // same 2,000 as `total`, because `words` holds one element per card
+        // dealt and `missed` held one per card missed.
         && list(d.get('missed', []), 2000)
+        && list(d.get('words', []), 2000)
         // Same again, and `mode` is bounded by length rather than by value on
         // purpose. `PRACTICE_MODES` in `src/domain/practice.ts` holds two words
         // today, and an earlier version of this comment said four — but writing

--- a/src/components/history/SessionDialog.tsx
+++ b/src/components/history/SessionDialog.tsx
@@ -1,17 +1,266 @@
+import { useState } from 'react';
 import { Modal } from '@/components/Modal';
 import { VocabLink } from '@/components/VocabLink';
 import type { Entry } from '@/domain/entry';
 import type { PracticeSession } from '@/domain/practice';
 import { useI18n } from '@/i18n/context';
+import type { MessageKey } from '@/i18n/messages';
 import { JAPANESE } from '@/lib/contentLang';
-import { missedWords, sessionTime } from '@/lib/history';
+import { missedWords, practisedWords, sessionTime } from '@/lib/history';
+import type { WordRow } from '@/lib/history';
+
+/**
+ * The word itself, however much of it is left.
+ *
+ * Split out because the dialog prints the same word twice — once in the run and
+ * once in 間違えた語 — and the two lists must not drift apart in how they draw
+ * a word that has since been deleted.
+ */
+function WordLabel({ row }: { row: WordRow }) {
+  const headword = row.kind === 'entry' ? row.entry.headword : row.headword;
+  const reading = row.kind === 'entry' ? row.entry.reading : row.reading;
+
+  return (
+    // `flex-1` rather than leaving the row to `justify-between`: the run has
+    // three columns, so spacing them apart centres the word between the number
+    // and the mark instead of starting every word at the same place.
+    <span className="min-w-0 flex-1 truncate text-left">
+      <span className="font-display font-bold" lang={JAPANESE}>
+        {headword}
+      </span>
+      {reading && (
+        <span className="cjk-face text-sm text-muted" lang={JAPANESE}>
+          （{reading}）
+        </span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * Said rather than left blank, wherever a deleted word appears.
+ *
+ * The row is already not clickable, so nothing here reads as a rendering fault
+ * rather than as a word the learner deleted themselves. Muted and not
+ * `text-danger` — deleting it was their own decision, not an error.
+ */
+function DeletedBadge() {
+  const { t } = useI18n();
+
+  return (
+    <span className="shrink-0 rounded-pill bg-bg-alt px-2 py-0.5 text-[11px] font-semibold text-muted">
+      {t('history.deletedWord')}
+    </span>
+  );
+}
+
+/**
+ * One word, as a link to its note when there still is one.
+ *
+ * Not a `VocabLink` for a deleted word: the note is gone, so the address behind
+ * it would 404 and the dialog it opens would be empty. A link here is an offer
+ * the app cannot keep.
+ *
+ * The columns either side are the caller's, because the two lists do not carry
+ * the same ones: 間違えた語 is a list of words and ends in the JLPT level, while
+ * the run is a list of *answers* and ends in how each one went.
+ */
+function WordLine({
+  row,
+  lead,
+  trail,
+}: {
+  row: WordRow;
+  lead?: React.ReactNode;
+  trail?: React.ReactNode;
+}) {
+  const body = (
+    <>
+      {lead}
+      <WordLabel row={row} />
+      {trail}
+    </>
+  );
+
+  return row.kind === 'entry' ? (
+    <li>
+      <VocabLink entryId={row.entry.id} className="flex items-center gap-3 py-2">
+        {body}
+      </VocabLink>
+    </li>
+  ) : (
+    <li className="flex items-center gap-3 py-2 text-muted">{body}</li>
+  );
+}
+
+/**
+ * How the run is narrowed. `all` first because it is the default: this section
+ * is titled "every word in this session", and opening it already filtered would
+ * hide part of what it claims to show.
+ */
+const ANSWER_FILTERS = ['all', 'correct', 'missed'] as const;
+type AnswerFilter = (typeof ANSWER_FILTERS)[number];
+
+/**
+ * Two of these are the labels the ○ and ✕ already carry.
+ *
+ * Shared rather than duplicated because they name the same thing — a chip that
+ * said 「正解」 while the mark beside it was labelled something else would be two
+ * words for one idea in a list six rows long.
+ */
+const FILTER_LABEL = {
+  all: 'history.filterAll',
+  correct: 'history.answeredCorrect',
+  missed: 'history.answeredWrong',
+} as const satisfies Record<AnswerFilter, MessageKey>;
+
+/**
+ * The run, and the control that narrows it.
+ *
+ * **One list rather than two.** This was a full run and a separate list of the
+ * wrong answers, and every missed word appeared in both — the same rows, drawn
+ * twice, in a dialog on a phone. The questions they answered ("how did that
+ * drill go", "what do I still not know") turn out to be the same list under two
+ * filters, so they are one list and a filter.
+ *
+ * **Numbered before it is filtered.** The position is the drill's, not the
+ * list's: narrowing to the wrong answers and reading 1, 2, 3 would say the
+ * learner got the first three cards wrong. 2, 5, 9 says where they actually
+ * came up.
+ *
+ * Buttons with `aria-pressed`, not a `tablist`. Tabs announce several panels
+ * with one showing; this is one list that shrinks, and saying otherwise would
+ * promise a structure that is not there.
+ */
+function RunList({ run }: { run: (WordRow & { correct: boolean })[] }) {
+  const { t } = useI18n();
+  const [filter, setFilter] = useState<AnswerFilter>('all');
+
+  const numbered = run.map((row, index) => ({ ...row, position: index + 1 }));
+  const counts = {
+    all: numbered.length,
+    correct: numbered.filter((row) => row.correct).length,
+    missed: numbered.filter((row) => !row.correct).length,
+  } satisfies Record<AnswerFilter, number>;
+  const shown =
+    filter === 'all' ? numbered : numbered.filter((row) => row.correct === (filter === 'correct'));
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold tracking-wide text-muted">
+        {t('history.practisedWords')}
+      </h3>
+
+      <div role="group" aria-label={t('history.answerFilter')} className="mt-2 flex gap-2">
+        {ANSWER_FILTERS.map((option) => (
+          <button
+            key={option}
+            type="button"
+            aria-pressed={filter === option}
+            onClick={() => setFilter(option)}
+            className={`min-h-9 rounded-pill px-3 text-xs font-medium transition ${
+              filter === option ? 'bg-accent text-on-accent' : 'bg-bg-alt text-muted hover:text-ink'
+            }`}
+          >
+            {t(FILTER_LABEL[option])}{' '}
+            {/* The count is what the separate missed list used to say out loud.
+                Losing it would make "how many did I get wrong" a thing you
+                count by eye. */}
+            <span className="tabular-nums">{counts[option]}</span>
+          </button>
+        ))}
+      </div>
+
+      {shown.length > 0 ? (
+        <ol className="mt-2 divide-y divide-line">
+          {shown.map((row) => (
+            <WordLine
+              key={`${row.kind === 'entry' ? row.entry.id : row.entryId}-${row.position}`}
+              row={row}
+              lead={
+                <span className="w-5 shrink-0 text-right text-xs text-muted tabular-nums">
+                  {row.position}
+                </span>
+              }
+              /* No JLPT level here. This list is read down the outcome column —
+                 the eye follows one column of ○ and ✕ — and a second badge in
+                 the way makes that a scan rather than a glance. */
+              trail={
+                <>
+                  {row.kind === 'deleted' && <DeletedBadge />}
+                  <span
+                    role="img"
+                    aria-label={t(
+                      row.correct ? 'history.answeredCorrect' : 'history.answeredWrong',
+                    )}
+                    className={`w-4 shrink-0 text-center text-sm ${
+                      row.correct ? 'text-sprout' : 'text-danger'
+                    }`}
+                  >
+                    {row.correct ? '○' : '✕'}
+                  </span>
+                </>
+              }
+            />
+          ))}
+        </ol>
+      ) : (
+        <p className="mt-2 text-sm text-muted">{t('history.none')}</p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The wrong answers of a session recorded before the run was kept.
+ *
+ * **Transitional, and tracked for removal.** Those sessions never wrote down
+ * what was answered correctly, so there is no run to filter and no way to
+ * reconstruct one; without this they would open as a score with nothing under
+ * it. It goes when the sessions that need it do.
+ */
+function LegacyMissedList({ missed }: { missed: WordRow[] }) {
+  const { t } = useI18n();
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold tracking-wide text-muted">{t('practice.missed')}</h3>
+      {missed.length > 0 ? (
+        <ul className="mt-2 divide-y divide-line">
+          {missed.map((row) => (
+            <WordLine
+              key={row.kind === 'entry' ? row.entry.id : row.entryId}
+              row={row}
+              trail={
+                row.kind === 'entry' ? (
+                  <span className="shrink-0 rounded-pill bg-accent-soft px-2 py-0.5 text-[11px] font-semibold text-accent">
+                    {row.entry.jlpt}
+                  </span>
+                ) : (
+                  <DeletedBadge />
+                )
+              }
+            />
+          ))}
+        </ul>
+      ) : (
+        /* A perfect run, or one whose every missed word has since been deleted
+           without a headword to fall back on. The score above tells them apart. */
+        <p className="mt-2 text-sm text-muted">{t('history.none')}</p>
+      )}
+    </div>
+  );
+}
 
 /**
  * One session, opened out.
  *
  * The row it comes from is a summary — mode, score, when — and this is where
  * the parts that do not fit go: the filter label in full rather than clipped,
- * and every word that was missed, each a link to the note.
+ * and every card the session dealt, in the order it dealt them.
+ *
+ * A word whose note has since been deleted is printed from the copy the session
+ * kept and marked as gone; see `MissedWord` for why the copy exists at all.
  *
  * **No duration.** `startedAt` is the learner's own clock and `finishedAt` is
  * the server's, deliberately — see `PracticeSessionDraft`. Subtracting one from
@@ -19,6 +268,50 @@ import { missedWords, sessionTime } from '@/lib/history';
  * and a drill that appears to have taken minus three minutes is worse than no
  * figure at all.
  */
+function SessionBody({
+  session,
+  entries,
+}: {
+  session: PracticeSession;
+  entries: readonly Entry[];
+}) {
+  const { locale, t } = useI18n();
+
+  const run = practisedWords(session, entries);
+  const percent = session.total > 0 ? Math.round((session.correct / session.total) * 100) : 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-baseline gap-3">
+        <p className="font-display text-3xl font-bold tabular-nums">
+          {session.correct} / {session.total}
+        </p>
+        <p className="text-sm text-muted tabular-nums">{percent}%</p>
+      </div>
+
+      <dl className="space-y-2 text-sm">
+        <div className="flex gap-3">
+          <dt className="w-20 shrink-0 text-muted">{t('history.finished')}</dt>
+          <dd className="tabular-nums">{sessionTime(session.finishedAt, locale)}</dd>
+        </div>
+        <div className="flex gap-3">
+          <dt className="w-20 shrink-0 text-muted">{t('history.filters')}</dt>
+          {/* The label stored on the day, not one rebuilt now: a 単語集 renamed
+              since would otherwise rewrite what was drilled. */}
+          <dd className="prose-cjk min-w-0">{session.filterLabel}</dd>
+        </div>
+      </dl>
+
+      {/* Null is not an empty run — see `practisedWords`. */}
+      {run !== null ? (
+        <RunList run={run} />
+      ) : (
+        <LegacyMissedList missed={missedWords(session, entries)} />
+      )}
+    </div>
+  );
+}
+
 export function SessionDialog({
   session,
   entries,
@@ -29,11 +322,8 @@ export function SessionDialog({
   entries: readonly Entry[];
   onClose: () => void;
 }) {
-  const { locale, t } = useI18n();
+  const { t } = useI18n();
   if (!session) return null;
-
-  const missed = missedWords(session, entries);
-  const percent = session.total > 0 ? Math.round((session.correct / session.total) * 100) : 0;
 
   return (
     <Modal
@@ -41,61 +331,11 @@ export function SessionDialog({
       title={t(session.mode === 'flashcard' ? 'practice.flashcard' : 'practice.dictation')}
       onClose={onClose}
     >
-      <div className="space-y-4">
-        <div className="flex items-baseline gap-3">
-          <p className="font-display text-3xl font-bold tabular-nums">
-            {session.correct} / {session.total}
-          </p>
-          <p className="text-sm text-muted tabular-nums">{percent}%</p>
-        </div>
-
-        <dl className="space-y-2 text-sm">
-          <div className="flex gap-3">
-            <dt className="w-20 shrink-0 text-muted">{t('history.finished')}</dt>
-            <dd className="tabular-nums">{sessionTime(session.finishedAt, locale)}</dd>
-          </div>
-          <div className="flex gap-3">
-            <dt className="w-20 shrink-0 text-muted">{t('history.filters')}</dt>
-            {/* The label stored on the day, not one rebuilt now: a 単語集
-                renamed since would otherwise rewrite what was drilled. */}
-            <dd className="prose-cjk min-w-0">{session.filterLabel}</dd>
-          </div>
-        </dl>
-
-        <div>
-          <h3 className="text-xs font-semibold tracking-wide text-muted">{t('practice.missed')}</h3>
-          {missed.length > 0 ? (
-            <ul className="mt-2 divide-y divide-line">
-              {missed.map((entry) => (
-                <li key={entry.id}>
-                  <VocabLink
-                    entryId={entry.id}
-                    className="flex items-center justify-between gap-3 py-2"
-                  >
-                    <span className="min-w-0 truncate">
-                      <span className="font-display font-bold" lang={JAPANESE}>
-                        {entry.headword}
-                      </span>
-                      {entry.reading && (
-                        <span className="cjk-face text-sm text-muted" lang={JAPANESE}>
-                          （{entry.reading}）
-                        </span>
-                      )}
-                    </span>
-                    <span className="shrink-0 rounded-pill bg-accent-soft px-2 py-0.5 text-[11px] font-semibold text-accent">
-                      {entry.jlpt}
-                    </span>
-                  </VocabLink>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            /* Either a perfect run or every missed word has since been deleted —
-               the count above is what distinguishes them. */
-            <p className="mt-2 text-sm text-muted">{t('history.none')}</p>
-          )}
-        </div>
-      </div>
+      {/* Keyed, so opening a different session remounts the body and the answer
+          filter starts at "all" again. A `useEffect` resetting it would run a
+          render late, showing the new session through the old session's filter
+          for one frame. */}
+      <SessionBody key={session.id} session={session} entries={entries} />
     </Modal>
   );
 }

--- a/src/components/history/SessionDialog.tsx
+++ b/src/components/history/SessionDialog.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import { Modal } from '@/components/Modal';
 import { VocabLink } from '@/components/VocabLink';
 import type { Entry } from '@/domain/entry';
@@ -65,15 +66,7 @@ function DeletedBadge() {
  * the same ones: 間違えた語 is a list of words and ends in the JLPT level, while
  * the run is a list of *answers* and ends in how each one went.
  */
-function WordLine({
-  row,
-  lead,
-  trail,
-}: {
-  row: WordRow;
-  lead?: React.ReactNode;
-  trail?: React.ReactNode;
-}) {
+function WordLine({ row, lead, trail }: { row: WordRow; lead?: ReactNode; trail?: ReactNode }) {
   const body = (
     <>
       {lead}

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -80,8 +80,19 @@ export interface PracticeSession {
  * hour fast would file its sessions above everything and repeat or skip rows at
  * every page boundary. `startedAt` stays a device value because that is what it
  * honestly is: the session had already begun before any write happened.
+ *
+ * **`words` is narrowed rather than inherited.** Null is a *read* state — it
+ * says a stored session predates the field — and it is not a thing any caller
+ * may send. `validSession` in `firestore.rules` asks that `words` is a list,
+ * and `get('words', [])` falls back to the default only when the key is absent,
+ * so an explicit null reaches `null is list` and the write is refused. Inheriting
+ * the nullable type would let a draft typecheck that production rejects, with
+ * nothing between the two to say so.
  */
-export type PracticeSessionDraft = Omit<PracticeSession, 'id' | 'finishedAt' | 'missed'>;
+export type PracticeSessionDraft = Omit<
+  PracticeSession,
+  'id' | 'finishedAt' | 'missed' | 'words'
+> & { words: PractisedWord[] };
 
 /**
  * Per-entry practice state.

--- a/src/domain/practice.ts
+++ b/src/domain/practice.ts
@@ -3,6 +3,37 @@ import type { IsoDateTime } from './common';
 export const PRACTICE_MODES = ['flashcard', 'dictation'] as const;
 export type PracticeMode = (typeof PRACTICE_MODES)[number];
 
+/**
+ * One word a session got wrong, with enough of the note copied in to outlive it.
+ *
+ * The id alone was the whole record until this field existed, and it made 履歴
+ * mutable by the back door: deleting a word rewrote every session that had
+ * named it, because a row could only be drawn by resolving the id against the
+ * notebook as it stands today. A session is a statement about a day that has
+ * already happened, so the words it names are copied rather than referenced.
+ *
+ * The id stays, and is still what links a surviving word to its note. The
+ * snapshot is the fallback for when there is nothing left to link to — it is
+ * never preferred over the live entry, because a word that still exists is the
+ * same word and the notebook is the truth about it.
+ *
+ * **Empty strings are the legacy shape**, not corruption: sessions written
+ * before this field carried a bare id, and no backfill can invent a headword
+ * for a word already deleted. `sanitizeSession` reads both.
+ */
+export interface MissedWord {
+  entryId: string;
+  /** The headword as it read on the day of the session. */
+  headword: string;
+  /** Its reading on the day, or '' — the note may not have carried one. */
+  reading: string;
+}
+
+/** One card as it was dealt: the same snapshot, plus how it was answered. */
+export interface PractisedWord extends MissedWord {
+  correct: boolean;
+}
+
 /** A completed practice run — the source for 履歴 and the dashboard panel. */
 export interface PracticeSession {
   id: string;
@@ -11,8 +42,22 @@ export interface PracticeSession {
   filterLabel: string;
   total: number;
   correct: number;
-  /** Entry ids answered wrong, for the session summary and quick re-practice. */
-  missed: string[];
+  /**
+   * Every card the session dealt, in the order it dealt them.
+   *
+   * **Null for a session recorded before this field existed**, where only the
+   * wrong answers were ever written down — an absent list and an empty one are
+   * different claims, and a drill of nothing is not a thing that happens.
+   */
+  words: PractisedWord[] | null;
+  /**
+   * The words answered wrong, in the order the session recorded them.
+   *
+   * Derived from `words` and not stored beside it, so the two cannot disagree.
+   * Read from the stored field only for a session that predates `words`, which
+   * is the one case where the wrong answers are all there is.
+   */
+  missed: MissedWord[];
   /** When the learner pressed 開始する — necessarily their own clock. */
   startedAt: IsoDateTime;
   /** Set by the write path from the server clock, never by the device. */
@@ -26,13 +71,17 @@ export interface PracticeSession {
  * caller that invented one would either collide or have to know how the
  * datasource generates ids.
  *
+ * `missed` is omitted because nothing writes it any more: it is `words` with
+ * the correct answers taken out, and a stored copy of a derived list is a
+ * second thing that can be wrong.
+ *
  * `finishedAt` is omitted for a different reason. 履歴 is ordered and paged by
  * it, and a cursor is only sound over a value one clock produced — a device an
  * hour fast would file its sessions above everything and repeat or skip rows at
  * every page boundary. `startedAt` stays a device value because that is what it
  * honestly is: the session had already begun before any write happened.
  */
-export type PracticeSessionDraft = Omit<PracticeSession, 'id' | 'finishedAt'>;
+export type PracticeSessionDraft = Omit<PracticeSession, 'id' | 'finishedAt' | 'missed'>;
 
 /**
  * Per-entry practice state.

--- a/src/i18n/learningMessages.ts
+++ b/src/i18n/learningMessages.ts
@@ -95,6 +95,12 @@ const en = {
   'history.finished': 'Finished',
   'history.filters': 'Filters',
   'history.missedCount': '{count} missed',
+  'history.deletedWord': 'Deleted',
+  'history.practisedWords': 'Every word in this session',
+  'history.answerFilter': 'Filter by answer',
+  'history.filterAll': 'All',
+  'history.answeredCorrect': 'Correct',
+  'history.answeredWrong': 'Missed',
   'history.none': 'None',
 } as const;
 
@@ -199,6 +205,12 @@ const ja: LearningMessages = {
   'history.finished': '終了',
   'history.filters': '条件',
   'history.missedCount': '間違えた語 {count}',
+  'history.deletedWord': '削除済み',
+  'history.practisedWords': '出題した語',
+  'history.answerFilter': '正誤で絞り込み',
+  'history.filterAll': 'すべて',
+  'history.answeredCorrect': '正解',
+  'history.answeredWrong': '不正解',
   'history.none': 'ありません',
 };
 
@@ -298,6 +310,12 @@ const zhHant: LearningMessages = {
   'history.finished': '完成時間',
   'history.filters': '篩選條件',
   'history.missedCount': '答錯 {count} 個',
+  'history.deletedWord': '已刪除',
+  'history.practisedWords': '本次練習的單字',
+  'history.answerFilter': '依答題結果篩選',
+  'history.filterAll': '全部',
+  'history.answeredCorrect': '答對',
+  'history.answeredWrong': '答錯',
   'history.none': '沒有',
 };
 
@@ -397,6 +415,12 @@ const ko: LearningMessages = {
   'history.finished': '완료',
   'history.filters': '조건',
   'history.missedCount': '오답 {count}개',
+  'history.deletedWord': '삭제됨',
+  'history.practisedWords': '출제된 단어',
+  'history.answerFilter': '정답 여부로 필터',
+  'history.filterAll': '전체',
+  'history.answeredCorrect': '정답',
+  'history.answeredWrong': '오답',
   'history.none': '없음',
 };
 
@@ -497,6 +521,12 @@ const es: LearningMessages = {
   'history.finished': 'Finalizada',
   'history.filters': 'Filtros',
   'history.missedCount': '{count} fallos',
+  'history.deletedWord': 'Eliminada',
+  'history.practisedWords': 'Palabras de esta sesión',
+  'history.answerFilter': 'Filtrar por resultado',
+  'history.filterAll': 'Todas',
+  'history.answeredCorrect': 'Acierto',
+  'history.answeredWrong': 'Fallo',
   'history.none': 'Ninguna',
 };
 

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -525,7 +525,17 @@ export const progressRepositoryFor = (uid: string): ProgressRepository => {
 
     recordSession(session: PracticeSessionDraft, rows: EntryProgress[]): Promise<string> {
       const id = `e2e-session-${++sessionSequence}`;
-      sessions.push({ ...session, id, finishedAt: new Date().toISOString() });
+      // `missed` is derived on read from Firestore, so it is derived here too:
+      // a substitute that stored it would let the two disagree in the one place
+      // the end-to-end suite reads them both.
+      sessions.push({
+        ...session,
+        id,
+        finishedAt: new Date().toISOString(),
+        missed: (session.words ?? [])
+          .filter((word) => !word.correct)
+          .map(({ entryId, headword, reading }) => ({ entryId, headword, reading })),
+      });
       // Merging row by row, not replacing the map — the real adapter writes
       // with `merge: true` and a substitute that clobbered would hide it.
       for (const row of rows) progress.set(row.entryId, row);

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -532,7 +532,7 @@ export const progressRepositoryFor = (uid: string): ProgressRepository => {
         ...session,
         id,
         finishedAt: new Date().toISOString(),
-        missed: (session.words ?? [])
+        missed: session.words
           .filter((word) => !word.correct)
           .map(({ entryId, headword, reading }) => ({ entryId, headword, reading })),
       });

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -489,14 +489,19 @@ function sessionsFor(uid: string): PracticeSession[] {
   const existing = sessionStores.get(uid);
   if (existing) return existing;
 
-  const persisted = load<PracticeSession[] | null>(`sessions.${uid}`, null);
-  const restored =
-    persisted ??
-    (seed().sessions ?? []).map((raw, index) => {
-      const row = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
-      const id = typeof row.id === 'string' ? row.id : `e2e-session-${index + 1}`;
-      return sanitizeSession(id, row);
-    });
+  // Both branches go through `sanitizeSession`, because both are untrusted for
+  // the same reason the Firestore adapter's reads are: what came back was
+  // written by some earlier version of this code. `sessionStorage` outlives a
+  // rebuild in the same tab, so a session persisted before `words` existed
+  // reaches a build that expects it — and `JSON.parse` cast straight to
+  // `PracticeSession[]` would hand `words: undefined` to a reader whose type
+  // says the absence has already been normalised to null.
+  const persisted = load<unknown[] | null>(`sessions.${uid}`, null);
+  const restored = (persisted ?? seed().sessions ?? []).map((raw, index) => {
+    const row = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+    const id = typeof row.id === 'string' ? row.id : `e2e-session-${index + 1}`;
+    return sanitizeSession(id, row);
+  });
 
   for (const session of restored) {
     const n = Number(/^e2e-session-(\d+)$/.exec(session.id)?.[1]);

--- a/src/lib/devSeed.ts
+++ b/src/lib/devSeed.ts
@@ -319,6 +319,9 @@ export function devSeed(now: Date): E2ESeed {
     { id: 'dev-set-empty', name: '今週おぼえる語', description: '', entryIds: [] },
   ];
 
+  // `missed` is deliberately absent: a session stores the run and 間違えた語 is
+  // read out of it, so seeding both would demonstrate a document shape the app
+  // does not write.
   const sessions: SeedSession[] = [
     {
       id: 'dev-session-1',
@@ -326,7 +329,12 @@ export function devSeed(now: Date): E2ESeed {
       filterLabel: '単語集:仕事でよく聞く語',
       total: 4,
       correct: 3,
-      missed: ['dev-tetsuzuki'],
+      words: [
+        { entryId: 'dev-shimekiri', headword: '締め切り', reading: 'しめきり', correct: true },
+        { entryId: 'dev-tetsuzuki', headword: '手続き', reading: 'てつづき', correct: false },
+        { entryId: 'dev-uchiawase', headword: '打ち合わせ', reading: 'うちあわせ', correct: true },
+        { entryId: 'dev-kiriwake', headword: '切り分け', reading: 'きりわけ', correct: true },
+      ],
       startedAt: at(1, 21),
       finishedAt: at(1, 21),
     },
@@ -334,9 +342,19 @@ export function devSeed(now: Date): E2ESeed {
       id: 'dev-session-2',
       mode: 'dictation',
       filterLabel: '#日常',
-      total: 3,
+      total: 4,
       correct: 1,
-      missed: ['dev-ukkari', 'dev-sasuga'],
+      words: [
+        { entryId: 'dev-ukkari', headword: 'うっかり', reading: '', correct: false },
+        { entryId: 'dev-chotto', headword: 'ちょっと', reading: '', correct: true },
+        // Named by this session and absent from the notebook, because that is
+        // the one state 履歴 exists to hold and it cannot be reached in
+        // development otherwise: the word was drilled, got wrong, and deleted
+        // afterwards. It renders from the snapshot, marked 削除済み and not
+        // linked. See `devSeed.test.ts`, which expects this id and no other.
+        { entryId: 'dev-torikeshi', headword: '取り消し', reading: 'とりけし', correct: false },
+        { entryId: 'dev-sasuga', headword: 'さすが', reading: '', correct: false },
+      ],
       startedAt: at(3, 20),
       finishedAt: at(3, 20),
     },

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,34 +1,82 @@
 import type { Entry } from '@/domain/entry';
 import { PRACTICE_MODES } from '@/domain/practice';
-import type { PracticeMode, PracticeSession } from '@/domain/practice';
+import type { MissedWord, PracticeMode, PracticeSession } from '@/domain/practice';
 
 /**
  * Reading a recorded session back, weeks after the drill that produced it.
  *
- * A session stores entry ids and a filter label, not the words themselves —
- * so everything here is the same resolution `membersOf` does for a 単語集, and
- * carries the same hazard: nothing prunes a session when a word it names is
- * deleted, and nothing should. The record of what was drilled on the day is
- * true whether or not the word still exists.
+ * Nothing prunes a session when a word it names is deleted, and nothing should:
+ * the record of what was drilled on the day is true whether or not the word
+ * still exists. What used to undermine that is that a row could only be *drawn*
+ * by resolving its id against today's notebook, so deleting a word did rewrite
+ * the history that named it. `MissedWord` carries a copy of the headword for
+ * exactly that case.
  */
+
+/**
+ * One word a session recorded, in one of the two states it can be read back in.
+ *
+ * `entry` and not the snapshot when the word survives, deliberately: the
+ * snapshot is a fallback for lost data, not an override of live data. A word
+ * that still exists is the same word, so the row shows what the notebook says
+ * about it now and links to it exactly as it always has.
+ */
+export type WordRow =
+  | { kind: 'entry'; entry: Entry }
+  | { kind: 'deleted'; entryId: string; headword: string; reading: string };
+
+/**
+ * One recorded word against the notebook as it stands now.
+ *
+ * A snapshot with no headword resolves to nothing rather than to a blank row,
+ * and that is the *only* thing dropped anywhere on this screen: it means a
+ * session written before the snapshot existed, naming a word since deleted,
+ * where there is genuinely nothing left to print. A history row is a sentence
+ * a person reads, and a stray 「、」 with nothing either side of it is worse
+ * than a shorter list.
+ */
+function resolve(word: MissedWord, byId: Map<string, Entry>): WordRow | null {
+  const entry = byId.get(word.entryId);
+  if (entry) return { kind: 'entry', entry };
+  if (!word.headword) return null;
+  return { kind: 'deleted', entryId: word.entryId, headword: word.headword, reading: word.reading };
+}
+
+const index = (entries: readonly Entry[]) => new Map(entries.map((entry) => [entry.id, entry]));
 
 /**
  * The words a session got wrong, in the order it recorded them.
  *
- * **An id with no entry behind it is dropped rather than rendered blank.** A
- * word answered wrong and then deleted keeps its id in `missed` forever, and a
- * history row is a sentence a person reads — a stray 「、」 with nothing either
- * side of it is worse than a shorter list.
- *
- * The count of what is shown therefore does not always equal `total - correct`.
- * That is deliberate: the score is what happened, and this is what is left of
- * it to look at.
+ * For anything recorded from now on the length equals `total - correct`; for
+ * the sessions that predate the snapshot it still may not, because a deleted
+ * word leaves nothing behind to draw.
  */
-export function missedWords(session: PracticeSession, entries: readonly Entry[]): Entry[] {
-  const byId = new Map(entries.map((entry) => [entry.id, entry]));
-  return session.missed.flatMap((id) => {
-    const entry = byId.get(id);
-    return entry ? [entry] : [];
+export function missedWords(session: PracticeSession, entries: readonly Entry[]): WordRow[] {
+  const byId = index(entries);
+  return session.missed.flatMap((word) => {
+    const row = resolve(word, byId);
+    return row ? [row] : [];
+  });
+}
+
+/**
+ * Every card the session dealt, in the order it dealt them — or null.
+ *
+ * **Null means the session never recorded its run**, not that it dealt nothing.
+ * Only the wrong answers were written down before `PractisedWord` existed, so
+ * there is no full list to show and no way to reconstruct one; the dialog
+ * leaves the section out rather than printing the missed words under a heading
+ * that claims to be the whole drill.
+ */
+export function practisedWords(
+  session: PracticeSession,
+  entries: readonly Entry[],
+): (WordRow & { correct: boolean })[] | null {
+  if (session.words === null) return null;
+  const byId = index(entries);
+  return session.words.flatMap((word) => {
+    const row = resolve(word, byId);
+    return row ? [{ ...row, correct: word.correct }] : [];
   });
 }
 

--- a/src/lib/practice.ts
+++ b/src/lib/practice.ts
@@ -330,7 +330,14 @@ export function summariseSession(input: {
   filterLabel: string;
   answers: readonly Answer[];
   startedAt: string;
+  /**
+   * The words that were dealt, so each one can be copied into the record rather
+   * than only pointed at — see `MissedWord`. The queue, not the whole notebook:
+   * an answer can only name a card this session dealt.
+   */
+  entries: readonly Entry[];
 }): PracticeSessionDraft {
+  const byId = new Map(input.entries.map((entry) => [entry.id, entry]));
   return {
     mode: input.mode,
     /*
@@ -348,7 +355,25 @@ export function summariseSession(input: {
     filterLabel: ellipsise(input.filterLabel, SESSION_LIMITS.filterLabel),
     total: input.answers.length,
     correct: input.answers.filter((answer) => answer.correct).length,
-    missed: input.answers.filter((answer) => !answer.correct).map((answer) => answer.entryId),
+    /*
+      Every answer, right and wrong, in the order they were given — `answers`
+      is appended to as the session runs, so its order is the deal order.
+
+      A word the queue cannot name still gets a row, with an empty snapshot.
+      That should not happen, and if it does the honest record is the id: it is
+      the part that was actually observed, and dropping the answer would put
+      `words.length` below `total` in the one record whose whole job is to say
+      what happened.
+    */
+    words: input.answers.map((answer) => {
+      const entry = byId.get(answer.entryId);
+      return {
+        entryId: answer.entryId,
+        headword: entry?.headword ?? '',
+        reading: entry?.reading ?? '',
+        correct: answer.correct,
+      };
+    }),
     startedAt: input.startedAt,
   };
 }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -13,7 +13,7 @@ import type {
 } from '@/domain/entry';
 import { USER_LIMITS } from '@/domain/limits';
 import { PRACTICE_MODES } from '@/domain/practice';
-import type { EntryProgress, PracticeSession } from '@/domain/practice';
+import type { EntryProgress, MissedWord, PracticeSession, PractisedWord } from '@/domain/practice';
 import { THEME_PREFERENCES, TRANSLATION_LANGUAGES, UI_LANGUAGES } from '@/domain/user';
 import type { UserProfile } from '@/domain/user';
 import type { WordSet } from '@/domain/wordSet';
@@ -311,6 +311,85 @@ export function sanitizeProgressMap(value: unknown): EntryProgress[] {
   return Object.entries(raw).map(([entryId, row]) => progressRow(entryId, row));
 }
 
+/**
+ * The missed list, in either of the two shapes Firestore may hold it in.
+ *
+ * A bare string is a session written before `MissedWord` existed. It reads as a
+ * snapshot with nothing in it, which is exactly what it is — the id resolves
+ * against the notebook or the row is dropped, the way every session behaved
+ * before. There is no backfill: a headword for a word already deleted cannot be
+ * recovered, and one copied from a note that still exists would be today's
+ * value pretending to be the day's.
+ *
+ * An element with no `entryId` is dropped rather than kept on its snapshot
+ * alone. The id is what makes the row a link when the word survives, and a
+ * record that can never link is not one this screen has a place for.
+ */
+const missedList = (value: unknown): MissedWord[] =>
+  Array.isArray(value)
+    ? value.flatMap((item) => {
+        if (typeof item === 'string')
+          return item ? [{ entryId: item, headword: '', reading: '' }] : [];
+        const raw = record(item);
+        const entryId = str(raw.entryId);
+        return entryId ? [{ entryId, headword: str(raw.headword), reading: str(raw.reading) }] : [];
+      })
+    : [];
+
+/**
+ * The full run, or null for a session recorded before it was kept.
+ *
+ * Null and `[]` are deliberately different here, which is why this does not
+ * fall through to the empty list the way every other array field does: an
+ * absent list means the session never recorded one, and an empty list would
+ * claim a drill that dealt no cards. The dialog prints the run for the first
+ * and prints nothing for the second, and it cannot tell them apart otherwise.
+ *
+ * `correct` is `=== true` rather than truthy: an unreadable answer reads as
+ * wrong, the direction `sanitizeProgressMap` already defaults in, and for the
+ * same reason — a word shown as missed gets looked at, one shown as correct
+ * does not.
+ */
+const practisedList = (value: unknown): PractisedWord[] | null =>
+  Array.isArray(value)
+    ? value.flatMap((item) => {
+        const raw = record(item);
+        const entryId = str(raw.entryId);
+        return entryId
+          ? [
+              {
+                entryId,
+                headword: str(raw.headword),
+                reading: str(raw.reading),
+                correct: raw.correct === true,
+              },
+            ]
+          : [];
+      })
+    : null;
+
+/**
+ * The two list fields together, because one is derived from the other.
+ *
+ * A session written now stores `words` and no `missed`; one written before
+ * `words` existed stores `missed` and nothing else. Splitting these apart would
+ * let a caller read `missed` from a document that has a `words` field and get
+ * the empty list.
+ */
+const missedAndWords = (
+  raw: Record<string, unknown>,
+): Pick<PracticeSession, 'words' | 'missed'> => {
+  const words = practisedList(raw.words);
+  return {
+    words,
+    missed: words
+      ? words
+          .filter((word) => !word.correct)
+          .map(({ entryId, headword, reading }) => ({ entryId, headword, reading }))
+      : missedList(raw.missed),
+  };
+};
+
 export function sanitizeSession(id: string, data: unknown): PracticeSession {
   const raw = record(data);
   return {
@@ -319,7 +398,7 @@ export function sanitizeSession(id: string, data: unknown): PracticeSession {
     filterLabel: str(raw.filterLabel),
     total: nonNegativeInt(raw.total),
     correct: nonNegativeInt(raw.correct),
-    missed: strings(raw.missed),
+    ...missedAndWords(raw),
     startedAt: isoDateTime(raw.startedAt),
     finishedAt: isoDateTime(raw.finishedAt),
   };

--- a/src/routes/History.tsx
+++ b/src/routes/History.tsx
@@ -82,16 +82,20 @@ export function Component() {
   const weak = useMemo(() => weakWords(weakIds, entries), [weakIds, entries]);
 
   /**
-   * Opening a word from inside the session dialog closes the session dialog.
+   * Opening a word from inside the session dialog hides it, and closing the
+   * word brings it back.
    *
-   * Two modals over each other is one Escape closing both and a backdrop that
-   * belongs to neither. The word is what was asked for, so it is the one that
-   * stays.
+   * Never two modals at once — that is one Escape closing both and a backdrop
+   * belonging to neither — but the session is not thrown away to achieve it.
+   * It stays in `opened` and is simply not rendered while a word is showing, so
+   * closing the word returns to where the word was found rather than to an
+   * empty page. Going Back does the same thing, because that also clears
+   * `openId`.
+   *
+   * State rather than an effect: an effect clearing `opened` would run a render
+   * after the word opened, so both dialogs would be mounted for one frame.
    */
   const { openId } = useVocabDialog();
-  useEffect(() => {
-    if (openId !== null) setOpened(null);
-  }, [openId]);
 
   if (entriesLoading || progressLoading)
     return <p className="py-16 text-center text-sm text-muted">{t('vocabulary.loading')}</p>;
@@ -143,7 +147,11 @@ export function Component() {
         )}
       </section>
 
-      <SessionDialog session={opened} entries={entries} onClose={() => setOpened(null)} />
+      <SessionDialog
+        session={openId === null ? opened : null}
+        entries={entries}
+        onClose={() => setOpened(null)}
+      />
     </div>
   );
 }

--- a/src/routes/Practice.tsx
+++ b/src/routes/Practice.tsx
@@ -194,6 +194,7 @@ function Practice({ mode }: { mode: PracticeMode }) {
         filterLabel: finished.filterLabel,
         answers,
         startedAt: finished.startedAt,
+        entries: finished.queue,
       }),
       mergeProgress(progress, answers, mode, at),
     )

--- a/tests/component/SessionDialog.test.tsx
+++ b/tests/component/SessionDialog.test.tsx
@@ -1,0 +1,262 @@
+import { fireEvent, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { SessionDialog } from '@/components/history/SessionDialog';
+import type { Entry } from '@/domain/entry';
+import type { PracticeSession } from '@/domain/practice';
+import { VocabDialogProvider } from '@/lib/vocabDialog';
+import { makeEntry } from '../fixtures/entry';
+import { renderWithI18n as render } from '../fixtures/renderWithI18n';
+
+/**
+ * 練習履歴, opened out, after the notebook has moved on.
+ *
+ * A session is a record of a day that has already happened, and it used to stop
+ * being one the moment a word was deleted: the row could only be drawn by
+ * resolving its entry id against the notebook as it stands now, so deleting a
+ * note silently removed it from every drill that had ever marked it wrong. The
+ * score stayed; the words behind it changed. `MissedWord` copies the headword
+ * in so the record reads the same either way.
+ *
+ * 苦手な語 is deliberately not like this and is tested in `WeakWords`: a word
+ * the learner deleted is one they chose to stop studying, so it should leave
+ * the review list. Only the log is immutable.
+ */
+
+const KIRIWAKE = makeEntry({ id: 'w1', headword: '切り分け', reading: 'きりわけ', jlpt: 'N2' });
+const DELETED = { entryId: 'w9', headword: '曖昧', reading: 'あいまい' };
+
+const session = (over: Partial<PracticeSession>): PracticeSession => ({
+  id: 's1',
+  mode: 'flashcard',
+  filterLabel: '#仕事',
+  total: 3,
+  correct: 1,
+  words: null,
+  missed: [],
+  startedAt: '2026-06-24T09:00:00.000Z',
+  finishedAt: '2026-06-24T09:04:00.000Z',
+  ...over,
+});
+
+const renderDialog = (over: Partial<PracticeSession>, entries: Entry[] = [KIRIWAKE]) =>
+  render(
+    <MemoryRouter>
+      <VocabDialogProvider>
+        <SessionDialog session={session(over)} entries={entries} onClose={() => {}} />
+      </VocabDialogProvider>
+    </MemoryRouter>,
+  );
+
+/** Only the wrong answers, as a session recorded before `words` existed. */
+const missedOnly = (missed: PracticeSession['missed']) => ({ words: null, missed });
+
+describe('SessionDialog — a session recorded before the run was kept', () => {
+  it('still names the word, from the copy the session recorded', () => {
+    renderDialog(missedOnly([DELETED]), []);
+
+    expect(screen.getByText('曖昧')).toBeInTheDocument();
+    expect(screen.getByText('（あいまい）')).toBeInTheDocument();
+  });
+
+  /**
+   * Not an assertion about styling. The note is gone, so `/vocabulary/w9` is a
+   * dead address and the dialog behind it opens on nothing — a link here is an
+   * offer the app cannot keep.
+   */
+  it('does not offer a link to the note that no longer exists', () => {
+    renderDialog(missedOnly([DELETED]), []);
+
+    expect(screen.queryByRole('link', { name: /曖昧/ })).not.toBeInTheDocument();
+  });
+
+  /**
+   * The marker sits in the slot every other row fills with a JLPT badge. That
+   * placement is the point: without it the row is simply not clickable and has
+   * a gap where the badge was, which reads as a rendering fault rather than as
+   * a word the learner deleted themselves.
+   */
+  it('marks the row as deleted, so an unclickable row does not read as broken', () => {
+    renderDialog(missedOnly([DELETED]), []);
+
+    expect(screen.getByText('削除済み')).toBeInTheDocument();
+  });
+
+  it('leaves a word that still exists as a link to its note', () => {
+    renderDialog(
+      missedOnly([{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }, DELETED]),
+    );
+
+    const link = screen.getByRole('link', { name: /切り分け/ });
+    expect(link).toHaveAttribute('href', '/vocabulary/w1');
+    expect(within(link).getByText('N2')).toBeInTheDocument();
+  });
+
+  /**
+   * The snapshot is a fallback for a note that is gone, not an override of one
+   * that is not: a headword corrected after the drill reads as corrected here
+   * too, and the row keeps its live JLPT and its link.
+   */
+  it('shows the notebook, not the snapshot, for a word that was edited since', () => {
+    renderDialog(missedOnly([{ entryId: 'w1', headword: '切分け', reading: 'きりわけ' }]));
+
+    expect(screen.getByText('切り分け')).toBeInTheDocument();
+    expect(screen.queryByText('切分け')).not.toBeInTheDocument();
+  });
+
+  /**
+   * The only rows still dropped: a session recorded before the snapshot
+   * existed, naming a word since deleted. There is nothing left to print, and
+   * an empty line is worse than a shorter list.
+   */
+  it('drops a pre-snapshot id with no word behind it rather than drawing a blank row', () => {
+    renderDialog(missedOnly([{ entryId: 'w9', headword: '', reading: '' }]), []);
+
+    expect(screen.queryByText('削除済み')).not.toBeInTheDocument();
+    expect(screen.getByText('ありません')).toBeInTheDocument();
+  });
+});
+
+describe('SessionDialog — the run, printed in full', () => {
+  const CHOUKOU = makeEntry({ id: 'w2', headword: '兆候', reading: 'ちょうこう', jlpt: 'N1' });
+
+  const run = () =>
+    renderDialog(
+      {
+        words: [
+          { entryId: 'w2', headword: '兆候', reading: 'ちょうこう', correct: true },
+          { entryId: 'w1', headword: '切り分け', reading: 'きりわけ', correct: false },
+          { ...DELETED, correct: true },
+        ],
+        missed: [{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }],
+      },
+      [KIRIWAKE, CHOUKOU],
+    );
+
+  /**
+   * The order is the whole reason this list is separate from 間違えた語, which
+   * is filtered and therefore says nothing about where in the drill a word came
+   * up. The numbers are read back with the words because both together are what
+   * makes a row placeable — 「3問目を間違えた」 needs the position printed.
+   *
+   * The column order is asserted too, and it is not decoration: the outcome is
+   * last so the ○ and ✕ line up as one column to read down, and the JLPT badge
+   * is absent so nothing sits between the word and that column.
+   */
+  it('lists every word dealt in deal order — number, word, then outcome', () => {
+    run();
+    const ordered = screen.getAllByRole('list').find((element) => element.tagName === 'OL');
+    const rows = within(ordered!).getAllByRole('listitem');
+
+    expect(rows.map((row) => row.textContent)).toEqual([
+      '1兆候（ちょうこう）○',
+      '2切り分け（きりわけ）✕',
+      '3曖昧（あいまい）削除済み○',
+    ]);
+  });
+
+  /**
+   * The glyph is the only thing distinguishing a right answer from a wrong one
+   * in this list, so it carries a label rather than being decorative — the
+   * shape alone is not readable, and colour alone is not either.
+   */
+  it('says how each word was answered, in text and not by colour alone', () => {
+    run();
+
+    expect(screen.getAllByRole('img', { name: '正解' })).toHaveLength(2);
+    expect(screen.getAllByRole('img', { name: '不正解' })).toHaveLength(1);
+  });
+
+  /**
+   * One list, not two. The run and a separate list of the wrong answers drew
+   * every missed word twice, in a dialog read on a phone.
+   */
+  it('draws each word once, with no second list of the wrong answers', () => {
+    run();
+    expect(screen.getAllByText('切り分け')).toHaveLength(1);
+    expect(screen.queryByText('間違えた語')).not.toBeInTheDocument();
+  });
+
+  it('counts each outcome on its own chip, which is where the missed count went', () => {
+    run();
+
+    expect(screen.getByRole('button', { name: 'すべて 3' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '正解 2' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '不正解 1' })).toBeInTheDocument();
+  });
+
+  it('opens on the whole run, so nothing it claims to show starts hidden', () => {
+    run();
+    expect(screen.getByRole('button', { name: 'すべて 3' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+  });
+
+  /**
+   * The position is the drill's, not the list's. Renumbering a filtered list
+   * from 1 would say the learner got the first card wrong, when what happened
+   * is that they got the second one wrong.
+   */
+  it('keeps each row numbered by where it came up in the drill, not in the filter', () => {
+    run();
+    fireEvent.click(screen.getByRole('button', { name: '不正解 1' }));
+
+    const rows = screen.getAllByRole('listitem');
+    expect(rows.map((row) => row.textContent)).toEqual(['2切り分け（きりわけ）✕']);
+  });
+
+  /**
+   * The note is gone, so `/vocabulary/w9` is a dead address and the dialog
+   * behind it opens on nothing. A link here is an offer the app cannot keep.
+   */
+  it('leaves a deleted word unlinked in the run, and links the ones that remain', () => {
+    run();
+
+    expect(screen.getByRole('link', { name: /兆候/ })).toHaveAttribute('href', '/vocabulary/w2');
+    expect(screen.queryByRole('link', { name: /曖昧/ })).not.toBeInTheDocument();
+  });
+
+  it('narrows to the correct answers without losing their order', () => {
+    run();
+    fireEvent.click(screen.getByRole('button', { name: '正解 2' }));
+
+    expect(screen.getAllByRole('listitem').map((row) => row.textContent)).toEqual([
+      '1兆候（ちょうこう）○',
+      '3曖昧（あいまい）削除済み○',
+    ]);
+  });
+
+  /**
+   * Buttons with `aria-pressed`, not a tablist: this is one list that shrinks,
+   * and announcing several panels would promise a structure that is not there.
+   */
+  it('offers the filter as pressed buttons rather than as tabs', () => {
+    run();
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: '正誤で絞り込み' })).toBeInTheDocument();
+  });
+
+  it('says so plainly when a filter selects nothing', () => {
+    renderDialog({
+      words: [{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ', correct: false }],
+      missed: [{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }],
+    });
+    fireEvent.click(screen.getByRole('button', { name: '正解 0' }));
+
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+    expect(screen.getByText('ありません')).toBeInTheDocument();
+  });
+
+  /**
+   * Null and empty are different claims. A session recorded before the run was
+   * kept has only its wrong answers, and printing those under this heading
+   * would say the learner got nothing right in a drill they scored 1/3 on.
+   */
+  it('leaves the section out entirely for a session that never recorded its run', () => {
+    renderDialog(missedOnly([{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }]));
+
+    expect(screen.queryByText('出題した語')).not.toBeInTheDocument();
+  });
+});

--- a/tests/component/SessionDialog.test.tsx
+++ b/tests/component/SessionDialog.test.tsx
@@ -123,6 +123,11 @@ describe('SessionDialog — the run, printed in full', () => {
   const run = () =>
     renderDialog(
       {
+        // The score agrees with the outcomes below it. The dialog prints both —
+        // `2 / 3` above the chips that count 正解 2 — so a fixture where they
+        // disagree describes a session that cannot happen and renders as one.
+        total: 3,
+        correct: 2,
         words: [
           { entryId: 'w2', headword: '兆候', reading: 'ちょうこう', correct: true },
           { entryId: 'w1', headword: '切り分け', reading: 'きりわけ', correct: false },
@@ -187,6 +192,10 @@ describe('SessionDialog — the run, printed in full', () => {
 
   it('opens on the whole run, so nothing it claims to show starts hidden', () => {
     run();
+    // `aria-pressed` is what a screen reader announces as the active chip, and
+    // it is the only thing that says so: the selected chip is otherwise told
+    // apart by its fill. Wrong here and the list shows every word while the
+    // control claims something narrower is selected.
     expect(screen.getByRole('button', { name: 'すべて 3' })).toHaveAttribute(
       'aria-pressed',
       'true',

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -303,8 +303,15 @@ export function makeSessions(count: number): SeedSession[] {
     mode: index % 2 === 0 ? 'flashcard' : 'dictation',
     filterLabel: `記録 ${index + 1}`,
     total: 3,
-    correct: index % 3,
-    words: [],
+    // Three cards, of which `index % 3` went right — so the run agrees with the
+    // score printed above it. An empty list beside `total: 3` would claim a
+    // drill that dealt no cards, which is the one thing `words` cannot mean.
+    words: Array.from({ length: 3 }, (_, card) => ({
+      entryId: `w-${index}-${card}`,
+      headword: `記録${index + 1}の${card + 1}`,
+      reading: '',
+      correct: card < index % 3,
+    })),
     startedAt: new Date(Date.UTC(2026, 5, 1, index)).toISOString(),
     finishedAt: new Date(Date.UTC(2026, 5, 1, index, 5)).toISOString(),
   })) satisfies SeedSession[];

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -304,7 +304,7 @@ export function makeSessions(count: number): SeedSession[] {
     filterLabel: `記録 ${index + 1}`,
     total: 3,
     correct: index % 3,
-    missed: [],
+    words: [],
     startedAt: new Date(Date.UTC(2026, 5, 1, index)).toISOString(),
     finishedAt: new Date(Date.UTC(2026, 5, 1, index, 5)).toISOString(),
   })) satisfies SeedSession[];

--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -80,6 +80,45 @@ test.describe('history', () => {
   });
 
   /**
+   * Two dialogs, and a stack rather than a swap.
+   *
+   * Opening a word closes the session dialog on purpose — two modals over each
+   * other is one Escape closing both and a backdrop belonging to neither — but
+   * closing the word used to leave the bare history page, so reading one word
+   * out of a drill cost the whole session you were reading.
+   *
+   * Here rather than in a component test because the two dialogs are driven by
+   * different things: the session by this route's own state, the word by a
+   * provider that pushes the address bar and listens for `popstate`.
+   */
+  test('returns to the session after closing a word opened from inside it', async ({ page }) => {
+    await seedSignedIn(page);
+    await page.goto('/practice/flashcards');
+    await page.getByRole('button', { name: '#仕事' }).click();
+    await page.getByRole('button', { name: '開始する' }).click();
+    await page.getByRole('button', { name: /裏を見る/ }).click();
+    await page.getByRole('button', { name: /もう一度/ }).click();
+
+    await page.goto('/history');
+    await sessionRows(page).first().getByRole('button').click();
+
+    const session = page.getByRole('dialog', { name: 'フラッシュカード' });
+    await session.locator('a[href="/vocabulary/w-kiriwake"]').click();
+
+    // Never both at once: the session steps back while the word is showing.
+    const word = page.getByRole('dialog', { name: '単語' });
+    await expect(word).toBeVisible();
+    await expect(session).toBeHidden();
+    await expect(page).toHaveURL(/\/vocabulary\/w-kiriwake$/);
+
+    await word.getByRole('button', { name: '閉じる' }).click();
+
+    await expect(word).toBeHidden();
+    await expect(session).toBeVisible();
+    await expect(page).toHaveURL(/\/history$/);
+  });
+
+  /**
    * The only screen in the app that pages. `listSessions` is tested against the
    * emulator; what is untested until here is a component walking the cursor.
    */

--- a/tests/e2e/history.spec.ts
+++ b/tests/e2e/history.spec.ts
@@ -50,11 +50,11 @@ test.describe('history', () => {
 
   /**
    * The row is a summary and the dialog is where the parts that do not fit go —
-   * chiefly the words that were missed, which the row can only count. The row
-   * became a single button to make it openable at all: a control cannot hold
-   * controls, so the links had to move somewhere with room for them.
+   * the words that were missed, which the row can only count, and the run in
+   * full. The row became a single button to make it openable at all: a control
+   * cannot hold controls, so the links had to move somewhere with room.
    */
-  test('opens a session to see which words were missed', async ({ page }) => {
+  test('opens a session to see the run and which words were missed', async ({ page }) => {
     await seedSignedIn(page);
     await page.goto('/practice/flashcards');
     await page.getByRole('button', { name: '#仕事' }).click();
@@ -68,7 +68,15 @@ test.describe('history', () => {
     const dialog = page.getByRole('dialog', { name: 'フラッシュカード' });
     await expect(dialog).toContainText('0 / 1');
     await expect(dialog).toContainText('0%');
-    await expect(dialog.locator('a[href="/vocabulary/w-kiriwake"]')).toBeVisible();
+
+    // The claim that needs a browser is that the run written by the practice
+    // screen is the run read back here. What the filter does to it, and how a
+    // deleted word draws, are covered in `tests/component`.
+    const run = dialog.locator('ol');
+    await expect(run.locator('a[href="/vocabulary/w-kiriwake"]')).toBeVisible();
+    await expect(run.getByRole('listitem')).toHaveCount(1);
+    await expect(run.getByRole('img', { name: '不正解' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'すべて 1' })).toBeVisible();
   });
 
   /**
@@ -121,7 +129,7 @@ test.describe('history', () => {
           filterLabel: '古い記録',
           total: 3,
           correct: 1,
-          missed: [],
+          words: [],
           startedAt: '2026-06-01T00:00:00.000Z',
           finishedAt: '2026-06-01T00:05:00.000Z',
         },
@@ -131,7 +139,7 @@ test.describe('history', () => {
           filterLabel: '新しい記録',
           total: 3,
           correct: 3,
-          missed: [],
+          words: [],
           startedAt: '2026-06-02T00:00:00.000Z',
           finishedAt: '2026-06-02T00:05:00.000Z',
         },

--- a/tests/e2e/monkey.spec.ts
+++ b/tests/e2e/monkey.spec.ts
@@ -92,6 +92,9 @@ function makeMonkeyEntry(index: number): SeedEntry {
 
 const MONKEY_ENTRIES = Array.from({ length: 50 }, (_, index) => makeMonkeyEntry(index));
 
+/** The 200-character headword, named because the session fixture snapshots it. */
+const MONKEY_WORD_1 = makeMonkeyEntry(0);
+
 const MONKEY_SET = {
   id: 'monkey-set',
   name: 'W'.repeat(200),
@@ -414,7 +417,16 @@ for (const scenario of SCENARIOS) {
           filterLabel: `単語集:${MONKEY_SET.name}`,
           total: 12,
           correct: 7,
-          missed: ['monkey-word-1'],
+          // Snapshot taken from the entry itself, so the 200-character headword
+          // this fixture exists to be hostile with reaches the history dialog
+          // too, not only the word list.
+          missed: [
+            {
+              entryId: MONKEY_WORD_1.id,
+              headword: MONKEY_WORD_1.headword ?? '',
+              reading: MONKEY_WORD_1.reading ?? '',
+            },
+          ],
           startedAt: '2026-06-23T00:00:00.000Z',
           finishedAt: '2026-06-23T00:05:00.000Z',
         },

--- a/tests/integration/localWrite.test.ts
+++ b/tests/integration/localWrite.test.ts
@@ -55,7 +55,7 @@ const sessionDraft = () => ({
   filterLabel: 'すべての語',
   total: 1,
   correct: 1,
-  words: [],
+  words: [{ entryId: 'e1', headword: '切り分け', reading: 'きりわけ', correct: true }],
   startedAt: '2026-08-25T10:00:00.000Z',
 });
 

--- a/tests/integration/localWrite.test.ts
+++ b/tests/integration/localWrite.test.ts
@@ -55,7 +55,7 @@ const sessionDraft = () => ({
   filterLabel: 'すべての語',
   total: 1,
   correct: 1,
-  missed: [],
+  words: [],
   startedAt: '2026-08-25T10:00:00.000Z',
 });
 

--- a/tests/integration/progressRepo.test.ts
+++ b/tests/integration/progressRepo.test.ts
@@ -47,7 +47,7 @@ const session = (overrides: Partial<PracticeSessionDraft> = {}): PracticeSession
   filterLabel: 'すべての語',
   total: 1,
   correct: 1,
-  missed: [],
+  words: [{ entryId: 'e1', headword: '切り分け', reading: 'きりわけ', correct: true }],
   startedAt: '2026-06-24T09:59:00.000Z',
   ...overrides,
 });

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -88,8 +88,8 @@ const session = (ownerUid: string, over: Record<string, unknown> = {}) => ({
   ownerUid,
   finishedAt: new Date('2026-08-13T00:01:00.000Z'),
   filterLabel: 'すべて',
-  total: 10,
-  correct: 8,
+  total: 1,
+  correct: 0,
   words: [{ entryId: 'e1', headword: '切り分け', reading: 'きりわけ', correct: false }],
   ...over,
 });
@@ -613,6 +613,39 @@ describe('bounds on what an owner may write', () => {
     const db = as(ALICE);
     const ids = Array.from({ length: 1001 }, (_, i) => `e${i}`);
     await assertFails(db.doc(`users/${ALICE}/wordSets/big`).set(wordSet(ALICE, { entryIds: ids })));
+  });
+
+  /**
+   * The same for a session, which grows by one element per card dealt.
+   *
+   * Both sides of the bound, because a denial on its own does not say *where*
+   * the line is: a rule that refused every list would pass it. 2,000 is the
+   * ceiling `total` already carries, so a run longer than that describes a
+   * drill the same document says did not happen.
+   */
+  it('refuses a session recording more words than a drill could have dealt', async () => {
+    const db = as(ALICE);
+    const run = (length: number) =>
+      Array.from({ length }, (_, i) => ({
+        entryId: `e${i}`,
+        headword: 'x',
+        reading: '',
+        correct: false,
+      }));
+
+    // `total` moves with the run: rules do not compare the two, but a fixture
+    // that says one card was dealt and lists two thousand is describing a
+    // document the app cannot write.
+    await assertSucceeds(
+      db
+        .doc(`users/${ALICE}/practiceSessions/at-limit`)
+        .set(session(ALICE, { total: 2000, correct: 0, words: run(2000) })),
+    );
+    await assertFails(
+      db
+        .doc(`users/${ALICE}/practiceSessions/over`)
+        .set(session(ALICE, { total: 2000, correct: 0, words: run(2001) })),
+    );
   });
 
   /**

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -90,7 +90,7 @@ const session = (ownerUid: string, over: Record<string, unknown> = {}) => ({
   filterLabel: 'すべて',
   total: 10,
   correct: 8,
-  missed: ['e1'],
+  words: [{ entryId: 'e1', headword: '切り分け', reading: 'きりわけ', correct: false }],
   ...over,
 });
 
@@ -810,9 +810,9 @@ describe('bounds on what an owner may write', () => {
       ),
     );
     await assertSucceeds(
-      db.doc(`users/${ALICE}/practiceSessions/short-missed-id`).set(
+      db.doc(`users/${ALICE}/practiceSessions/short-recorded-word`).set(
         session(ALICE, {
-          missed: [shortNestedString],
+          words: [shortNestedString],
         }),
       ),
     );
@@ -825,9 +825,9 @@ describe('bounds on what an owner may write', () => {
       ),
     );
     await assertSucceeds(
-      db.doc(`users/${ALICE}/practiceSessions/large-missed-id`).set(
+      db.doc(`users/${ALICE}/practiceSessions/large-recorded-word`).set(
         session(ALICE, {
-          missed: [largeNestedString],
+          words: [largeNestedString],
         }),
       ),
     );
@@ -1077,7 +1077,10 @@ describe('what the adapters write is what the rules accept', () => {
       filterLabel: 'すべて',
       total: 10,
       correct: 8,
-      missed: ['e1', 'e2'],
+      words: [
+        { entryId: 'e1', headword: '切り分け', reading: 'きりわけ', correct: false },
+        { entryId: 'e2', headword: '兆候', reading: 'ちょうこう', correct: false },
+      ],
       startedAt: '2026-08-13T00:00:00.000Z',
     };
     await assertSucceeds(

--- a/tests/unit/devSeed.test.ts
+++ b/tests/unit/devSeed.test.ts
@@ -28,9 +28,26 @@ describe('devSeed', () => {
     expect(dangling).toEqual([]);
   });
 
-  it('names only words the notebook has in 苦手 and in every missed list', () => {
-    const missed = (seed.sessions ?? []).flatMap((session) => session.missed ?? []);
-    expect([...(seed.weak ?? []), ...missed].filter((id) => !ids.has(id))).toEqual([]);
+  /**
+   * 苦手な語 is resolved against the notebook, so an id with nothing behind it
+   * makes the list one shorter than the drill the button under it starts.
+   */
+  it('names only words the notebook has in 苦手, which would otherwise list short', () => {
+    expect((seed.weak ?? []).filter((id) => !ids.has(id))).toEqual([]);
+  });
+
+  /**
+   * A session is the one place a dangling id is not a defect: 履歴 records a day
+   * that has happened, and deleting the note afterwards cannot unhappen it. The
+   * seed carries exactly one such word on purpose, because it is the only way
+   * to see the 削除済み row in development — so this pins *which* id, rather
+   * than allowing any number of them and no longer catching a typo.
+   */
+  it('names one deliberately deleted word in the run, and no other stray id', () => {
+    const dealt = (seed.sessions ?? []).flatMap((session) =>
+      (session.words ?? []).map((word) => word.entryId),
+    );
+    expect([...new Set(dealt.filter((id) => !ids.has(id)))]).toEqual(['dev-torikeshi']);
   });
 
   /**

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import type { PracticeSession } from '@/domain/practice';
-import { latestByMode, missedWords, RECENT_WINDOW, sessionTime, weakWords } from '@/lib/history';
+import type { Entry } from '@/domain/entry';
+import type { MissedWord, PracticeSession, PractisedWord } from '@/domain/practice';
+import {
+  latestByMode,
+  missedWords,
+  practisedWords,
+  RECENT_WINDOW,
+  sessionTime,
+  weakWords,
+} from '@/lib/history';
+import type { WordRow } from '@/lib/history';
 import { makeEntry } from '../fixtures/entry';
 
 /**
@@ -9,45 +18,139 @@ import { makeEntry } from '../fixtures/entry';
  * The hazard throughout is the one word sets have: a session names entry ids
  * and nothing prunes it when a word is deleted, so every list on 履歴 is a
  * resolution against a notebook that may no longer hold what it names.
+ *
+ * 苦手な語 accepts that — a deleted word is one the learner chose to stop
+ * studying, and it should leave the review list. 練習履歴 must not, and the
+ * copy `MissedWord` carries is what stops it.
  */
 
 const KIRIWAKE = makeEntry({ id: 'w1', headword: '切り分け' });
 const CHOUKOU = makeEntry({ id: 'w2', headword: '兆候' });
 const NOTEBOOK = [KIRIWAKE, CHOUKOU];
 
+/** As a session records it: the id to link by, and the word as it read. */
+const dealt = (entry: Entry, correct: boolean): PractisedWord => ({
+  entryId: entry.id,
+  headword: entry.headword,
+  reading: entry.reading,
+  correct,
+});
+
+const wrong = (entry: Entry): MissedWord => {
+  const { correct: _correct, ...word } = dealt(entry, false);
+  return word;
+};
+
+/** How a session written before `MissedWord` existed reads back. */
+const legacyWrong = (entryId: string): MissedWord => ({ entryId, headword: '', reading: '' });
+
+/**
+ * A session as `sanitizeSession` hands it over: `words` is the whole run, and
+ * `missed` has already been derived from it. Overriding one without the other
+ * is how these tests describe a session written before `words` existed.
+ */
 const makeSession = (overrides: Partial<PracticeSession> = {}): PracticeSession => ({
   id: 's1',
   mode: 'flashcard',
   filterLabel: 'すべての語',
   total: 3,
   correct: 1,
-  missed: ['w1', 'w2'],
+  words: [dealt(KIRIWAKE, false), dealt(CHOUKOU, false)],
+  missed: [wrong(KIRIWAKE), wrong(CHOUKOU)],
   startedAt: '2026-06-24T09:00:00.000Z',
   finishedAt: '2026-06-24T09:04:00.000Z',
   ...overrides,
 });
 
+/** A session from before the run was kept: wrong answers and nothing else. */
+const legacySession = (missed: MissedWord[]) => makeSession({ words: null, missed });
+
+const label = (row: WordRow) => (row.kind === 'entry' ? row.entry.headword : row.headword);
+
 describe('missedWords', () => {
   it('keeps the order the session recorded them in', () => {
-    const session = makeSession({ missed: ['w2', 'w1'] });
-    expect(missedWords(session, NOTEBOOK).map((entry) => entry.headword)).toEqual([
-      '兆候',
-      '切り分け',
+    const session = makeSession({ missed: [wrong(CHOUKOU), wrong(KIRIWAKE)] });
+    expect(missedWords(session, NOTEBOOK).map(label)).toEqual(['兆候', '切り分け']);
+  });
+
+  /**
+   * The defect this whole field exists for. Deleting a word used to erase it
+   * from every session that had ever recorded it getting the word wrong —
+   * 履歴 is a record of a day that has happened, and deleting a note today
+   * cannot make yesterday's drill have gone differently.
+   */
+  it('still shows a missed word whose note has since been deleted', () => {
+    const deleted = makeEntry({ id: 'w3', headword: '曖昧', reading: 'あいまい' });
+    const session = makeSession({ missed: [wrong(KIRIWAKE), wrong(deleted)] });
+
+    expect(missedWords(session, NOTEBOOK)).toEqual([
+      { kind: 'entry', entry: KIRIWAKE },
+      { kind: 'deleted', entryId: 'w3', headword: '曖昧', reading: 'あいまい' },
     ]);
   });
 
   /**
-   * A word answered wrong and then deleted keeps its id in `missed` forever,
-   * and rightly so — the record of that day is true either way. What must not
-   * happen is 「間違えた語：切り分け、」 with nothing after the separator.
+   * The snapshot is a fallback for a note that is gone, never an override of
+   * one that is not. A headword corrected after the drill reads as corrected
+   * everywhere — and the row links, which a `deleted` row cannot.
    */
-  it('drops an id whose word has been deleted rather than rendering a gap', () => {
-    const session = makeSession({ missed: ['w1', 'gone', 'w2'] });
-    expect(missedWords(session, NOTEBOOK).map((entry) => entry.id)).toEqual(['w1', 'w2']);
+  it('prefers the live note over the snapshot for a word that still exists', () => {
+    const session = makeSession({
+      missed: [{ entryId: 'w1', headword: '切分け', reading: 'きりわけ' }],
+    });
+    expect(missedWords(session, NOTEBOOK)).toEqual([{ kind: 'entry', entry: KIRIWAKE }]);
+  });
+
+  /**
+   * Sessions recorded before the snapshot existed carry a bare id, and no
+   * backfill can invent a headword for a word already deleted. Those rows keep
+   * the old behaviour: dropped, rather than rendered as an empty line.
+   */
+  it('drops a pre-snapshot id whose word is gone, having nothing left to print', () => {
+    const session = legacySession([legacyWrong('w1'), legacyWrong('gone'), legacyWrong('w2')]);
+    expect(missedWords(session, NOTEBOOK).map(label)).toEqual(['切り分け', '兆候']);
   });
 
   it('has nothing to show for a perfect session', () => {
     expect(missedWords(makeSession({ missed: [], correct: 3 }), NOTEBOOK)).toEqual([]);
+  });
+});
+
+describe('practisedWords', () => {
+  it('keeps the deal order, correct answers included', () => {
+    const session = makeSession({
+      words: [dealt(CHOUKOU, true), dealt(KIRIWAKE, false), dealt(CHOUKOU, false)],
+    });
+
+    expect(practisedWords(session, NOTEBOOK)?.map((row) => [label(row), row.correct])).toEqual([
+      ['兆候', true],
+      ['切り分け', false],
+      ['兆候', false],
+    ]);
+  });
+
+  /**
+   * The same rule the missed list follows, and it has to be the same one: the
+   * two lists print the same word, so a word deleted since would otherwise
+   * appear in one and not the other.
+   */
+  it('still shows a correctly answered word whose note has since been deleted', () => {
+    const deleted = makeEntry({ id: 'w3', headword: '曖昧', reading: 'あいまい' });
+    const session = makeSession({ words: [dealt(deleted, true)] });
+
+    expect(practisedWords(session, NOTEBOOK)).toEqual([
+      { kind: 'deleted', entryId: 'w3', headword: '曖昧', reading: 'あいまい', correct: true },
+    ]);
+  });
+
+  /**
+   * Null, not `[]`, and the dialog leans on the difference: a session recorded
+   * before the run was kept never wrote one down, and only its wrong answers
+   * survive. Printing those under a heading that claims to be the whole drill
+   * would say the learner got nothing right.
+   */
+  it('reports no run at all for a session recorded before one was kept', () => {
+    expect(practisedWords(legacySession([legacyWrong('w1')]), NOTEBOOK)).toBeNull();
   });
 });
 

--- a/tests/unit/history.test.ts
+++ b/tests/unit/history.test.ts
@@ -45,16 +45,21 @@ const wrong = (entry: Entry): MissedWord => {
 const legacyWrong = (entryId: string): MissedWord => ({ entryId, headword: '', reading: '' });
 
 /**
- * A session as `sanitizeSession` hands it over: `words` is the whole run, and
- * `missed` has already been derived from it. Overriding one without the other
- * is how these tests describe a session written before `words` existed.
+ * A session as `sanitizeSession` hands it over: `words` is the whole run,
+ * `missed` has already been derived from it, and the score agrees with both.
+ *
+ * A case that overrides one list and not the other is describing a document
+ * neither reader would meet in production. That is deliberate — each of these
+ * exercises one reader with input built by hand, the way `makeEntry` is — but
+ * the default has to be a session that could have happened, or every case
+ * starts from a contradiction it did not ask for.
  */
 const makeSession = (overrides: Partial<PracticeSession> = {}): PracticeSession => ({
   id: 's1',
   mode: 'flashcard',
   filterLabel: 'すべての語',
-  total: 3,
-  correct: 1,
+  total: 2,
+  correct: 0,
   words: [dealt(KIRIWAKE, false), dealt(CHOUKOU, false)],
   missed: [wrong(KIRIWAKE), wrong(CHOUKOU)],
   startedAt: '2026-06-24T09:00:00.000Z',
@@ -112,7 +117,12 @@ describe('missedWords', () => {
   });
 
   it('has nothing to show for a perfect session', () => {
-    expect(missedWords(makeSession({ missed: [], correct: 3 }), NOTEBOOK)).toEqual([]);
+    const perfect = makeSession({
+      words: [dealt(KIRIWAKE, true), dealt(CHOUKOU, true)],
+      missed: [],
+      correct: 2,
+    });
+    expect(missedWords(perfect, NOTEBOOK)).toEqual([]);
   });
 });
 

--- a/tests/unit/practice.test.ts
+++ b/tests/unit/practice.test.ts
@@ -323,7 +323,25 @@ describe('mergeProgress', () => {
 });
 
 describe('summariseSession', () => {
-  it('counts the answers and lists the ids that were missed', () => {
+  const QUEUE = [
+    makeEntry({ id: 'a', headword: '切り分け', reading: 'きりわけ' }),
+    makeEntry({ id: 'b', headword: '兆候', reading: 'ちょうこう' }),
+    // No reading, which is an ordinary note and not a missing value.
+    makeEntry({ id: 'c', headword: 'さすが', reading: '' }),
+  ];
+
+  /**
+   * The headword is copied in, not only pointed at.
+   *
+   * An id alone made 履歴 rewritable by deleting a word: the row could only be
+   * drawn by resolving the id against today's notebook, so a deleted note took
+   * the record of getting it wrong with it.
+   *
+   * Every answer is recorded, not only the wrong ones, so the dialog can print
+   * the run as it happened. `missed` is derived from this on read rather than
+   * stored beside it — two copies of one list are two things that can be wrong.
+   */
+  it('copies the headword of every word dealt into the record, not just its id', () => {
     expect(
       summariseSession({
         mode: 'flashcard',
@@ -334,15 +352,40 @@ describe('summariseSession', () => {
           { entryId: 'c', correct: false },
         ],
         startedAt: '2026-06-24T09:59:00.000Z',
+        entries: QUEUE,
       }),
     ).toEqual({
       mode: 'flashcard',
       filterLabel: '#仕事',
       total: 3,
       correct: 1,
-      missed: ['b', 'c'],
+      // The whole run, in deal order, right answers included — `missed` is not
+      // stored beside it and is derived on read.
+      words: [
+        { entryId: 'a', headword: '切り分け', reading: 'きりわけ', correct: true },
+        { entryId: 'b', headword: '兆候', reading: 'ちょうこう', correct: false },
+        { entryId: 'c', headword: 'さすが', reading: '', correct: false },
+      ],
       startedAt: '2026-06-24T09:59:00.000Z',
     });
+  });
+
+  /**
+   * `words.length` is what the dialog numbers its rows from, and the score
+   * beside it is `total`. An answer the queue cannot name — which should not
+   * happen, and would mean the queue changed under the session — still gets a
+   * row, so the two can never disagree in the one record whose job is to say
+   * what happened. It reads back the way a pre-snapshot session does.
+   */
+  it('records an answer whose word is not in the queue rather than dropping it', () => {
+    const { words } = summariseSession({
+      mode: 'flashcard',
+      filterLabel: '#仕事',
+      answers: [{ entryId: 'ghost', correct: false }],
+      startedAt: '2026-06-24T09:59:00.000Z',
+      entries: QUEUE,
+    });
+    expect(words).toEqual([{ entryId: 'ghost', headword: '', reading: '', correct: false }]);
   });
 
   /**
@@ -363,6 +406,7 @@ describe('summariseSession', () => {
       filterLabel: label,
       answers: [],
       startedAt: '2026-06-24T09:59:00.000Z',
+      entries: [],
     });
 
     expect(filterLabel.length).toBeLessThanOrEqual(SESSION_LIMITS.filterLabel);
@@ -382,6 +426,7 @@ describe('summariseSession', () => {
         filterLabel: label,
         answers: [],
         startedAt: '2026-06-24T09:59:00.000Z',
+        entries: [],
       }).filterLabel,
     ).toBe(label);
   });

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { toDraft } from '@/lib/draft';
-import { isValidIsoDate, sanitizeDraft, sanitizeEntry, sanitizeProgressMap } from '@/lib/sanitize';
+import {
+  isValidIsoDate,
+  sanitizeDraft,
+  sanitizeEntry,
+  sanitizeProgressMap,
+  sanitizeSession,
+} from '@/lib/sanitize';
 import { makeEntry } from '../fixtures/entry';
 
 /**
@@ -450,5 +456,128 @@ describe('sanitizeProgressMap', () => {
       status: 'wrong',
       attempts: 0,
     });
+  });
+});
+
+/**
+ * The one place the two shapes of `missed` meet.
+ *
+ * Sessions written before `MissedWord` existed hold a bare id, and there is no
+ * backfill that could fix that — a headword for a word already deleted cannot
+ * be recovered. So the reader takes both, and the old shape reads back as a
+ * snapshot with nothing in it, which is what it is.
+ */
+describe('sanitizeSession — the missed list, in both shapes it is stored in', () => {
+  const stored = (missed: unknown) => ({
+    mode: 'flashcard',
+    filterLabel: 'すべて',
+    total: 3,
+    correct: 1,
+    missed,
+    startedAt: '2026-06-24T09:00:00.000Z',
+    finishedAt: '2026-06-24T09:04:00.000Z',
+  });
+
+  it('reads the snapshot a session records now', () => {
+    expect(
+      sanitizeSession('s1', stored([{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }]))
+        .missed,
+    ).toEqual([{ entryId: 'w1', headword: '切り分け', reading: 'きりわけ' }]);
+  });
+
+  /**
+   * A session recorded before this field existed. Read as anything other than
+   * a `MissedWord`, every history row it holds throws on `.entryId`.
+   */
+  it('reads a pre-snapshot session, whose missed list is bare ids', () => {
+    expect(sanitizeSession('s1', stored(['w1', 'w2'])).missed).toEqual([
+      { entryId: 'w1', headword: '', reading: '' },
+      { entryId: 'w2', headword: '', reading: '' },
+    ]);
+  });
+
+  /**
+   * The id is what makes a surviving word a link, so a row without one can
+   * never be anything but dead text. Dropped rather than rendered, the same
+   * way a pre-snapshot id with no word behind it is.
+   */
+  it('drops an element with no entry id, which could never link anywhere', () => {
+    expect(
+      sanitizeSession('s1', stored([{ headword: '切り分け' }, null, 42, '', { entryId: 'w1' }]))
+        .missed,
+    ).toEqual([{ entryId: 'w1', headword: '', reading: '' }]);
+  });
+
+  it('reads a missed list that is not a list at all as empty', () => {
+    expect(sanitizeSession('s1', stored('w1')).missed).toEqual([]);
+  });
+});
+
+/**
+ * The full run, and the missed list that is read out of it.
+ *
+ * Nothing writes `missed` any more — it is `words` with the correct answers
+ * taken out — so a session recorded now has no such field, and reading one
+ * without deriving it leaves every history row's missed list empty.
+ */
+describe('sanitizeSession — the run', () => {
+  const stored = (over: Record<string, unknown>) => ({
+    mode: 'flashcard',
+    filterLabel: 'すべて',
+    total: 2,
+    correct: 1,
+    startedAt: '2026-06-24T09:00:00.000Z',
+    finishedAt: '2026-06-24T09:04:00.000Z',
+    ...over,
+  });
+
+  const RUN = [
+    { entryId: 'w1', headword: '切り分け', reading: 'きりわけ', correct: true },
+    { entryId: 'w2', headword: '兆候', reading: 'ちょうこう', correct: false },
+  ];
+
+  it('derives the missed list from the run, since nothing stores it any more', () => {
+    expect(sanitizeSession('s1', stored({ words: RUN })).missed).toEqual([
+      { entryId: 'w2', headword: '兆候', reading: 'ちょうこう' },
+    ]);
+  });
+
+  /**
+   * A document that somehow holds both. The run is the record of what happened
+   * and the other is a list that was derived from something; trusting the
+   * stored copy would let a stale one outrank the answers themselves.
+   */
+  it('reads the missed list out of the run even when a stored one sits beside it', () => {
+    const session = sanitizeSession(
+      's1',
+      stored({ words: RUN, missed: [{ entryId: 'w9', headword: '曖昧', reading: 'あいまい' }] }),
+    );
+    expect(session.missed).toEqual([{ entryId: 'w2', headword: '兆候', reading: 'ちょうこう' }]);
+  });
+
+  /**
+   * Null and `[]` are different claims, and the dialog leans on the difference:
+   * null means the session never recorded a run, which is every session written
+   * before the field existed. An empty list would claim a drill that dealt no
+   * cards, and the dialog would print a heading over nothing.
+   */
+  it('reports no run at all, rather than an empty one, when the field is absent', () => {
+    expect(sanitizeSession('s1', stored({ missed: ['w2'] })).words).toBeNull();
+  });
+
+  /**
+   * The direction `sanitizeProgressMap` already defaults in, for the same
+   * reason: a word shown as missed gets looked at again, one shown as correct
+   * does not. So anything that is not exactly `true` reads as a wrong answer.
+   */
+  it('reads an unusable answer as wrong, so the word surfaces rather than hides', () => {
+    const session = sanitizeSession(
+      's1',
+      stored({ words: [{ entryId: 'w1', headword: '切り分け', reading: '', correct: 'yes' }] }),
+    );
+    expect(session.words).toEqual([
+      { entryId: 'w1', headword: '切り分け', reading: '', correct: false },
+    ]);
+    expect(session.missed).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Deleting a word rewrote history. A practice session stored entry ids, so a row
in 履歴 could only be drawn by resolving those ids against the notebook as it
stands *now* — and a deleted note took the record of getting it wrong with it.
The score stayed put and the words behind it changed, which is the one thing a
log of what happened on a day must not do.

## 1. A session keeps its own copy of every word it dealt

`PractisedWord` is the whole run: every card, in the order it was dealt, with
`headword` and `reading` copied in beside the id.

- **The live note still wins where there is one.** The copy is a fallback for
  lost data, not an override — a word that still exists keeps its current text,
  its level and its link, so a headword corrected after the drill reads as
  corrected. Only a word with nothing left to link to is drawn from the copy,
  muted and marked 削除済み.
- **`missed` is derived on read, not stored.** It is the run with the correct
  answers taken out. Two copies of one list are two things that can disagree,
  and nothing writes the field any more.
- **苦手な語 is untouched, deliberately.** A deleted word still leaves that
  list. It is current state — words to review — not history, and a word the
  learner deleted is one they chose to stop studying.

## 2. The dialog shows the run, narrowed by outcome

This started as two lists — the run, and the wrong answers again on their own —
and every missed word appeared in both. They turned out to be one list under two
filters, so that is what they are now: `全部 / 正解 / 不正解` as `aria-pressed`
buttons carrying counts, opening on 全部.

- **Rows are numbered by the drill, not by the filter.** Narrowing to the wrong
  answers and renumbering from 1 would say the learner got the first three cards
  wrong; 2, 5, 9 says where they actually came up.
- Buttons rather than a `tablist`: this is one list that shrinks, and announcing
  several panels would promise a structure that is not there.
- The counts are where the old separate list's count went. Losing them would
  make "how many did I get wrong" something you count by eye.
- `history.practisedWords`, `history.answerFilter`, `history.filterAll`,
  `history.deletedWord`, `history.answeredCorrect` and `history.answeredWrong`
  are new in all five locales.

## 3. Closing a word returns to the session it was opened from

Opening a word from inside the session dialog threw the session away, so closing
the word left the bare history page — reading one word out of a drill cost the
drill you were reading. The session now stays in state and is simply not
rendered while a word is showing, so closing it, or going Back, returns there.

Still never two modals at once, which is what the original swap was for: that is
one Escape closing both and a backdrop belonging to neither. This also replaces
an effect that ran a render late and left both dialogs mounted for a frame.

## Sessions written before this, and why there is no backfill

They hold only their wrong answers, as bare ids. `sanitizeSession` reads both
shapes; those rows keep the old behaviour and are dropped when there is nothing
left to print, and the dialog falls back to the old missed list for them.

A backfill cannot help. The correct answers were never written down, so the run
is not reconstructable at all — and a headword for a word already deleted is not
recoverable, while one copied from a note that still exists would be today's
value pretending to be the day's. Since the app is not open to signups, the
decision is to delete that data after the production deploy instead: **#142**
tracks it, along with the follow-up that drops the transitional read paths.

## Rules, and deploy order

`sessionFields()` accepts `words` and keeps accepting `missed`, so a session
written before this can still be updated. `hasOnly` refuses an unknown field, so
a client that wrote `words` under the old rules would have every session write
refused — `deploy-prod.yml` already deploys rules before hosting for exactly
this reason, so the client is never newer than the rules it runs under.

`PracticeSessionDraft` narrows `words` to non-null rather than inheriting it.
Null is a read state, meaning a stored session predates the field; rules ask
that `words` is a list, and `get('words', [])` falls back only when the key is
absent, so an explicit null reaches `null is list` and the write is refused. The
type used to accept a draft that production rejects.

## Test layers, and why each

- **Unit** (`sanitize`, `history`, `practice`) for the coercion and the
  resolution — both are functions of their inputs, which is where `CLAUDE.md`
  puts the default. This is also where both stored shapes of `missed` are read
  back, and where `null` and `[]` are held apart as different claims.
- **Component** (`SessionDialog.test.tsx`, new) for what the dialog draws: the
  filter counts, the drill positions surviving a filter, a deleted word printed
  and left unlinked, and the empty state a filter can select.
- **End to end** for two claims that need a browser. One is the round trip — the
  run the practice screen writes is the run the dialog reads back, which spans a
  provider. The other is the dialog stack, where the two dialogs are driven by
  different things: the session by the route's own state, the word by a provider
  that pushes the address bar and listens for `popstate`.

Nothing was added to `visual.spec.ts`: no baseline covers the history dialog,
and none of this is a rendering claim of the kind the WebKit project exists for.

## Proved red before green

Five reverts, each failing only what it should:

- `resolve` returning null for any unresolved id — the original shape — took
  down 2 unit and 4 component cases. The guards around it stayed green, which is
  correct: they are guards, not the defect.
- `missedList` refusing a bare string took down the pre-snapshot case alone.
- Storing `missed` instead of deriving it took down 3. **This one found a real
  gap** — the derivation had no test at all until the revert exposed it, so a
  test was written before the fix went back.
- `practisedList` returning `[]` instead of `null` took down 5.
- Restoring the effect and `session={opened}` failed the new stacking case at
  `expect(session).toBeVisible()`, and nothing else in the spec moved.

For the draft type, a throwaway literal with `words: null` fails `yarn
typecheck` with TS2322 and compiled clean before the change.

## What is not verified here

**`tests/rules` and `tests/integration` have not been run.** The machine this
was written on has no JDK 21, which `firebase-tools` now requires, so the
emulator layer is typechecked and unrun — the fixtures for both were updated for
the new shape. CI is the first place they execute.

No rules test asserts that `words: null` is refused. The emulator cannot run
locally to see it go either way, and the type change makes the value
unrepresentable from the client, which is the stronger guarantee.

`yarn typecheck`, `yarn test:unit` (954) and `yarn test:e2e --project=chromium`
(149) pass on the branch tip. `yarn format` was run.

Closes nothing; **#142** is the follow-up this creates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Practice history now shows every word from a session, including numbered answers and correct/incorrect results.
  * Added filters for all, correct, and incorrect answers.
  * Deleted words remain visible with their recorded details.
  * Opening a word from a session temporarily hides the session view and restores it afterward.
* **Bug Fixes**
  * Older sessions continue to display correctly using their existing data.
  * Historical word details are preserved even when entries are later edited or deleted.
* **Localization**
  * Added translations for the new history and answer-filtering messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->