### PR TITLE
feat(dashboard): load vocabulary stats on demand

### DIFF
--- a/HANDOFF-dashboard-on-demand-vocab.md
+++ b/HANDOFF-dashboard-on-demand-vocab.md
@@ -38,13 +38,14 @@ deploy` (<https://github.com/kowinauyeung/japanese-learning-notes/issues/140>)
 
 ## Status update
 
-The review blockers below have now been implemented in the uncommitted
-worktree. `saveDashboardStats()` bootstraps a complete cache document after the
-Dashboard fallback drain. CRUD awaits the stats delta before resolving, and the
-Dashboard derives period totals from cached day buckets rather than three server
-aggregates. The focused adapter regression was proven red by restoring
-`void writeStatsDelta(...)`, which read `total: 0` after create, then green with
-the awaited implementation. Full emulator verification passes with 113 tests.
+The client-side full-scan writer was removed after review identified its stale
+snapshot race. Dashboard now has a read-only fallback for a missing cache. The
+privileged `yarn backfill:vocabulary-stats` Admin SDK script creates and rebuilds
+every cache document transactionally, then sample-verifies source parity. CRUD
+awaits stats deltas, and Dashboard derives period totals from cached day buckets
+rather than three server aggregates. The focused adapter regression was proven
+red by restoring `void writeStatsDelta(...)`, which read `total: 0` after create,
+then green with the awaited implementation.
 
 ## Feature implemented so far
 

--- a/HANDOFF-dashboard-on-demand-vocab.md
+++ b/HANDOFF-dashboard-on-demand-vocab.md
@@ -1,0 +1,200 @@
+# Dashboard on-demand vocabulary handoff
+
+## Working agreement
+
+- Reply to the user in Cantonese, using Traditional Chinese. Keep repository
+  artifacts (commits, branches, PRs, GitHub issues, and review replies) in
+  English.
+- Read `AGENTS.md` before changing code. In particular, shared port changes
+  require enumerating downstream consumers, and regression tests must be proven
+  red before the fix is claimed green.
+- Use `apply_patch` for edits. Use `gh` for GitHub operations.
+- Do not commit without proposing the exact commit message and receiving the
+  user's explicit approval.
+
+## Repository state
+
+- Repository: `/Users/kowin/Documents/japanese-learning-notes`
+- Branch: `feat/dashboard-on-demand-vocab`
+- Base: `develop`
+- Existing GitHub issue: #140, `Backfill vocabulary dashboard stats after
+deploy` (<https://github.com/kowinauyeung/japanese-learning-notes/issues/140>)
+- No pull request has been opened yet.
+- The worktree currently has one intentional, uncommitted partial change in
+  `src/domain/ports.ts`:
+
+  ```ts
+  saveDashboardStats(stats: Omit<EntryDashboardStats, 'ownerUid'>): Promise<void>;
+  ```
+
+  It is only a port declaration. Its implementations, consumers, and tests have
+  not yet been added.
+
+## Relevant commits
+
+- `2f7f46d feat(dashboard): load vocabulary stats on demand`
+- `161397d fix(dashboard): keep vocabulary stats consistent`
+- `57345d3 fix(dashboard): refresh stats after vocabulary edits`
+
+## Status update
+
+The review blockers below have now been implemented in the uncommitted
+worktree. `saveDashboardStats()` bootstraps a complete cache document after the
+Dashboard fallback drain. CRUD awaits the stats delta before resolving, and the
+Dashboard derives period totals from cached day buckets rather than three server
+aggregates. The focused adapter regression was proven red by restoring
+`void writeStatsDelta(...)`, which read `total: 0` after create, then green with
+the awaited implementation. Full emulator verification passes with 113 tests.
+
+## Feature implemented so far
+
+The branch moves Dashboard reads away from an unconditional full notebook load.
+
+- Firestore dashboard cache document: `users/{uid}/stats/vocabulary`.
+- `EntryRepository` has dashboard-specific read methods: `dashboardStats`,
+  `countLearnedSince`, `recentLearned`, `listLearnedOn`, and `wordOfDay`.
+- Vocabulary paging and selected-day heatmap reads use cursors and drain every
+  page when a selected day is opened.
+- Dashboard edits propagate through `EntriesProvider.mutationVersion`, so the
+  Dashboard reloads after a dialog save without loading the whole notebook.
+- Account deletion explicitly removes `stats/vocabulary` after writing the
+  tombstone, avoiding stale user statistics.
+- Firestore rule access for `stats/vocabulary` is owner-gated and create/update
+  are tombstone-gated.
+- `statsDelta` accumulates numeric deltas before producing Firestore
+  `increment()` values, fixing path-overwrite inflation for no-op counter edits
+  and partially overlapping `pos` arrays.
+- Word of the day seed uses the Firestore auto-ID alphabet rather than a
+  left-zero-padded value.
+
+## Historical review blockers
+
+### 1. Bootstrap missing dashboard stats
+
+`writeStatsDelta()` in `src/infra/firebase/entryRepo.ts` returns when the stats
+document does not exist. `Dashboard` falls back to draining all entries and
+computing a `Summary`, but never persists that computed result. New accounts and
+accounts not yet backfilled will therefore keep full-reading the notebook.
+
+Recommended direction:
+
+1. Keep the already-added `saveDashboardStats` port method.
+2. Implement it in `src/infra/firebase/entryRepo.ts`. It should create the
+   complete stats document for the current owner, including `ownerUid`, total,
+   `countsByDay`, `jlptCounts`, `posCounts`, and `updatedAt`.
+3. Add the matching implementation to `src/lib/backend.e2e.ts` and every test
+   fake that implements `EntryRepository`.
+4. In `src/routes/Dashboard.tsx`, after fallback `drainEntries()` and
+   `summarise(all, now)`, persist the calculated stats before completing the
+   Dashboard load. The UI may still render the already calculated fallback
+   summary; the important property is that the next visit uses the cache.
+
+Consider offline behavior deliberately. Existing Firestore writes use
+`LocalWriteTracker`, so a local Firestore cache write can resolve the user save
+flow without waiting for server acknowledgement.
+
+### 2. Stats update is not part of mutation completion
+
+`create`, `update`, and `remove` currently use `void writeStatsDelta(...)`.
+The entry mutation can complete, `syncAfterMutation()` can bump
+`mutationVersion`, and Dashboard can read the old stats doc before the delta is
+locally queued. It then treats that old doc as authoritative until the next
+reload.
+
+Recommended direction:
+
+1. Make `create`, `update`, and `remove` await `writeStatsDelta(...)` after
+   their entry mutation has locally completed.
+2. Preserve the existing expected-error handling for a missing/unavailable
+   stats document so an offline entry save does not hang or fail merely because
+   the cache has not been bootstrapped.
+3. Add an integration regression test proving that immediately after awaiting a
+   repository mutation, `dashboardStats()` observes the local delta. Before the
+   fix, temporarily restore the `void writeStatsDelta(...)` behavior and confirm
+   only the intended regression test fails; then restore the awaited behavior
+   and rerun it green.
+
+## Review suggestion worth including
+
+Dashboard currently calls the server aggregate `countLearnedSince()` three
+times for week/month/year even when `storedStats.countsByDay` is available.
+Replace that with a pure helper in `src/lib/stats.ts` that totals day buckets for
+the three date ranges. This removes three server-only reads and works from the
+cached stats document offline.
+
+Likely shape:
+
+```ts
+summaryFromDashboardStats(stats, now);
+```
+
+instead of passing separately queried period counts into the helper. Add unit
+tests in `tests/unit/stats.test.ts` because this is date/map arithmetic, not a
+Firestore query behavior.
+
+## Shared port downstream consumers
+
+The new `saveDashboardStats` method changes `EntryRepository`. Update all
+implementations and structural fakes before typechecking:
+
+- `src/infra/firebase/entryRepo.ts`
+- `src/lib/backend.e2e.ts`
+- test repository fakes, including `tests/unit/accountData.test.ts`
+- any other `EntryRepository` object literals found with
+  `rg "EntryRepository|removeDashboardStats" src tests`
+
+The `Summary` and dashboard-stat conversion helpers are used by:
+
+- `src/routes/Dashboard.tsx`
+- `tests/unit/stats.test.ts`
+
+## Existing tests and prior red checks
+
+`tests/integration/entryRepo.test.ts` already covers:
+
+- create, update, and remove stats counter values at each step;
+- dashboard stats deletion;
+- non-counter edits followed by a date move (prevents counter inflation);
+- partial `pos` overlap edits (prevents incorrect part-of-speech deltas).
+
+For the last two tests, the previous agent temporarily reintroduced the old
+per-path overwrite implementation. Both tests failed with inflated counters,
+then passed after restoring accumulated numeric deltas.
+
+New tests needed:
+
+- A unit test for day-bucket period totals, if the suggested helper is added.
+- An integration test for immediate post-mutation stats visibility.
+- Coverage that Dashboard fallback persists a full stats document. Prefer the
+  cheapest layer that can see the behavior. A pure conversion helper belongs in
+  unit tests; Firestore document/query semantics belong in integration tests.
+
+## Previous verification
+
+Passed after `57345d3`:
+
+- `yarn typecheck`
+- `yarn lint` (18 existing warnings, no errors)
+- `yarn vitest run tests/unit/accountData.test.ts tests/unit/stats.test.ts`
+  (30 tests)
+- focused `entryRepo` emulator tests (21 tests)
+- `yarn test:emulator` (7 files, 112 tests)
+
+Known environment issue:
+
+- `yarn test:unit` has a pre-existing local failure because
+  `inter-latin-400-normal.woff2` is missing from `node_modules`; reviewer
+  reported all other 916 tests passing.
+
+For emulator tests on macOS, use JDK 21 first on `PATH` as documented in
+`AGENTS.md`. Localhost emulator ports may require sandbox escalation.
+
+## Before opening a PR
+
+1. Run `yarn format` and include formatter changes.
+2. Run `yarn typecheck`, focused unit/integration tests, and then the relevant
+   full suites where practical.
+3. State the test layer and the red-to-green proof in the PR description.
+4. Propose a commit message and wait for explicit user approval before commit.
+5. Do not create the PR until the user asks. After creating it, link issue #140
+   to the PR as requested by the user.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ source tree.
 | `yarn release`                         | Bump the version and write `CHANGELOG.md`             |
 | `yarn rules:dev` / `yarn rules:prod`   | Deploy `firestore.rules`                              |
 | `yarn auth:login` / `yarn auth:revoke` | Repo-local Google ADC, used by the operator scripts   |
+| `yarn backfill:vocabulary-stats`       | Rebuild cached Dashboard vocabulary stats on dev      |
+| `yarn backfill:vocabulary-stats prod`  | Rebuild and sample-verify every production user       |
 
 `yarn auth:login` writes to `.gcloud/` via `CLOUDSDK_CONFIG`, deliberately apart
 from the machine-wide `~/.config/gcloud`. There is no long-lived service-account
@@ -382,6 +384,30 @@ production — an account that signs in and finds every write refused while its
 data is still there. Deleting `deletedAccounts/{uid}` restores writing
 immediately, because the rule reads the document on each write rather than
 anything in the token.
+
+**Backfilling Dashboard vocabulary stats after deploy.** Run this only after
+the app and Firestore rules containing `users/{uid}/stats/vocabulary` have
+deployed:
+
+```sh
+yarn auth:login
+yarn backfill:vocabulary-stats prod --sample 20
+```
+
+The script visits every `users/{uid}` document, creates a zeroed stats document
+when one is missing, then uses an Admin SDK transaction to scan that user's
+entries and replace the counters. It reads the stats document in the same
+transaction, so a client counter delta that overlaps the scan forces a retry
+rather than being overwritten by an older snapshot. It also samples the requested
+number of rebuilt users and compares each stored stats document with its source
+entries; a mismatch exits non-zero.
+
+The operation is idempotent and safe to rerun. Run it once after this deploy and
+again after any manual data repair or bulk import. It needs ADC for the target
+project and Firestore read/write permission (for example `roles/datastore.user`)
+on the operator identity. Do not use the Dashboard's client fallback as a
+migration mechanism: it may read missing cache data, but it deliberately never
+writes a full cache snapshot.
 
 **Releasing.** Cutting the version — the branch, the changelog and the tag — is
 [docs/releasing.md](docs/releasing.md). What follows is only the access half of

--- a/admin/backfill-vocabulary-stats.lib.ts
+++ b/admin/backfill-vocabulary-stats.lib.ts
@@ -1,0 +1,116 @@
+import { FieldValue } from 'firebase-admin/firestore';
+import type { DocumentData, Firestore } from 'firebase-admin/firestore';
+import type { EntryDashboardStats } from '../src/domain/ports';
+import { dashboardStatsFor, sameDashboardStats } from './backfill-vocabulary-stats.shared';
+
+export async function rebuildVocabularyStats(
+  db: Firestore,
+  uid: string,
+  { onSourceRead }: { onSourceRead?: () => Promise<void> } = {},
+): Promise<'active' | 'deleted'> {
+  const user = db.collection('users').doc(uid);
+  const entries = user.collection('entries');
+  const stats = user.collection('stats').doc('vocabulary');
+  const tombstone = db.doc(`deletedAccounts/${uid}`);
+
+  const status = await db.runTransaction(async (transaction) => {
+    const [deletedAccount, existingStats] = await Promise.all([
+      transaction.get(tombstone),
+      transaction.get(stats),
+    ]);
+    if (deletedAccount.exists) {
+      if (existingStats.exists) transaction.delete(stats);
+      return 'deleted' as const;
+    }
+    if (!existingStats.exists) transaction.create(stats, emptyDashboardStats(uid));
+    return 'active' as const;
+  });
+  if (status === 'deleted') return status;
+
+  return db.runTransaction(async (transaction) => {
+    const [deletedAccount, source, currentStats] = await Promise.all([
+      transaction.get(tombstone),
+      transaction.get(entries),
+      transaction.get(stats),
+    ]);
+    if (deletedAccount.exists) {
+      if (currentStats.exists) transaction.delete(stats);
+      return 'deleted' as const;
+    }
+    if (!currentStats.exists) throw new Error(`stats document disappeared for ${uid}`);
+
+    const calculated = dashboardStatsFor(
+      source.docs.map((entry) => statsEntry(entry.id, entry.data())),
+    );
+    await onSourceRead?.();
+    transaction.set(stats, {
+      ownerUid: uid,
+      ...calculated,
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    return 'active' as const;
+  });
+}
+
+export async function verifyVocabularyStats(db: Firestore, uid: string): Promise<void> {
+  const user = db.collection('users').doc(uid);
+  const [source, stored] = await Promise.all([
+    user.collection('entries').get(),
+    user.collection('stats').doc('vocabulary').get(),
+  ]);
+  if (!stored.exists) throw new Error(`missing stats document after backfill for ${uid}`);
+
+  const expected = dashboardStatsFor(
+    source.docs.map((entry) => statsEntry(entry.id, entry.data())),
+  );
+  const actual = statsDocument(uid, stored.data());
+  if (!sameDashboardStats(actual, expected)) {
+    throw new Error(`stats/source mismatch after backfill for ${uid}`);
+  }
+}
+
+function emptyDashboardStats(uid: string) {
+  return {
+    ownerUid: uid,
+    total: 0,
+    countsByDay: {},
+    jlptCounts: {},
+    posCounts: {},
+    updatedAt: FieldValue.serverTimestamp(),
+  };
+}
+
+function statsEntry(id: string, data: DocumentData) {
+  if (typeof data.learnedOn !== 'string' || typeof data.jlpt !== 'string') {
+    throw new Error(`entry ${id} has no valid learnedOn or jlpt value`);
+  }
+  if (!Array.isArray(data.pos) || !data.pos.every((part) => typeof part === 'string')) {
+    throw new Error(`entry ${id} has no valid pos array`);
+  }
+  return { learnedOn: data.learnedOn, jlpt: data.jlpt, pos: data.pos };
+}
+
+function statsDocument(uid: string, data: DocumentData | undefined): EntryDashboardStats {
+  if (!data) throw new Error(`stats document has no data for ${uid}`);
+  return {
+    ownerUid: uid,
+    total: numberValue(data.total, 'total', uid),
+    countsByDay: numberRecord(data.countsByDay, 'countsByDay', uid),
+    jlptCounts: numberRecord(data.jlptCounts, 'jlptCounts', uid),
+    posCounts: numberRecord(data.posCounts, 'posCounts', uid),
+  };
+}
+
+function numberRecord(value: unknown, field: string, uid: string): Record<string, number> {
+  if (!value || typeof value !== 'object') throw new Error(`invalid ${field} for ${uid}`);
+  const record: Record<string, number> = {};
+  for (const [key, count] of Object.entries(value)) record[key] = numberValue(count, field, uid);
+  return record;
+}
+
+function numberValue(value: unknown, field: string, uid: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`invalid ${field} for ${uid}`);
+  }
+  return value;
+}

--- a/admin/backfill-vocabulary-stats.shared.ts
+++ b/admin/backfill-vocabulary-stats.shared.ts
@@ -1,0 +1,98 @@
+import type { EntryDashboardStats } from '../src/domain/ports';
+
+export interface DashboardStatsEntry {
+  learnedOn: string;
+  jlpt: string;
+  pos: string[];
+}
+
+export type ParsedBackfillVocabularyStatsArgs =
+  | { ok: true; projectId: string; sampleSize: number }
+  | { ok: false; errors: string[]; usage: string };
+
+const USAGE =
+  'usage: backfill-vocabulary-stats.ts [prod] [--project <project-id>] [--sample <positive integer>]';
+
+export function parseBackfillVocabularyStatsArgs(
+  args: string[],
+): ParsedBackfillVocabularyStatsArgs {
+  const errors: string[] = [];
+  let prod = false;
+  let projectId: string | null = null;
+  let sampleSize = 20;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === 'prod') {
+      prod = true;
+      continue;
+    }
+    if (arg === '--project') {
+      const value = args[index + 1];
+      if (!value || value.startsWith('--')) {
+        errors.push('--project requires a project id');
+        continue;
+      }
+      if (projectId) errors.push('--project specified multiple times');
+      else projectId = value;
+      index += 1;
+      continue;
+    }
+    if (arg === '--sample') {
+      const value = args[index + 1];
+      const parsed = value ? Number(value) : Number.NaN;
+      if (!Number.isSafeInteger(parsed) || parsed < 1) {
+        errors.push('--sample requires a positive integer');
+      } else {
+        sampleSize = parsed;
+      }
+      index += 1;
+      continue;
+    }
+    errors.push(`unknown argument: ${arg}`);
+  }
+
+  if (prod && projectId) errors.push('choose either prod or --project <project-id>, not both');
+  if (errors.length > 0) return { ok: false, errors, usage: USAGE };
+  return { ok: true, projectId: projectId ?? (prod ? 'goitei' : 'goitei-dev'), sampleSize };
+}
+
+export function dashboardStatsFor(
+  entries: Iterable<DashboardStatsEntry>,
+): Omit<EntryDashboardStats, 'ownerUid'> {
+  const countsByDay: Record<string, number> = {};
+  const jlptCounts: Record<string, number> = {};
+  const posCounts: Record<string, number> = {};
+  let total = 0;
+
+  for (const entry of entries) {
+    total += 1;
+    addCount(countsByDay, entry.learnedOn);
+    addCount(jlptCounts, entry.jlpt);
+    for (const part of entry.pos) addCount(posCounts, part);
+  }
+
+  return { total, countsByDay, jlptCounts, posCounts };
+}
+
+export function sameDashboardStats(
+  actual: EntryDashboardStats,
+  expected: Omit<EntryDashboardStats, 'ownerUid'>,
+): boolean {
+  return (
+    actual.total === expected.total &&
+    sameRecord(actual.countsByDay, expected.countsByDay) &&
+    sameRecord(actual.jlptCounts, expected.jlptCounts) &&
+    sameRecord(actual.posCounts, expected.posCounts)
+  );
+}
+
+function addCount(counts: Record<string, number>, key: string) {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+function sameRecord(left: Record<string, number>, right: Record<string, number>): boolean {
+  const leftEntries = Object.entries(left);
+  if (leftEntries.length !== Object.keys(right).length) return false;
+  return leftEntries.every(([key, count]) => right[key] === count);
+}

--- a/admin/backfill-vocabulary-stats.ts
+++ b/admin/backfill-vocabulary-stats.ts
@@ -1,0 +1,62 @@
+import { applicationDefault, cert, getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { ensureAdcQuotaProject } from './allow-user.shared';
+import { rebuildVocabularyStats, verifyVocabularyStats } from './backfill-vocabulary-stats.lib';
+import { parseBackfillVocabularyStatsArgs } from './backfill-vocabulary-stats.shared';
+
+/**
+ * Rebuild every user's cached vocabulary statistics from its source entries.
+ *
+ *   yarn backfill:vocabulary-stats          # goitei-dev, sample 20 users
+ *   yarn backfill:vocabulary-stats prod     # production, sample 20 users
+ *   yarn backfill:vocabulary-stats prod --sample 50
+ *
+ * A missing document is created as zero before its source scan. From that
+ * point every client mutation applies its atomic delta. The subsequent
+ * transaction reads both the source query and stats document before replacing
+ * the counters, so a concurrent delta conflicts and retries instead of being
+ * silently overwritten by an older scan.
+ */
+
+const parsed = parseBackfillVocabularyStatsArgs(process.argv.slice(2));
+
+if (!parsed.ok) {
+  for (const error of parsed.errors) console.error(error);
+  console.error(parsed.usage);
+  process.exit(1);
+}
+
+const { projectId, sampleSize } = parsed;
+
+if (getApps().length === 0) {
+  const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (!key) ensureAdcQuotaProject(process.env, projectId);
+  initializeApp({ credential: key ? cert(key) : applicationDefault(), projectId });
+}
+
+const db = getFirestore();
+const users = await db.collection('users').get();
+const activeUserIds: string[] = [];
+let deleted = 0;
+
+for (const user of users.docs) {
+  const result = await rebuildVocabularyStats(db, user.id);
+  if (result === 'deleted') deleted += 1;
+  else activeUserIds.push(user.id);
+}
+
+const sampledIds = evenlySpacedSample(activeUserIds, sampleSize);
+for (const uid of sampledIds) await verifyVocabularyStats(db, uid);
+
+console.log(
+  `backfilled ${activeUserIds.length} active users on ${projectId}; ` +
+    `removed stale stats for ${deleted} deleted users; verified ${sampledIds.length} sampled users.`,
+);
+
+function evenlySpacedSample(ids: string[], requested: number): string[] {
+  if (ids.length <= requested) return ids;
+  return Array.from(
+    { length: requested },
+    (_, index) => ids[Math.floor((index * ids.length) / requested)],
+  ).filter((uid): uid is string => Boolean(uid));
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -246,6 +246,13 @@ service cloud.firestore {
       ];
     }
 
+    function dashboardStatsFields() {
+      return [
+        'ownerUid', 'total', 'countsByDay', 'jlptCounts', 'posCounts',
+        'updatedAt'
+      ];
+    }
+
     function str(value, max) {
       return value is string && value.size() <= max;
     }
@@ -322,6 +329,20 @@ service cloud.firestore {
         && d.get('usage', {}).size() <= 20
         && (d.get('posInfo', null) == null || d.get('posInfo', {}).size() <= 20)
         && (d.get('copiedFrom', null) == null || d.get('copiedFrom', {}).size() <= 10);
+    }
+
+    function validDashboardStats(uid) {
+      let d = request.resource.data;
+      return ownedBy(uid)
+        && d.keys().hasOnly(dashboardStatsFields())
+        && d.total is int && d.total >= 0 && d.total <= 50000
+        // These maps are client-maintained cached counters. Rules can bound
+        // their shape and size, but cannot prove every delta matches the entry
+        // mutation in the same transaction.
+        && d.get('countsByDay', {}).size() <= 5000
+        && d.get('jlptCounts', {}).size() <= 20
+        && d.get('posCounts', {}).size() <= 50
+        && d.updatedAt is timestamp;
     }
 
     function validUser(uid) {
@@ -434,6 +455,11 @@ service cloud.firestore {
       match /practiceSessions/{sessionId} {
         allow read, delete: if mine();
         allow create, update: if mine() && validSession(uid) && keepsCreatedAt() && notDeleted(uid);
+      }
+
+      match /stats/vocabulary {
+        allow read, delete: if mine();
+        allow create, update: if mine() && validDashboardStats(uid) && notDeleted(uid);
       }
 
       // One document holding every entry's progress — see ProgressRepository

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "auth:login": "CLOUDSDK_CONFIG=.gcloud gcloud auth application-default login",
     "auth:revoke": "CLOUDSDK_CONFIG=.gcloud gcloud auth application-default revoke",
     "allow": "vite-node admin/allow-user.ts --",
+    "backfill:vocabulary-stats": "vite-node admin/backfill-vocabulary-stats.ts --",
     "mint-preview-appcheck-token": "vite-node admin/mint-preview-app-check-token.ts --",
     "icons": "vite-node scripts/icons.ts",
     "fonts": "vite-node scripts/fonts.ts",

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -96,11 +96,12 @@ function AuthenticatedLayout({
 }) {
   const { t } = useI18n();
   const navigate = useNavigate();
+  const location = useLocation();
   const [menuOpen, setMenuOpen] = useState(false);
   const [adding, setAdding] = useState(false);
 
   return (
-    <EntriesProvider uid={uid}>
+    <EntriesProvider key={uid} uid={uid} loadOnMount={location.pathname !== '/'}>
       <ProgressProvider uid={uid}>
         <WordSetsProvider uid={uid}>
           {/* Below the data providers because the dialog reads the notebook

--- a/src/components/VocabDialog.tsx
+++ b/src/components/VocabDialog.tsx
@@ -21,16 +21,14 @@ import { useVocabDialog } from '@/lib/vocabDialog';
  * `bg-card`, so the sections are separated by a border instead of by a card.
  *
  * Editing is here and deleting is not, and the two are not the same call.
- * Both write through `EntriesProvider`, which every screen reads from, so a
- * saved edit reaches the page underneath on the next render rather than leaving
- * it stale. A delete would leave this dialog sitting over a word that no longer
- * exists, showing 「単語が見つかりません」 above the list it was deleted from;
- * that belongs on the detail page, which can navigate away afterwards.
+ * Both write through `EntriesProvider`, so a saved edit invalidates the page
+ * underneath even when that page chose dashboard-sized reads over holding the
+ * whole notebook. A delete would leave this dialog sitting over a word that no
+ * longer exists, showing 「単語が見つかりません」 above the list it was deleted
+ * from; that belongs on the detail page, which can navigate away afterwards.
  *
- * Read out of `EntriesProvider` rather than fetched, because every screen that
- * can open this already holds the whole notebook. A word that is not there is
- * one deleted in another tab, and the dialog says so rather than showing a
- * frame with nothing in it.
+ * Prefer `EntriesProvider` when it holds the whole notebook, and fall back to a
+ * single-entry read for dashboard-sized pages that deliberately do not.
  */
 export function VocabDialog() {
   const { t } = useI18n();
@@ -100,7 +98,22 @@ export function VocabDialog() {
    * reading the entry the save refreshed.
    */
   if (editingId === entry.id) {
-    return <EntryFormModal open entry={entry} onClose={() => setEditingId(null)} />;
+    return (
+      <EntryFormModal
+        open
+        entry={entry}
+        onClose={() => setEditingId(null)}
+        onSaved={(id) => {
+          void repository
+            .get(id)
+            .then((item) => setFetched({ id, entry: item }))
+            .catch((cause: unknown) => {
+              console.error(cause);
+              setFetched({ id, entry: null });
+            });
+        }}
+      />
+    );
   }
 
   return (

--- a/src/components/VocabDialog.tsx
+++ b/src/components/VocabDialog.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { EntryBody } from '@/components/detail/EntryBody';
 import { EntryHeadline } from '@/components/detail/EntryHeadline';
 import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
 import { Modal } from '@/components/Modal';
 import { SpeakButton, SpeechStatusNote } from '@/components/SpeakButton';
+import type { Entry } from '@/domain/entry';
 import { useI18n } from '@/i18n/context';
 import { useEntries } from '@/lib/entries';
 import { spokenForm, useJapaneseSpeech } from '@/lib/speech';
@@ -34,7 +35,8 @@ import { useVocabDialog } from '@/lib/vocabDialog';
 export function VocabDialog() {
   const { t } = useI18n();
   const { openId, close } = useVocabDialog();
-  const { entries } = useEntries();
+  const { entries, repository } = useEntries();
+  const [fetched, setFetched] = useState<{ id: string; entry: Entry | null } | null>(null);
   // Above the early return, because hooks are: this component is mounted for
   // the whole session and renders nothing until a word is asked for.
   const { status: speechStatus, speak } = useJapaneseSpeech();
@@ -47,9 +49,38 @@ export function VocabDialog() {
    * effect having to reset it.
    */
   const [editingId, setEditingId] = useState<string | null>(null);
+  const cached = useMemo(
+    () => entries.find((item) => item.id === openId) ?? null,
+    [entries, openId],
+  );
+  const entry = cached ?? (fetched?.id === openId ? fetched.entry : null);
+
+  useEffect(() => {
+    if (openId === null || cached) return;
+    let cancelled = false;
+    repository
+      .get(openId)
+      .then((item) => {
+        if (!cancelled) setFetched({ id: openId, entry: item });
+      })
+      .catch((cause: unknown) => {
+        console.error(cause);
+        if (!cancelled) setFetched({ id: openId, entry: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cached, openId, repository]);
 
   if (openId === null) return null;
-  const entry = entries.find((item) => item.id === openId);
+
+  if (!entry && fetched?.id !== openId) {
+    return (
+      <Modal open title={t('vocabDialog.title')} onClose={close}>
+        <p className="py-6 text-center text-sm text-muted">{t('vocabulary.loading')}</p>
+      </Modal>
+    );
+  }
 
   if (!entry) {
     return (

--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -36,7 +36,7 @@ export function EntryFormModal({
   onClose: () => void;
   onSaved?: (id: string) => void;
 }) {
-  const { refresh, repository } = useEntries();
+  const { repository, syncAfterMutation } = useEntries();
   const { t } = useI18n();
   const tabs: { id: Tab; label: string }[] = [
     { id: 'simple', label: t('form.simple') },
@@ -170,7 +170,7 @@ export function EntryFormModal({
       const id = entry
         ? (await repository.update(entry.id, draft), entry.id)
         : await repository.create(draft);
-      await refresh();
+      await syncAfterMutation();
       onSaved?.(id);
       onClose();
     } catch (cause) {

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -34,8 +34,21 @@ export interface PageQuery {
   cursor: string | null;
 }
 
+export interface EntryDashboardStats {
+  ownerUid: string;
+  total: number;
+  countsByDay: Record<string, number>;
+  jlptCounts: Record<string, number>;
+  posCounts: Record<string, number>;
+}
+
 export interface EntryRepository {
   list(q: PageQuery): Promise<Page<Entry>>;
+  dashboardStats(): Promise<EntryDashboardStats | null>;
+  countLearnedSince(date: string): Promise<number>;
+  recentLearned(limit: number): Promise<Entry[]>;
+  listLearnedOn(day: string, q: PageQuery): Promise<Page<Entry>>;
+  wordOfDay(seed: string): Promise<Entry | null>;
   get(id: string): Promise<Entry | null>;
   create(draft: EntryDraft): Promise<string>;
   update(id: string, draft: EntryDraft): Promise<void>;

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -53,6 +53,7 @@ export interface EntryRepository {
   create(draft: EntryDraft): Promise<string>;
   update(id: string, draft: EntryDraft): Promise<void>;
   remove(id: string): Promise<void>;
+  removeDashboardStats(): Promise<void>;
   /** Waits until locally accepted writes have either reached durable storage or failed. */
   settlePendingWrites(): Promise<void>;
 }

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -45,6 +45,7 @@ export interface EntryDashboardStats {
 export interface EntryRepository {
   list(q: PageQuery): Promise<Page<Entry>>;
   dashboardStats(): Promise<EntryDashboardStats | null>;
+  saveDashboardStats(stats: Omit<EntryDashboardStats, 'ownerUid'>): Promise<void>;
   countLearnedSince(date: string): Promise<number>;
   recentLearned(limit: number): Promise<Entry[]>;
   listLearnedOn(day: string, q: PageQuery): Promise<Page<Entry>>;

--- a/src/domain/ports.ts
+++ b/src/domain/ports.ts
@@ -45,7 +45,6 @@ export interface EntryDashboardStats {
 export interface EntryRepository {
   list(q: PageQuery): Promise<Page<Entry>>;
   dashboardStats(): Promise<EntryDashboardStats | null>;
-  saveDashboardStats(stats: Omit<EntryDashboardStats, 'ownerUid'>): Promise<void>;
   countLearnedSince(date: string): Promise<number>;
   recentLearned(limit: number): Promise<Entry[]>;
   listLearnedOn(day: string, q: PageQuery): Promise<Page<Entry>>;

--- a/src/infra/firebase/entryRepo.ts
+++ b/src/infra/firebase/entryRepo.ts
@@ -122,6 +122,20 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
       return snapshot.exists() ? statsFrom(snapshot.data()) : null;
     },
 
+    async saveDashboardStats(stats: Omit<EntryDashboardStats, 'ownerUid'>): Promise<void> {
+      const ref = statsPath();
+      await writes.write(ref, () =>
+        setDoc(ref, {
+          ownerUid: uid,
+          total: stats.total,
+          countsByDay: stats.countsByDay,
+          jlptCounts: stats.jlptCounts,
+          posCounts: stats.posCounts,
+          updatedAt: serverTimestamp(),
+        }),
+      );
+    },
+
     async countLearnedSince(date: string): Promise<number> {
       const snapshot = await getCountFromServer(
         query(entriesPath(), where('learnedOn', '>=', date)),
@@ -194,7 +208,7 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
           updatedAt: serverTimestamp(),
         }),
       );
-      void writeStatsDelta(
+      await writeStatsDelta(
         null,
         toEntry(ref.id, { ...draft, createdAt: new Date(), updatedAt: new Date(), ownerUid: uid }),
       );
@@ -216,7 +230,7 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
           updatedAt: serverTimestamp(),
         }),
       );
-      if (before) void writeStatsDelta(before, { ...before, ...draft });
+      if (before) await writeStatsDelta(before, { ...before, ...draft });
     },
 
     async remove(id: string): Promise<void> {
@@ -225,7 +239,7 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
         .then((snapshot) => (snapshot.exists() ? toEntry(snapshot.id, snapshot.data()) : null))
         .catch(() => null);
       await writes.write(ref, () => deleteDoc(ref));
-      if (before) void writeStatsDelta(before, null);
+      if (before) await writeStatsDelta(before, null);
     },
 
     async removeDashboardStats(): Promise<void> {

--- a/src/infra/firebase/entryRepo.ts
+++ b/src/infra/firebase/entryRepo.ts
@@ -6,6 +6,7 @@ import {
   getCountFromServer,
   getDoc,
   getDocs,
+  increment,
   limit as limitTo,
   orderBy,
   query,
@@ -23,7 +24,7 @@ import type { Entry, EntryDraft } from '@/domain/entry';
 import type { EntryDashboardStats, EntryRepository, Page, PageQuery } from '@/domain/ports';
 import { sanitizeEntry } from '@/lib/sanitize';
 import { decodeCursor, encodeCursor } from './cursor';
-import { LocalWriteTracker } from './localWrite';
+import { LocalWriteTracker, waitForLocalWrite } from './localWrite';
 import { withIsoTimestamps } from './mappers';
 
 /**
@@ -58,21 +59,20 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
     posCounts: numberRecord(data.posCounts),
   });
 
-  const updateStats = (stats: EntryDashboardStats, before: Entry | null, after: Entry | null) => {
-    if (before) adjustStats(stats, before, -1);
-    if (after) adjustStats(stats, after, 1);
-  };
-
   const writeStatsDelta = async (before: Entry | null, after: Entry | null) => {
+    const delta = statsDelta(before, after);
+    if (Object.keys(delta).length === 0) return;
     try {
       const ref = statsPath();
       const snapshot = await getDoc(ref);
       if (!snapshot.exists()) return;
-      const stats = statsFrom(snapshot.data());
-      updateStats(stats, before, after);
-      await setDoc(ref, { ...stats, updatedAt: serverTimestamp() });
+      await waitForLocalWrite(ref, () => updateDoc(ref, delta), {
+        onLateRejection: (error) => {
+          if (!isExpectedStatsRejection(error)) console.error(error);
+        },
+      });
     } catch (cause) {
-      if (!isUnavailable(cause)) console.error(cause);
+      if (!isExpectedStatsRejection(cause)) console.error(cause);
     }
   };
 
@@ -194,7 +194,7 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
           updatedAt: serverTimestamp(),
         }),
       );
-      await writeStatsDelta(
+      void writeStatsDelta(
         null,
         toEntry(ref.id, { ...draft, createdAt: new Date(), updatedAt: new Date(), ownerUid: uid }),
       );
@@ -216,7 +216,7 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
           updatedAt: serverTimestamp(),
         }),
       );
-      if (before) await writeStatsDelta(before, { ...before, ...draft });
+      if (before) void writeStatsDelta(before, { ...before, ...draft });
     },
 
     async remove(id: string): Promise<void> {
@@ -225,7 +225,12 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
         .then((snapshot) => (snapshot.exists() ? toEntry(snapshot.id, snapshot.data()) : null))
         .catch(() => null);
       await writes.write(ref, () => deleteDoc(ref));
-      if (before) await writeStatsDelta(before, null);
+      if (before) void writeStatsDelta(before, null);
+    },
+
+    async removeDashboardStats(): Promise<void> {
+      const ref = statsPath();
+      await writes.write(ref, () => deleteDoc(ref));
     },
 
     async settlePendingWrites(): Promise<void> {
@@ -243,22 +248,30 @@ function numberRecord(raw: unknown): Record<string, number> {
   );
 }
 
-function adjust(stats: Record<string, number>, key: string, delta: number) {
-  if (!key) return;
-  const next = (stats[key] ?? 0) + delta;
-  if (next > 0) stats[key] = next;
-  else delete stats[key];
+function statsDelta(before: Entry | null, after: Entry | null): Record<string, unknown> {
+  const delta: Record<string, unknown> = { updatedAt: serverTimestamp() };
+  if (!before && after) delta.total = increment(1);
+  if (before && !after) delta.total = increment(-1);
+  if (before) addEntryDelta(delta, before, -1);
+  if (after) addEntryDelta(delta, after, 1);
+  return delta;
 }
 
-function adjustStats(stats: EntryDashboardStats, entry: Entry, delta: 1 | -1) {
-  stats.total = Math.max(0, stats.total + delta);
-  adjust(stats.countsByDay, entry.learnedOn, delta);
-  adjust(stats.jlptCounts, entry.jlpt, delta);
-  for (const part of entry.pos) adjust(stats.posCounts, part, delta);
+function addEntryDelta(delta: Record<string, unknown>, entry: Entry, by: 1 | -1) {
+  delta[`countsByDay.${entry.learnedOn}`] = increment(by);
+  delta[`jlptCounts.${entry.jlpt}`] = increment(by);
+  for (const part of entry.pos) delta[`posCounts.${part}`] = increment(by);
 }
 
 function isUnavailable(cause: unknown): boolean {
   return (
     typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'unavailable'
+  );
+}
+
+function isExpectedStatsRejection(cause: unknown): boolean {
+  return (
+    isUnavailable(cause) ||
+    (typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'not-found')
   );
 }

--- a/src/infra/firebase/entryRepo.ts
+++ b/src/infra/firebase/entryRepo.ts
@@ -3,6 +3,7 @@ import {
   deleteDoc,
   doc,
   documentId,
+  getCountFromServer,
   getDoc,
   getDocs,
   limit as limitTo,
@@ -10,14 +11,16 @@ import {
   query,
   serverTimestamp,
   startAfter,
+  startAt,
   setDoc,
   Timestamp,
   updateDoc,
   waitForPendingWrites,
+  where,
 } from 'firebase/firestore';
 import type { Firestore } from 'firebase/firestore';
 import type { Entry, EntryDraft } from '@/domain/entry';
-import type { EntryRepository, Page, PageQuery } from '@/domain/ports';
+import type { EntryDashboardStats, EntryRepository, Page, PageQuery } from '@/domain/ports';
 import { sanitizeEntry } from '@/lib/sanitize';
 import { decodeCursor, encodeCursor } from './cursor';
 import { LocalWriteTracker } from './localWrite';
@@ -41,10 +44,37 @@ import { withIsoTimestamps } from './mappers';
  */
 export function createEntryRepository(db: Firestore, uid: string): EntryRepository {
   const entriesPath = () => collection(db, 'users', uid, 'entries');
+  const statsPath = () => doc(db, 'users', uid, 'stats', 'vocabulary');
   const writes = new LocalWriteTracker();
 
   const toEntry = (id: string, data: Record<string, unknown>): Entry =>
     sanitizeEntry(id, withIsoTimestamps(data));
+
+  const statsFrom = (data: Record<string, unknown>): EntryDashboardStats => ({
+    ownerUid: typeof data.ownerUid === 'string' ? data.ownerUid : uid,
+    total: numberRecord({ total: data.total }).total ?? 0,
+    countsByDay: numberRecord(data.countsByDay),
+    jlptCounts: numberRecord(data.jlptCounts),
+    posCounts: numberRecord(data.posCounts),
+  });
+
+  const updateStats = (stats: EntryDashboardStats, before: Entry | null, after: Entry | null) => {
+    if (before) adjustStats(stats, before, -1);
+    if (after) adjustStats(stats, after, 1);
+  };
+
+  const writeStatsDelta = async (before: Entry | null, after: Entry | null) => {
+    try {
+      const ref = statsPath();
+      const snapshot = await getDoc(ref);
+      if (!snapshot.exists()) return;
+      const stats = statsFrom(snapshot.data());
+      updateStats(stats, before, after);
+      await setDoc(ref, { ...stats, updatedAt: serverTimestamp() });
+    } catch (cause) {
+      if (!isUnavailable(cause)) console.error(cause);
+    }
+  };
 
   return {
     async list({ limit, cursor }: PageQuery): Promise<Page<Entry>> {
@@ -87,6 +117,60 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
       };
     },
 
+    async dashboardStats(): Promise<EntryDashboardStats | null> {
+      const snapshot = await getDoc(statsPath());
+      return snapshot.exists() ? statsFrom(snapshot.data()) : null;
+    },
+
+    async countLearnedSince(date: string): Promise<number> {
+      const snapshot = await getCountFromServer(
+        query(entriesPath(), where('learnedOn', '>=', date)),
+      );
+      return snapshot.data().count;
+    },
+
+    async recentLearned(limit: number): Promise<Entry[]> {
+      const snapshot = await getDocs(
+        query(
+          entriesPath(),
+          orderBy('learnedOn', 'desc'),
+          orderBy(documentId(), 'desc'),
+          limitTo(limit),
+        ),
+      );
+      return snapshot.docs.map((d) => toEntry(d.id, d.data()));
+    },
+
+    async listLearnedOn(day, { limit, cursor }: PageQuery): Promise<Page<Entry>> {
+      const constraints = [
+        where('learnedOn', '==', day),
+        orderBy(documentId(), 'desc'),
+        limitTo(limit + 1),
+      ];
+      const snapshot = await getDocs(
+        cursor
+          ? query(entriesPath(), ...constraints, startAfter(cursor))
+          : query(entriesPath(), ...constraints),
+      );
+      const page = snapshot.docs.slice(0, limit);
+      return {
+        items: page.map((d) => toEntry(d.id, d.data())),
+        cursor: snapshot.docs.length > limit ? (page[page.length - 1]?.id ?? null) : null,
+      };
+    },
+
+    async wordOfDay(seed: string): Promise<Entry | null> {
+      const afterSeed = await getDocs(
+        query(entriesPath(), orderBy(documentId()), startAt(seed), limitTo(1)),
+      );
+      const picked = afterSeed.docs[0];
+      if (picked) return toEntry(picked.id, picked.data());
+
+      const first = await getDocs(query(entriesPath(), orderBy(documentId()), limitTo(1)));
+      const wrapped = first.docs[0];
+      return wrapped ? toEntry(wrapped.id, wrapped.data()) : null;
+    },
+
     async get(id: string): Promise<Entry | null> {
       const snapshot = await getDoc(doc(db, 'users', uid, 'entries', id));
       return snapshot.exists() ? toEntry(snapshot.id, snapshot.data()) : null;
@@ -110,6 +194,10 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
           updatedAt: serverTimestamp(),
         }),
       );
+      await writeStatsDelta(
+        null,
+        toEntry(ref.id, { ...draft, createdAt: new Date(), updatedAt: new Date(), ownerUid: uid }),
+      );
       return ref.id;
     },
 
@@ -119,21 +207,58 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
      */
     async update(id: string, draft: EntryDraft): Promise<void> {
       const ref = doc(db, 'users', uid, 'entries', id);
+      const before = await getDoc(ref)
+        .then((snapshot) => (snapshot.exists() ? toEntry(snapshot.id, snapshot.data()) : null))
+        .catch(() => null);
       await writes.write(ref, () =>
         updateDoc(ref, {
           ...draft,
           updatedAt: serverTimestamp(),
         }),
       );
+      if (before) await writeStatsDelta(before, { ...before, ...draft });
     },
 
     async remove(id: string): Promise<void> {
       const ref = doc(db, 'users', uid, 'entries', id);
+      const before = await getDoc(ref)
+        .then((snapshot) => (snapshot.exists() ? toEntry(snapshot.id, snapshot.data()) : null))
+        .catch(() => null);
       await writes.write(ref, () => deleteDoc(ref));
+      if (before) await writeStatsDelta(before, null);
     },
 
     async settlePendingWrites(): Promise<void> {
       await writes.settle(() => waitForPendingWrites(db));
     },
   };
+}
+
+function numberRecord(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(raw)
+      .filter(([, value]) => typeof value === 'number' && Number.isFinite(value) && value > 0)
+      .map(([key, value]) => [key, value as number]),
+  );
+}
+
+function adjust(stats: Record<string, number>, key: string, delta: number) {
+  if (!key) return;
+  const next = (stats[key] ?? 0) + delta;
+  if (next > 0) stats[key] = next;
+  else delete stats[key];
+}
+
+function adjustStats(stats: EntryDashboardStats, entry: Entry, delta: 1 | -1) {
+  stats.total = Math.max(0, stats.total + delta);
+  adjust(stats.countsByDay, entry.learnedOn, delta);
+  adjust(stats.jlptCounts, entry.jlpt, delta);
+  for (const part of entry.pos) adjust(stats.posCounts, part, delta);
+}
+
+function isUnavailable(cause: unknown): boolean {
+  return (
+    typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'unavailable'
+  );
 }

--- a/src/infra/firebase/entryRepo.ts
+++ b/src/infra/firebase/entryRepo.ts
@@ -122,20 +122,6 @@ export function createEntryRepository(db: Firestore, uid: string): EntryReposito
       return snapshot.exists() ? statsFrom(snapshot.data()) : null;
     },
 
-    async saveDashboardStats(stats: Omit<EntryDashboardStats, 'ownerUid'>): Promise<void> {
-      const ref = statsPath();
-      await writes.write(ref, () =>
-        setDoc(ref, {
-          ownerUid: uid,
-          total: stats.total,
-          countsByDay: stats.countsByDay,
-          jlptCounts: stats.jlptCounts,
-          posCounts: stats.posCounts,
-          updatedAt: serverTimestamp(),
-        }),
-      );
-    },
-
     async countLearnedSince(date: string): Promise<number> {
       const snapshot = await getCountFromServer(
         query(entriesPath(), where('learnedOn', '>=', date)),

--- a/src/infra/firebase/entryRepo.ts
+++ b/src/infra/firebase/entryRepo.ts
@@ -249,18 +249,29 @@ function numberRecord(raw: unknown): Record<string, number> {
 }
 
 function statsDelta(before: Entry | null, after: Entry | null): Record<string, unknown> {
-  const delta: Record<string, unknown> = { updatedAt: serverTimestamp() };
-  if (!before && after) delta.total = increment(1);
-  if (before && !after) delta.total = increment(-1);
-  if (before) addEntryDelta(delta, before, -1);
-  if (after) addEntryDelta(delta, after, 1);
-  return delta;
+  const amounts: Record<string, number> = {};
+  if (!before && after) addAmount(amounts, 'total', 1);
+  if (before && !after) addAmount(amounts, 'total', -1);
+  if (before) addEntryDelta(amounts, before, -1);
+  if (after) addEntryDelta(amounts, after, 1);
+
+  const delta = Object.fromEntries(
+    Object.entries(amounts)
+      .filter(([, amount]) => amount !== 0)
+      .map(([path, amount]) => [path, increment(amount)]),
+  );
+  if (Object.keys(delta).length === 0) return {};
+  return { ...delta, updatedAt: serverTimestamp() };
 }
 
-function addEntryDelta(delta: Record<string, unknown>, entry: Entry, by: 1 | -1) {
-  delta[`countsByDay.${entry.learnedOn}`] = increment(by);
-  delta[`jlptCounts.${entry.jlpt}`] = increment(by);
-  for (const part of entry.pos) delta[`posCounts.${part}`] = increment(by);
+function addEntryDelta(amounts: Record<string, number>, entry: Entry, by: 1 | -1) {
+  addAmount(amounts, `countsByDay.${entry.learnedOn}`, by);
+  addAmount(amounts, `jlptCounts.${entry.jlpt}`, by);
+  for (const part of entry.pos) addAmount(amounts, `posCounts.${part}`, by);
+}
+
+function addAmount(amounts: Record<string, number>, path: string, by: number) {
+  amounts[path] = (amounts[path] ?? 0) + by;
 }
 
 function isUnavailable(cause: unknown): boolean {

--- a/src/lib/accountData.ts
+++ b/src/lib/accountData.ts
@@ -235,6 +235,7 @@ export async function deleteEverything({
 
   const entryList = await drain((q) => entries.list(q));
   for (const entry of entryList) await entries.remove(entry.id);
+  await entries.removeDashboardStats();
 
   // The progress map and every session, which the count above does not cover:
   // the map is one document and the sessions are a collection, and neither is

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -460,6 +460,10 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       return Promise.resolve();
     },
 
+    removeDashboardStats(): Promise<void> {
+      return Promise.resolve();
+    },
+
     settlePendingWrites(): Promise<void> {
       return Promise.resolve();
     },

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -387,10 +387,6 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       return Promise.resolve(stats);
     },
 
-    saveDashboardStats(): Promise<void> {
-      return Promise.resolve();
-    },
-
     countLearnedSince(date: string) {
       return Promise.resolve([...store.values()].filter((entry) => entry.learnedOn >= date).length);
     },

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -387,6 +387,10 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       return Promise.resolve(stats);
     },
 
+    saveDashboardStats(): Promise<void> {
+      return Promise.resolve();
+    },
+
     countLearnedSince(date: string) {
       return Promise.resolve([...store.values()].filter((entry) => entry.learnedOn >= date).length);
     },

--- a/src/lib/backend.e2e.ts
+++ b/src/lib/backend.e2e.ts
@@ -371,6 +371,54 @@ export const entryRepositoryFor = (uid: string): EntryRepository => {
       };
     },
 
+    dashboardStats() {
+      const stats = {
+        ownerUid: uid,
+        total: store.size,
+        countsByDay: {} as Record<string, number>,
+        jlptCounts: {} as Record<string, number>,
+        posCounts: {} as Record<string, number>,
+      };
+      for (const entry of store.values()) {
+        stats.countsByDay[entry.learnedOn] = (stats.countsByDay[entry.learnedOn] ?? 0) + 1;
+        stats.jlptCounts[entry.jlpt] = (stats.jlptCounts[entry.jlpt] ?? 0) + 1;
+        for (const part of entry.pos) stats.posCounts[part] = (stats.posCounts[part] ?? 0) + 1;
+      }
+      return Promise.resolve(stats);
+    },
+
+    countLearnedSince(date: string) {
+      return Promise.resolve([...store.values()].filter((entry) => entry.learnedOn >= date).length);
+    },
+
+    recentLearned(limit: number) {
+      return Promise.resolve(
+        [...store.values()]
+          .sort((a, b) => b.learnedOn.localeCompare(a.learnedOn) || b.id.localeCompare(a.id))
+          .slice(0, limit),
+      );
+    },
+
+    listLearnedOn(day: string, { limit, cursor }: PageQuery): Promise<Page<Entry>> {
+      const all = [...store.values()]
+        .filter((entry) => entry.learnedOn === day)
+        .sort((a, b) => b.id.localeCompare(a.id));
+      const start = cursor ? all.findIndex((entry) => entry.id === cursor) + 1 : 0;
+      const items = all.slice(start, start + limit);
+      const more = start + items.length < all.length;
+      return Promise.resolve({
+        items,
+        cursor: more ? (items[items.length - 1]?.id ?? null) : null,
+      });
+    },
+
+    wordOfDay(seed: string) {
+      const all = [...store.values()].sort((a, b) => a.id.localeCompare(b.id));
+      return Promise.resolve(
+        all.find((entry) => entry.id.localeCompare(seed) >= 0) ?? all[0] ?? null,
+      );
+    },
+
     get(id: string): Promise<Entry | null> {
       return Promise.resolve(store.get(id) ?? null);
     },

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -56,9 +56,17 @@ const PAGE_SIZE = 200;
  * is what lets `repository` be non-null, which removes a null branch from
  * every write site.
  */
-export function EntriesProvider({ uid, children }: { uid: string; children: ReactNode }) {
+export function EntriesProvider({
+  uid,
+  loadOnMount = true,
+  children,
+}: {
+  uid: string;
+  loadOnMount?: boolean;
+  children: ReactNode;
+}) {
   const [entries, setEntries] = useState<Entry[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(loadOnMount);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   // Rebuilt when the signed-in user changes, so the `users/{uid}` path baked
@@ -119,9 +127,10 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
   }, [repository]);
 
   useEffect(() => {
+    if (!loadOnMount) return;
     setLoading(true);
     void refresh();
-  }, [refresh]);
+  }, [loadOnMount, refresh]);
 
   /**
    * Denial does not belong here: signing back in is what clears it, not the

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -20,6 +20,8 @@ interface EntriesValue {
   loading: boolean;
   error: LoadFailure | null;
   refresh: () => Promise<void>;
+  syncAfterMutation: () => Promise<void>;
+  mutationVersion: number;
   /**
    * Exposed so the form and the detail page write through the same instance the
    * list was read from, instead of each building their own. It is the only
@@ -68,6 +70,7 @@ export function EntriesProvider({
   const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(loadOnMount);
   const [error, setError] = useState<LoadFailure | null>(null);
+  const [mutationVersion, setMutationVersion] = useState(0);
 
   // Rebuilt when the signed-in user changes, so the `users/{uid}` path baked
   // into the repository can never outlive the session it belongs to.
@@ -126,6 +129,11 @@ export function EntriesProvider({
     }
   }, [repository]);
 
+  const syncAfterMutation = useCallback(async () => {
+    if (loadOnMount) await refresh();
+    setMutationVersion((version) => version + 1);
+  }, [loadOnMount, refresh]);
+
   useEffect(() => {
     if (!loadOnMount) return;
     setLoading(true);
@@ -139,8 +147,8 @@ export function EntriesProvider({
   useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
 
   const value = useMemo(
-    () => ({ entries, loading, error, refresh, repository }),
-    [entries, loading, error, refresh, repository],
+    () => ({ entries, loading, error, refresh, syncAfterMutation, mutationVersion, repository }),
+    [entries, loading, error, refresh, syncAfterMutation, mutationVersion, repository],
   );
   return <EntriesContext.Provider value={value}>{children}</EntriesContext.Provider>;
 }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,5 +1,6 @@
 import { JLPT_LEVELS } from '@/domain/entry';
 import type { Entry } from '@/domain/entry';
+import type { EntryDashboardStats } from '@/domain/ports';
 import { parseLocalDate, startOfISOWeek, startOfMonth, startOfYear } from './dates';
 
 /**
@@ -26,6 +27,12 @@ export interface Summary {
   jlptRows: DistributionRow[];
   /** Descending by count, since there is no natural order over 品詞. */
   posRows: DistributionRow[];
+}
+
+export interface PeriodCounts {
+  inWeek: number;
+  inMonth: number;
+  inYear: number;
 }
 
 export function summarise(entries: Entry[], now: Date): Summary {
@@ -63,6 +70,28 @@ export function summarise(entries: Entry[], now: Date): Summary {
       count: jlpt.get(level) ?? 0,
     })),
     posRows: [...pos.entries()]
+      .map(([label, count]) => ({ label, count }))
+      .sort((a, b) => b.count - a.count),
+  };
+}
+
+export function summaryFromDashboardStats(
+  stats: EntryDashboardStats,
+  periods: PeriodCounts,
+): Summary {
+  return {
+    countsByDay: new Map(
+      Object.entries(stats.countsByDay).filter(([, count]) => Number.isFinite(count) && count > 0),
+    ),
+    inWeek: periods.inWeek,
+    inMonth: periods.inMonth,
+    inYear: periods.inYear,
+    jlptRows: JLPT_LEVELS.map((level) => ({
+      label: level,
+      count: stats.jlptCounts[level] ?? 0,
+    })).filter((row) => row.count > 0),
+    posRows: Object.entries(stats.posCounts)
+      .filter(([, count]) => Number.isFinite(count) && count > 0)
       .map(([label, count]) => ({ label, count }))
       .sort((a, b) => b.count - a.count),
   };

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,7 +1,7 @@
 import { JLPT_LEVELS } from '@/domain/entry';
 import type { Entry } from '@/domain/entry';
 import type { EntryDashboardStats } from '@/domain/ports';
-import { parseLocalDate, startOfISOWeek, startOfMonth, startOfYear } from './dates';
+import { dateKey, parseLocalDate, startOfISOWeek, startOfMonth, startOfYear } from './dates';
 
 /**
  * The dashboard's aggregation, lifted out of the route so it can be tested
@@ -27,12 +27,6 @@ export interface Summary {
   jlptRows: DistributionRow[];
   /** Descending by count, since there is no natural order over 品詞. */
   posRows: DistributionRow[];
-}
-
-export interface PeriodCounts {
-  inWeek: number;
-  inMonth: number;
-  inYear: number;
 }
 
 export function summarise(entries: Entry[], now: Date): Summary {
@@ -75,14 +69,13 @@ export function summarise(entries: Entry[], now: Date): Summary {
   };
 }
 
-export function summaryFromDashboardStats(
-  stats: EntryDashboardStats,
-  periods: PeriodCounts,
-): Summary {
+export function summaryFromDashboardStats(stats: EntryDashboardStats, now: Date): Summary {
+  const countsByDay = new Map(
+    Object.entries(stats.countsByDay).filter(([, count]) => Number.isFinite(count) && count > 0),
+  );
+  const periods = periodCountsFromDays(countsByDay, now);
   return {
-    countsByDay: new Map(
-      Object.entries(stats.countsByDay).filter(([, count]) => Number.isFinite(count) && count > 0),
-    ),
+    countsByDay,
     inWeek: periods.inWeek,
     inMonth: periods.inMonth,
     inYear: periods.inYear,
@@ -95,4 +88,33 @@ export function summaryFromDashboardStats(
       .map(([label, count]) => ({ label, count }))
       .sort((a, b) => b.count - a.count),
   };
+}
+
+export function dashboardStatsFromSummary(
+  summary: Summary,
+  total: number,
+): Omit<EntryDashboardStats, 'ownerUid'> {
+  return {
+    total,
+    countsByDay: Object.fromEntries(summary.countsByDay),
+    jlptCounts: Object.fromEntries(summary.jlptRows.map((row) => [row.label, row.count])),
+    posCounts: Object.fromEntries(summary.posRows.map((row) => [row.label, row.count])),
+  };
+}
+
+function periodCountsFromDays(countsByDay: Map<string, number>, now: Date) {
+  const weekStart = dateKey(startOfISOWeek(now));
+  const monthStart = dateKey(startOfMonth(now));
+  const yearStart = dateKey(startOfYear(now));
+  let inWeek = 0;
+  let inMonth = 0;
+  let inYear = 0;
+
+  for (const [day, count] of countsByDay) {
+    if (day >= weekStart) inWeek += count;
+    if (day >= monthStart) inMonth += count;
+    if (day >= yearStart) inYear += count;
+  }
+
+  return { inWeek, inMonth, inYear };
 }

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -11,13 +11,13 @@ import type { PracticeMode, PracticeSession } from '@/domain/practice';
 import { useI18n } from '@/i18n/context';
 import { useEntryLabel } from '@/i18n/useEntryLabel';
 import { useLoadErrorMessage } from '@/i18n/useLoadErrorMessage';
-import { dateKey, startOfISOWeek, startOfMonth, startOfYear } from '@/lib/dates';
+import { dateKey } from '@/lib/dates';
 import { useEntries } from '@/lib/entries';
 import { latestByMode, RECENT_WINDOW } from '@/lib/history';
 import { captureLoadFailure } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
 import { useProgress } from '@/lib/progress';
-import { summarise, summaryFromDashboardStats } from '@/lib/stats';
+import { dashboardStatsFromSummary, summarise, summaryFromDashboardStats } from '@/lib/stats';
 import type { Summary } from '@/lib/stats';
 
 const ENTRY_PAGE_SIZE = 200;
@@ -79,11 +79,8 @@ export function Component() {
       setLoading(true);
       const now = new Date();
       try {
-        const [storedStats, inWeek, inMonth, inYear, recent, wordOfDay] = await Promise.all([
+        const [storedStats, recent, wordOfDay] = await Promise.all([
           entriesRepository.dashboardStats(),
-          entriesRepository.countLearnedSince(dateKey(startOfISOWeek(now))),
-          entriesRepository.countLearnedSince(dateKey(startOfMonth(now))),
-          entriesRepository.countLearnedSince(dateKey(startOfYear(now))),
           entriesRepository.recentLearned(RECENT_WORDS),
           entriesRepository.wordOfDay(wordOfDaySeed(dateKey(now))),
         ]);
@@ -91,7 +88,7 @@ export function Component() {
         if (cancelled) return;
         if (storedStats) {
           setDashboard({
-            stats: summaryFromDashboardStats(storedStats, { inWeek, inMonth, inYear }),
+            stats: summaryFromDashboardStats(storedStats, now),
             recent,
             wordOfDay,
           });
@@ -102,6 +99,8 @@ export function Component() {
         const all = await drainEntries(entriesRepository);
         if (cancelled) return;
         const stats = summarise(all, now);
+        await entriesRepository.saveDashboardStats(dashboardStatsFromSummary(stats, all.length));
+        if (cancelled) return;
         const fallbackRecent = [...all]
           .sort((a, b) => b.learnedOn.localeCompare(a.learnedOn))
           .slice(0, RECENT_WORDS);

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -17,7 +17,7 @@ import { latestByMode, RECENT_WINDOW } from '@/lib/history';
 import { captureLoadFailure } from '@/lib/loadError';
 import type { LoadFailure } from '@/lib/loadError';
 import { useProgress } from '@/lib/progress';
-import { dashboardStatsFromSummary, summarise, summaryFromDashboardStats } from '@/lib/stats';
+import { summarise, summaryFromDashboardStats } from '@/lib/stats';
 import type { Summary } from '@/lib/stats';
 
 const ENTRY_PAGE_SIZE = 200;
@@ -96,11 +96,12 @@ export function Component() {
           return;
         }
 
+        // The Admin SDK migration owns cache bootstrap. A client may read this
+        // fallback, but must never publish a full snapshot that races another
+        // device's entry mutation.
         const all = await drainEntries(entriesRepository);
         if (cancelled) return;
         const stats = summarise(all, now);
-        await entriesRepository.saveDashboardStats(dashboardStatsFromSummary(stats, all.length));
-        if (cancelled) return;
         const fallbackRecent = [...all]
           .sort((a, b) => b.learnedOn.localeCompare(a.learnedOn))
           .slice(0, RECENT_WORDS);

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -5,23 +5,43 @@ import { Heatmap } from '@/components/dashboard/Heatmap';
 import { RecentPractice } from '@/components/dashboard/RecentPractice';
 import { StatTiles } from '@/components/dashboard/StatTiles';
 import { TodayWord, pickWordOfDay } from '@/components/dashboard/TodayWord';
+import type { Entry } from '@/domain/entry';
+import type { EntryRepository } from '@/domain/ports';
 import type { PracticeMode, PracticeSession } from '@/domain/practice';
 import { useI18n } from '@/i18n/context';
 import { useEntryLabel } from '@/i18n/useEntryLabel';
 import { useLoadErrorMessage } from '@/i18n/useLoadErrorMessage';
-import { dateKey } from '@/lib/dates';
+import { dateKey, startOfISOWeek, startOfMonth, startOfYear } from '@/lib/dates';
 import { useEntries } from '@/lib/entries';
 import { latestByMode, RECENT_WINDOW } from '@/lib/history';
+import { captureLoadFailure } from '@/lib/loadError';
+import type { LoadFailure } from '@/lib/loadError';
 import { useProgress } from '@/lib/progress';
-import { summarise } from '@/lib/stats';
+import { summarise, summaryFromDashboardStats } from '@/lib/stats';
+import type { Summary } from '@/lib/stats';
+
+const ENTRY_PAGE_SIZE = 200;
+const RECENT_WORDS = 8;
+const SELECTED_DAY_PAGE_SIZE = 50;
 
 export function Component() {
   const { locale, t } = useI18n();
   const entryLabel = useEntryLabel();
-  const { entries, loading, error } = useEntries();
+  const { repository: entriesRepository } = useEntries();
+  const [dashboard, setDashboard] = useState<{
+    stats: Summary;
+    recent: Entry[];
+    wordOfDay: Entry | null;
+  } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<LoadFailure | null>(null);
   const errorMessage = useLoadErrorMessage(error);
-  const { repository } = useProgress();
+  const { repository: progressRepository } = useProgress();
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  const [selectedEntries, setSelectedEntries] = useState<{
+    day: string;
+    entries: Entry[];
+  } | null>(null);
 
   /**
    * The newest session of each mode, or nulls while it is being read.
@@ -39,7 +59,7 @@ export function Component() {
 
   useEffect(() => {
     let cancelled = false;
-    repository
+    progressRepository
       .listSessions({ limit: RECENT_WINDOW, cursor: null })
       .then((page) => {
         if (!cancelled) setLatest(latestByMode(page.items));
@@ -50,19 +70,96 @@ export function Component() {
     return () => {
       cancelled = true;
     };
-  }, [repository]);
+  }, [progressRepository]);
 
-  const stats = useMemo(() => summarise(entries, new Date()), [entries]);
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      const now = new Date();
+      try {
+        const [storedStats, inWeek, inMonth, inYear, recent, wordOfDay] = await Promise.all([
+          entriesRepository.dashboardStats(),
+          entriesRepository.countLearnedSince(dateKey(startOfISOWeek(now))),
+          entriesRepository.countLearnedSince(dateKey(startOfMonth(now))),
+          entriesRepository.countLearnedSince(dateKey(startOfYear(now))),
+          entriesRepository.recentLearned(RECENT_WORDS),
+          entriesRepository.wordOfDay(wordOfDaySeed(dateKey(now))),
+        ]);
 
-  const recent = useMemo(() => {
-    const sorted = [...entries].sort((a, b) => b.learnedOn.localeCompare(a.learnedOn));
-    return selectedDay ? sorted.filter((e) => e.learnedOn === selectedDay) : sorted.slice(0, 8);
-  }, [entries, selectedDay]);
+        if (cancelled) return;
+        if (storedStats) {
+          setDashboard({
+            stats: summaryFromDashboardStats(storedStats, { inWeek, inMonth, inYear }),
+            recent,
+            wordOfDay,
+          });
+          setError(null);
+          return;
+        }
 
-  const wordOfDay = useMemo(() => pickWordOfDay(entries, dateKey(new Date())), [entries]);
+        const all = await drainEntries(entriesRepository);
+        if (cancelled) return;
+        const stats = summarise(all, now);
+        const fallbackRecent = [...all]
+          .sort((a, b) => b.learnedOn.localeCompare(a.learnedOn))
+          .slice(0, RECENT_WORDS);
+        setDashboard({
+          stats,
+          recent: fallbackRecent,
+          wordOfDay: pickWordOfDay(all, dateKey(now)),
+        });
+        setError(null);
+      } catch (cause) {
+        console.error(cause);
+        if (!cancelled) setError(captureLoadFailure(cause, 'load.entries'));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [entriesRepository]);
+
+  useEffect(() => {
+    if (!selectedDay) return;
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const page = await entriesRepository.listLearnedOn(selectedDay, {
+          limit: SELECTED_DAY_PAGE_SIZE,
+          cursor: null,
+        });
+        if (!cancelled) setSelectedEntries({ day: selectedDay, entries: page.items });
+      } catch (cause) {
+        console.error(cause);
+        if (!cancelled) setError(captureLoadFailure(cause, 'load.entries'));
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [entriesRepository, selectedDay]);
+
+  const stats = dashboard?.stats;
+  const recent = useMemo(
+    () =>
+      selectedDay
+        ? selectedEntries?.day === selectedDay
+          ? selectedEntries.entries
+          : []
+        : (dashboard?.recent ?? []),
+    [dashboard?.recent, selectedDay, selectedEntries],
+  );
+  const wordOfDay = dashboard?.wordOfDay ?? null;
 
   if (loading) return <p className="py-16 text-center text-sm text-muted">{t('common.loading')}</p>;
   if (errorMessage) return <p className="py-16 text-center text-sm text-danger">{errorMessage}</p>;
+  if (!stats) return <p className="py-16 text-center text-sm text-muted">{t('common.loading')}</p>;
 
   return (
     <div className="space-y-4">
@@ -77,7 +174,9 @@ export function Component() {
 
       <div className="grid gap-4 sm:grid-cols-2">
         <Distribution
-          title={t('dashboard.jlpt', { count: entries.length })}
+          title={t('dashboard.jlpt', {
+            count: stats.jlptRows.reduce((sum, row) => sum + row.count, 0),
+          })}
           rows={stats.jlptRows}
         />
         <Distribution
@@ -120,4 +219,21 @@ export function Component() {
       </section>
     </div>
   );
+}
+
+async function drainEntries(repository: EntryRepository): Promise<Entry[]> {
+  const all: Entry[] = [];
+  let cursor: string | null = null;
+  do {
+    const page = await repository.list({ limit: ENTRY_PAGE_SIZE, cursor });
+    all.push(...page.items);
+    cursor = page.cursor;
+  } while (cursor);
+  return all;
+}
+
+function wordOfDaySeed(todayKey: string) {
+  let hash = 0;
+  for (const char of todayKey) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  return hash.toString(36).padStart(20, '0').slice(0, 20);
 }

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -23,6 +23,7 @@ import type { Summary } from '@/lib/stats';
 const ENTRY_PAGE_SIZE = 200;
 const RECENT_WORDS = 8;
 const SELECTED_DAY_PAGE_SIZE = 50;
+const AUTO_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
 export function Component() {
   const { locale, t } = useI18n();
@@ -129,11 +130,8 @@ export function Component() {
     let cancelled = false;
     const load = async () => {
       try {
-        const page = await entriesRepository.listLearnedOn(selectedDay, {
-          limit: SELECTED_DAY_PAGE_SIZE,
-          cursor: null,
-        });
-        if (!cancelled) setSelectedEntries({ day: selectedDay, entries: page.items });
+        const entries = await drainLearnedOn(entriesRepository, selectedDay);
+        if (!cancelled) setSelectedEntries({ day: selectedDay, entries });
       } catch (cause) {
         console.error(cause);
         if (!cancelled) setError(captureLoadFailure(cause, 'load.entries'));
@@ -232,8 +230,28 @@ async function drainEntries(repository: EntryRepository): Promise<Entry[]> {
   return all;
 }
 
+async function drainLearnedOn(repository: EntryRepository, day: string): Promise<Entry[]> {
+  const all: Entry[] = [];
+  let cursor: string | null = null;
+  do {
+    const page = await repository.listLearnedOn(day, {
+      limit: SELECTED_DAY_PAGE_SIZE,
+      cursor,
+    });
+    all.push(...page.items);
+    cursor = page.cursor;
+  } while (cursor);
+  return all;
+}
+
 function wordOfDaySeed(todayKey: string) {
   let hash = 0;
   for (const char of todayKey) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
-  return hash.toString(36).padStart(20, '0').slice(0, 20);
+  let state = hash || 1;
+  let seed = '';
+  for (let i = 0; i < 20; i += 1) {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    seed += AUTO_ID_ALPHABET[state % AUTO_ID_ALPHABET.length];
+  }
+  return seed;
 }

--- a/src/routes/Dashboard.tsx
+++ b/src/routes/Dashboard.tsx
@@ -28,7 +28,7 @@ const AUTO_ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01
 export function Component() {
   const { locale, t } = useI18n();
   const entryLabel = useEntryLabel();
-  const { repository: entriesRepository } = useEntries();
+  const { mutationVersion, repository: entriesRepository } = useEntries();
   const [dashboard, setDashboard] = useState<{
     stats: Summary;
     recent: Entry[];
@@ -123,7 +123,7 @@ export function Component() {
     return () => {
       cancelled = true;
     };
-  }, [entriesRepository]);
+  }, [entriesRepository, mutationVersion]);
 
   useEffect(() => {
     if (!selectedDay) return;
@@ -141,7 +141,7 @@ export function Component() {
     return () => {
       cancelled = true;
     };
-  }, [entriesRepository, selectedDay]);
+  }, [entriesRepository, mutationVersion, selectedDay]);
 
   const stats = dashboard?.stats;
   const recent = useMemo(

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -4,6 +4,7 @@ import type { FirebaseApp } from 'firebase/app';
 import {
   connectFirestoreEmulator,
   doc,
+  getDoc,
   getFirestore,
   setDoc,
   Timestamp,
@@ -253,6 +254,77 @@ describe('list — pagination', () => {
     } while (cursor);
 
     expect(new Set(seen).size).toBe(ids.length);
+  });
+});
+
+describe('dashboard reads', () => {
+  it('counts learned dates from Firestore without reading every entry document', async () => {
+    const repo = freshRepo();
+    await repo.create(draft({ headword: '今週', learnedOn: '2026-06-24' }));
+    await repo.create(draft({ headword: '先月', learnedOn: '2026-05-31' }));
+
+    expect(await repo.countLearnedSince('2026-06-01')).toBe(1);
+    expect(await repo.countLearnedSince('2026-01-01')).toBe(2);
+  });
+
+  it('returns the recent learned words without walking the whole notebook', async () => {
+    const repo = freshRepo();
+    await repo.create(draft({ headword: '古い', learnedOn: '2026-01-01' }));
+    await repo.create(draft({ headword: '新しい', learnedOn: '2026-06-24' }));
+    await repo.create(draft({ headword: '中間', learnedOn: '2026-03-15' }));
+
+    const recent = await repo.recentLearned(2);
+
+    expect(recent.map((entry) => entry.headword)).toEqual(['新しい', '中間']);
+  });
+
+  it('pages the selected heatmap day instead of filtering a full notebook in memory', async () => {
+    const repo = freshRepo();
+    await repo.create(draft({ headword: '一', learnedOn: '2026-06-24' }));
+    await repo.create(draft({ headword: '二', learnedOn: '2026-06-24' }));
+    await repo.create(draft({ headword: '三', learnedOn: '2026-06-24' }));
+    await repo.create(draft({ headword: '別日', learnedOn: '2026-06-23' }));
+
+    const first = await repo.listLearnedOn('2026-06-24', { limit: 2, cursor: null });
+    const second = await repo.listLearnedOn('2026-06-24', { limit: 2, cursor: first.cursor });
+
+    expect(first.items).toHaveLength(2);
+    expect(second.items).toHaveLength(1);
+    expect([...first.items, ...second.items].map((entry) => entry.learnedOn)).toEqual([
+      '2026-06-24',
+      '2026-06-24',
+      '2026-06-24',
+    ]);
+  });
+
+  it('returns null dashboard stats until the post-deploy backfill has written them', async () => {
+    expect(await freshRepo().dashboardStats()).toBeNull();
+  });
+
+  it('updates the dashboard stats document on writes after backfill has created it', async () => {
+    const uid = `it-stats-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+    const statsRef = doc(db, 'users', uid, 'stats', 'vocabulary');
+    await setDoc(statsRef, {
+      ownerUid: uid,
+      total: 0,
+      countsByDay: {},
+      jlptCounts: {},
+      posCounts: {},
+      updatedAt: Timestamp.fromDate(new Date('2026-06-24T09:00:00.000Z')),
+    });
+
+    const id = await repo.create(
+      draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] }),
+    );
+    await repo.update(id, draft({ learnedOn: '2026-06-25', jlpt: 'N1', pos: ['副詞'] }));
+    await repo.remove(id);
+
+    const stats = (await getDoc(statsRef)).data();
+    expect(stats?.total).toBe(0);
+    expect(stats?.countsByDay).toEqual({});
+    expect(stats?.jlptCounts).toEqual({});
+    expect(stats?.posCounts).toEqual({});
   });
 });
 

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -300,6 +300,27 @@ describe('dashboard reads', () => {
     expect(await freshRepo().dashboardStats()).toBeNull();
   });
 
+  it('bootstraps a complete dashboard stats document from a fallback summary', async () => {
+    const uid = `it-stats-bootstrap-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+
+    await repo.saveDashboardStats({
+      total: 2,
+      countsByDay: { '2026-06-24': 1, '2026-06-23': 1 },
+      jlptCounts: { N2: 1, N3: 1 },
+      posCounts: { 名詞: 1, 動詞: 1 },
+    });
+
+    const stats = await repo.dashboardStats();
+    expect(stats).toEqual({
+      ownerUid: uid,
+      total: 2,
+      countsByDay: { '2026-06-24': 1, '2026-06-23': 1 },
+      jlptCounts: { N2: 1, N3: 1 },
+      posCounts: { 名詞: 1, 動詞: 1 },
+    });
+  });
+
   it('updates the dashboard stats document on writes after backfill has created it', async () => {
     const uid = `it-stats-${randomUUID()}`;
     const repo = createEntryRepository(db, uid);
@@ -316,35 +337,29 @@ describe('dashboard reads', () => {
     const id = await repo.create(
       draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] }),
     );
-    await expect
-      .poll(() => repo.dashboardStats())
-      .toMatchObject({
-        total: 1,
-        countsByDay: { '2026-06-24': 1 },
-        jlptCounts: { N2: 1 },
-        posCounts: { 名詞: 1, 動詞: 1 },
-      });
+    expect(await repo.dashboardStats()).toMatchObject({
+      total: 1,
+      countsByDay: { '2026-06-24': 1 },
+      jlptCounts: { N2: 1 },
+      posCounts: { 名詞: 1, 動詞: 1 },
+    });
 
     await repo.update(id, draft({ learnedOn: '2026-06-25', jlpt: 'N1', pos: ['副詞'] }));
-    await expect
-      .poll(() => repo.dashboardStats())
-      .toMatchObject({
-        total: 1,
-        countsByDay: { '2026-06-25': 1 },
-        jlptCounts: { N1: 1 },
-        posCounts: { 副詞: 1 },
-      });
+    expect(await repo.dashboardStats()).toMatchObject({
+      total: 1,
+      countsByDay: { '2026-06-25': 1 },
+      jlptCounts: { N1: 1 },
+      posCounts: { 副詞: 1 },
+    });
 
     await repo.remove(id);
 
-    await expect
-      .poll(() => repo.dashboardStats())
-      .toMatchObject({
-        total: 0,
-        countsByDay: {},
-        jlptCounts: {},
-        posCounts: {},
-      });
+    expect(await repo.dashboardStats()).toMatchObject({
+      total: 0,
+      countsByDay: {},
+      jlptCounts: {},
+      posCounts: {},
+    });
   });
 
   it('does not leave inflated dashboard stats after a non-counter edit is followed by a date move', async () => {

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -4,7 +4,6 @@ import type { FirebaseApp } from 'firebase/app';
 import {
   connectFirestoreEmulator,
   doc,
-  getDoc,
   getFirestore,
   setDoc,
   Timestamp,
@@ -317,14 +316,52 @@ describe('dashboard reads', () => {
     const id = await repo.create(
       draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] }),
     );
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toMatchObject({
+        total: 1,
+        countsByDay: { '2026-06-24': 1 },
+        jlptCounts: { N2: 1 },
+        posCounts: { 名詞: 1, 動詞: 1 },
+      });
+
     await repo.update(id, draft({ learnedOn: '2026-06-25', jlpt: 'N1', pos: ['副詞'] }));
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toMatchObject({
+        total: 1,
+        countsByDay: { '2026-06-25': 1 },
+        jlptCounts: { N1: 1 },
+        posCounts: { 副詞: 1 },
+      });
+
     await repo.remove(id);
 
-    const stats = (await getDoc(statsRef)).data();
-    expect(stats?.total).toBe(0);
-    expect(stats?.countsByDay).toEqual({});
-    expect(stats?.jlptCounts).toEqual({});
-    expect(stats?.posCounts).toEqual({});
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toMatchObject({
+        total: 0,
+        countsByDay: {},
+        jlptCounts: {},
+        posCounts: {},
+      });
+  });
+
+  it('removes dashboard stats explicitly because account deletion cannot rely on cascades', async () => {
+    const uid = `it-stats-delete-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+    await setDoc(doc(db, 'users', uid, 'stats', 'vocabulary'), {
+      ownerUid: uid,
+      total: 1,
+      countsByDay: { '2026-06-24': 1 },
+      jlptCounts: { N2: 1 },
+      posCounts: { 名詞: 1 },
+      updatedAt: Timestamp.fromDate(new Date('2026-06-24T09:00:00.000Z')),
+    });
+
+    await repo.removeDashboardStats();
+
+    expect(await repo.dashboardStats()).toBeNull();
   });
 });
 

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -1,4 +1,11 @@
 import { randomUUID } from 'node:crypto';
+import {
+  deleteApp as deleteAdminApp,
+  initializeApp as initializeAdminApp,
+} from 'firebase-admin/app';
+import type { App as AdminApp } from 'firebase-admin/app';
+import { getFirestore as getAdminFirestore } from 'firebase-admin/firestore';
+import type { Firestore as AdminFirestore } from 'firebase-admin/firestore';
 import { deleteApp, initializeApp } from 'firebase/app';
 import type { FirebaseApp } from 'firebase/app';
 import {
@@ -15,6 +22,10 @@ import type { EntryDraft } from '@/domain/entry';
 import type { EntryRepository } from '@/domain/ports';
 import { createEntryRepository } from '@/infra/firebase/entryRepo';
 import { emptyDraft } from '@/lib/draft';
+import {
+  rebuildVocabularyStats,
+  verifyVocabularyStats,
+} from '../../admin/backfill-vocabulary-stats.lib';
 
 /**
  * The Firestore adapter, run against a real Firestore.
@@ -45,6 +56,8 @@ import { emptyDraft } from '@/lib/draft';
 
 let app: FirebaseApp;
 let db: Firestore;
+let adminApp: AdminApp;
+let adminDb: AdminFirestore;
 
 /** A distinct `users/{uid}/entries` per test, so no cleanup is needed. */
 const freshRepo = (): EntryRepository => createEntryRepository(db, `it-${randomUUID()}`);
@@ -64,15 +77,18 @@ async function seed(repo: EntryRepository, headwords: string[]): Promise<string[
 }
 
 beforeAll(() => {
+  process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
   app = initializeApp({ projectId: 'demo-goitei' }, `entryRepo-${randomUUID()}`);
   db = getFirestore(app);
   // Plain getFirestore, not the app's initializeFirestore: the persistent cache
   // the real client uses is IndexedDB-backed and has nothing to run on here.
   connectFirestoreEmulator(db, '127.0.0.1', 8080, { mockUserToken: 'owner' });
+  adminApp = initializeAdminApp({ projectId: 'demo-goitei' }, `entryRepo-admin-${randomUUID()}`);
+  adminDb = getAdminFirestore(adminApp);
 });
 
 afterAll(async () => {
-  await deleteApp(app);
+  await Promise.all([deleteApp(app), deleteAdminApp(adminApp)]);
 });
 
 describe('create and read back', () => {
@@ -300,25 +316,26 @@ describe('dashboard reads', () => {
     expect(await freshRepo().dashboardStats()).toBeNull();
   });
 
-  it('bootstraps a complete dashboard stats document from a fallback summary', async () => {
-    const uid = `it-stats-bootstrap-${randomUUID()}`;
+  it('backfills a missing cache without dropping an entry created after the source scan begins', async () => {
+    const uid = `it-stats-concurrent-bootstrap-${randomUUID()}`;
     const repo = createEntryRepository(db, uid);
+    await repo.create(draft({ learnedOn: '2026-06-23', jlpt: 'N3', pos: ['名詞'] }));
 
-    await repo.saveDashboardStats({
-      total: 2,
-      countsByDay: { '2026-06-24': 1, '2026-06-23': 1 },
-      jlptCounts: { N2: 1, N3: 1 },
-      posCounts: { 名詞: 1, 動詞: 1 },
+    await rebuildVocabularyStats(adminDb, uid, {
+      onSourceRead: async () => {
+        await repo.create(draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['動詞'] }));
+      },
     });
 
-    const stats = await repo.dashboardStats();
-    expect(stats).toEqual({
+    await repo.settlePendingWrites();
+    expect(await repo.dashboardStats()).toEqual({
       ownerUid: uid,
       total: 2,
-      countsByDay: { '2026-06-24': 1, '2026-06-23': 1 },
-      jlptCounts: { N2: 1, N3: 1 },
+      countsByDay: { '2026-06-23': 1, '2026-06-24': 1 },
+      jlptCounts: { N3: 1, N2: 1 },
       posCounts: { 名詞: 1, 動詞: 1 },
     });
+    await expect(verifyVocabularyStats(adminDb, uid)).resolves.toBeUndefined();
   });
 
   it('updates the dashboard stats document on writes after backfill has created it', async () => {

--- a/tests/integration/entryRepo.test.ts
+++ b/tests/integration/entryRepo.test.ts
@@ -347,6 +347,99 @@ describe('dashboard reads', () => {
       });
   });
 
+  it('does not leave inflated dashboard stats after a non-counter edit is followed by a date move', async () => {
+    const uid = `it-stats-stable-edit-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+    await setDoc(doc(db, 'users', uid, 'stats', 'vocabulary'), {
+      ownerUid: uid,
+      total: 0,
+      countsByDay: {},
+      jlptCounts: {},
+      posCounts: {},
+      updatedAt: Timestamp.fromDate(new Date('2026-06-24T09:00:00.000Z')),
+    });
+    const id = await repo.create(
+      draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] }),
+    );
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toMatchObject({
+        total: 1,
+        countsByDay: { '2026-06-24': 1 },
+        jlptCounts: { N2: 1 },
+        posCounts: { 名詞: 1, 動詞: 1 },
+      });
+
+    await repo.update(
+      id,
+      draft({
+        headword: '前兆',
+        learnedOn: '2026-06-24',
+        jlpt: 'N2',
+        pos: ['名詞', '動詞'],
+      }),
+    );
+    await repo.update(
+      id,
+      draft({
+        headword: '前兆',
+        learnedOn: '2026-06-25',
+        jlpt: 'N2',
+        pos: ['名詞', '動詞'],
+      }),
+    );
+
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toEqual({
+        ownerUid: uid,
+        total: 1,
+        countsByDay: { '2026-06-25': 1 },
+        jlptCounts: { N2: 1 },
+        posCounts: { 名詞: 1, 動詞: 1 },
+      });
+  });
+
+  it('only moves dashboard pos counters whose keys changed during a partial-overlap edit', async () => {
+    const uid = `it-stats-pos-overlap-${randomUUID()}`;
+    const repo = createEntryRepository(db, uid);
+    await setDoc(doc(db, 'users', uid, 'stats', 'vocabulary'), {
+      ownerUid: uid,
+      total: 0,
+      countsByDay: {},
+      jlptCounts: {},
+      posCounts: {},
+      updatedAt: Timestamp.fromDate(new Date('2026-06-24T09:00:00.000Z')),
+    });
+    const id = await repo.create(
+      draft({ learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] }),
+    );
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toMatchObject({
+        posCounts: { 名詞: 1, 動詞: 1 },
+      });
+
+    await repo.update(
+      id,
+      draft({
+        learnedOn: '2026-06-24',
+        jlpt: 'N2',
+        pos: ['名詞', '副詞'],
+      }),
+    );
+
+    await expect
+      .poll(() => repo.dashboardStats())
+      .toEqual({
+        ownerUid: uid,
+        total: 1,
+        countsByDay: { '2026-06-24': 1 },
+        jlptCounts: { N2: 1 },
+        posCounts: { 名詞: 1, 副詞: 1 },
+      });
+  });
+
   it('removes dashboard stats explicitly because account deletion cannot rely on cascades', async () => {
     const uid = `it-stats-delete-${randomUUID()}`;
     const repo = createEntryRepository(db, uid);

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -94,6 +94,16 @@ const session = (ownerUid: string, over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+const dashboardStats = (ownerUid: string, over: Record<string, unknown> = {}) => ({
+  ownerUid,
+  total: 2,
+  countsByDay: { '2026-08-13': 2 },
+  jlptCounts: { N1: 1, N2: 1 },
+  posCounts: { 名詞: 2 },
+  updatedAt: new Date('2026-08-13T00:01:00.000Z'),
+  ...over,
+});
+
 const profile = (uid: string, over: Record<string, unknown> = {}) => ({
   uid,
   nickname: 'Alice',
@@ -178,6 +188,7 @@ describe('private data under users/{uid}', () => {
     await assertFails(db.doc(`users/${ALICE}/progress/entries`).get());
     await assertFails(db.doc(`users/${ALICE}/progress/entries`).set({ entries: {} }));
     await assertFails(db.doc(`users/${ALICE}/practiceSessions/p1`).set(session(BOB)));
+    await assertFails(db.doc(`users/${ALICE}/stats/vocabulary`).set(dashboardStats(BOB)));
   });
 
   it('denies an unauthenticated client', async () => {
@@ -219,6 +230,7 @@ describe("a deleted account's token", () => {
     await assertFails(
       db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries: {} }),
     );
+    await assertFails(db.doc(`users/${ALICE}/stats/vocabulary`).set(dashboardStats(ALICE)));
     await assertFails(db.doc(`users/${ALICE}`).set(profile(ALICE)));
   });
 
@@ -466,6 +478,7 @@ describe('bounds on what an owner may write', () => {
     await assertSucceeds(db.doc(`users/${ALICE}/entries/ok`).set(entry(ALICE)));
     await assertSucceeds(db.doc(`users/${ALICE}/wordSets/ok`).set(wordSet(ALICE)));
     await assertSucceeds(db.doc(`users/${ALICE}/practiceSessions/ok`).set(session(ALICE)));
+    await assertSucceeds(db.doc(`users/${ALICE}/stats/vocabulary`).set(dashboardStats(ALICE)));
   });
 
   /**
@@ -716,6 +729,9 @@ describe('bounds on what an owner may write', () => {
     await assertFails(db.doc(`users/${ALICE}/wordSets/x`).set(wordSet(ALICE, { junk: 'x' })));
     await assertFails(
       db.doc(`users/${ALICE}/practiceSessions/x`).set(session(ALICE, { junk: 'x' })),
+    );
+    await assertFails(
+      db.doc(`users/${ALICE}/stats/vocabulary`).set(dashboardStats(ALICE, { junk: 'x' })),
     );
     await assertFails(
       db.doc(`users/${ALICE}/progress/entries`).set({ ownerUid: ALICE, entries: {}, junk: 'x' }),

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -24,7 +24,6 @@ const rows = (n: number, prefix: string) =>
 const ports = (entryCount: number, setCount: number, sessionCount: number) => {
   const entries = {
     list: paged(rows(entryCount, 'e')),
-    saveDashboardStats: vi.fn(() => Promise.resolve()),
     remove: vi.fn(() => Promise.resolve()),
     removeDashboardStats: vi.fn(() => Promise.resolve()),
     settlePendingWrites: vi.fn(() => Promise.resolve()),

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -24,6 +24,7 @@ const rows = (n: number, prefix: string) =>
 const ports = (entryCount: number, setCount: number, sessionCount: number) => {
   const entries = {
     list: paged(rows(entryCount, 'e')),
+    saveDashboardStats: vi.fn(() => Promise.resolve()),
     remove: vi.fn(() => Promise.resolve()),
     removeDashboardStats: vi.fn(() => Promise.resolve()),
     settlePendingWrites: vi.fn(() => Promise.resolve()),

--- a/tests/unit/accountData.test.ts
+++ b/tests/unit/accountData.test.ts
@@ -25,6 +25,7 @@ const ports = (entryCount: number, setCount: number, sessionCount: number) => {
   const entries = {
     list: paged(rows(entryCount, 'e')),
     remove: vi.fn(() => Promise.resolve()),
+    removeDashboardStats: vi.fn(() => Promise.resolve()),
     settlePendingWrites: vi.fn(() => Promise.resolve()),
   };
   const wordSets = {
@@ -137,6 +138,13 @@ describe('deleteEverything', () => {
     await deleteEverything(p);
 
     expect((p.progress.removeAll as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
+
+  it('removes dashboard stats, whose cached counts are private notebook data', async () => {
+    const p = ports(1, 0, 0);
+    await deleteEverything(p);
+
+    expect((p.entries.removeDashboardStats as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
 
   it('deletes the account itself, not only its data', async () => {

--- a/tests/unit/backfillVocabularyStats.test.ts
+++ b/tests/unit/backfillVocabularyStats.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dashboardStatsFor,
+  parseBackfillVocabularyStatsArgs,
+  sameDashboardStats,
+} from '../../admin/backfill-vocabulary-stats.shared';
+
+describe('backfill vocabulary stats arguments', () => {
+  it('uses the dev project and verifies twenty users by default', () => {
+    expect(parseBackfillVocabularyStatsArgs([])).toEqual({
+      ok: true,
+      projectId: 'goitei-dev',
+      sampleSize: 20,
+    });
+  });
+
+  it('rejects an invalid sample size instead of silently skipping production verification', () => {
+    expect(parseBackfillVocabularyStatsArgs(['prod', '--sample', '0'])).toMatchObject({
+      ok: false,
+      errors: ['--sample requires a positive integer'],
+    });
+  });
+});
+
+describe('backfill vocabulary stats calculation', () => {
+  it('matches the source entry counters, including overlapping parts of speech', () => {
+    const expected = dashboardStatsFor([
+      { learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞', '動詞'] },
+      { learnedOn: '2026-06-24', jlpt: 'N2', pos: ['名詞'] },
+      { learnedOn: '2026-06-23', jlpt: 'N3', pos: [] },
+    ]);
+
+    expect(expected).toEqual({
+      total: 3,
+      countsByDay: { '2026-06-24': 2, '2026-06-23': 1 },
+      jlptCounts: { N2: 2, N3: 1 },
+      posCounts: { 名詞: 2, 動詞: 1 },
+    });
+    expect(sameDashboardStats({ ownerUid: 'u1', ...expected }, expected)).toBe(true);
+  });
+});

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { summarise } from '@/lib/stats';
+import { summarise, summaryFromDashboardStats } from '@/lib/stats';
 import { makeEntry } from '../fixtures/entry';
 
 /**
@@ -122,5 +122,31 @@ describe('summarise — distributions', () => {
   it('ignores an entry with no parts of speech rather than inventing a row', () => {
     const summary = summarise([on('2026-06-24', { pos: [] })], NOW);
     expect(summary.posRows).toEqual([]);
+  });
+});
+
+describe('summaryFromDashboardStats', () => {
+  it('builds the dashboard summary from persisted counters and live period counts', () => {
+    const summary = summaryFromDashboardStats(
+      {
+        ownerUid: 'u1',
+        total: 4,
+        countsByDay: { '2026-06-24': 2, '2026-06-23': 1, empty: 0 },
+        jlptCounts: { N3: 2, N1: 1 },
+        posCounts: { 名詞: 3, 動詞: 1 },
+      },
+      { inWeek: 2, inMonth: 3, inYear: 4 },
+    );
+
+    expect(summary.countsByDay.get('2026-06-24')).toBe(2);
+    expect([summary.inWeek, summary.inMonth, summary.inYear]).toEqual([2, 3, 4]);
+    expect(summary.jlptRows).toEqual([
+      { label: 'N1', count: 1 },
+      { label: 'N3', count: 2 },
+    ]);
+    expect(summary.posRows).toEqual([
+      { label: '名詞', count: 3 },
+      { label: '動詞', count: 1 },
+    ]);
   });
 });

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { summarise, summaryFromDashboardStats } from '@/lib/stats';
+import { dashboardStatsFromSummary, summarise, summaryFromDashboardStats } from '@/lib/stats';
 import { makeEntry } from '../fixtures/entry';
 
 /**
@@ -126,20 +126,26 @@ describe('summarise — distributions', () => {
 });
 
 describe('summaryFromDashboardStats', () => {
-  it('builds the dashboard summary from persisted counters and live period counts', () => {
+  it('builds period totals from persisted day counters without aggregate reads', () => {
     const summary = summaryFromDashboardStats(
       {
         ownerUid: 'u1',
-        total: 4,
-        countsByDay: { '2026-06-24': 2, '2026-06-23': 1, empty: 0 },
+        total: 5,
+        countsByDay: {
+          '2026-06-24': 2,
+          '2026-06-23': 1,
+          '2026-06-01': 1,
+          '2025-12-31': 1,
+          empty: 0,
+        },
         jlptCounts: { N3: 2, N1: 1 },
         posCounts: { 名詞: 3, 動詞: 1 },
       },
-      { inWeek: 2, inMonth: 3, inYear: 4 },
+      NOW,
     );
 
     expect(summary.countsByDay.get('2026-06-24')).toBe(2);
-    expect([summary.inWeek, summary.inMonth, summary.inYear]).toEqual([2, 3, 4]);
+    expect([summary.inWeek, summary.inMonth, summary.inYear]).toEqual([3, 4, 4]);
     expect(summary.jlptRows).toEqual([
       { label: 'N1', count: 1 },
       { label: 'N3', count: 2 },
@@ -148,5 +154,19 @@ describe('summaryFromDashboardStats', () => {
       { label: '名詞', count: 3 },
       { label: '動詞', count: 1 },
     ]);
+  });
+
+  it('converts a fallback summary into a complete stats document payload', () => {
+    const summary = summarise(
+      [on('2026-06-24', { jlpt: 'N2', pos: ['名詞'] }), on('2026-06-23', { pos: ['動詞'] })],
+      NOW,
+    );
+
+    expect(dashboardStatsFromSummary(summary, 2)).toEqual({
+      total: 2,
+      countsByDay: { '2026-06-24': 1, '2026-06-23': 1 },
+      jlptCounts: { N2: 2 },
+      posCounts: { 名詞: 1, 動詞: 1 },
+    });
   });
 });


### PR DESCRIPTION
### Summary

Load Dashboard vocabulary data on demand instead of mounting the full notebook. Persisted dashboard counters supply distributions and heatmap data, while recent words, selected-day words, and word of the day use targeted reads and pagination.

### Changes

- Added owner-gated vocabulary stats reads and atomic counter deltas.
- Kept account deletion, selected-day pagination, and Dashboard dialog refreshes consistent with the cache.
- Added an Admin SDK `yarn backfill:vocabulary-stats` command that rebuilds every user cache, sample-verifies source parity, and documents the production runbook.
- Removed client-side full-scan cache writes; a missing cache uses a read-only fallback so concurrent mutations cannot be overwritten.

### Test coverage

- Unit: cached day-bucket period totals, backfill argument validation, and source counter calculation.
- Adapter integration: cache bootstrap, immediate mutation visibility, paged selected days, and an Admin SDK missing-cache concurrent-create regression.
- Red-to-green proof: restoring query-then-plain-set drops the concurrent entry (`total: 1`); the transaction implementation preserves it. Restoring fire-and-forget stats deltas reads `total: 0` immediately after create; awaiting the delta passes.

### Verification

- `yarn format`
- `yarn typecheck`
- `yarn lint` (18 existing warnings, no errors)
- `yarn test:emulator` (113 tests)
- `yarn test:unit` (920/921 passed; existing local font fixture failure: `inter-latin-400-normal.woff2` missing from `node_modules`)

Closes #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vocabulary dashboard statistics, including totals, daily activity, JLPT levels, and parts of speech.
  * Added recent learned entries, date-filtered browsing, and a deterministic Word of the Day.
  * Added reliable statistics rebuilding and verification tools for administrators.
* **Improvements**
  * Vocabulary details now load automatically when an entry is not already cached.
  * Entry changes update dashboard data more reliably.
  * Authenticated homepages load faster by avoiding unnecessary entry requests.
* **Documentation**
  * Added setup and production guidance for rebuilding vocabulary statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->