### PR TITLE
feat(admin): register App Check debug tokens with a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,28 @@ source tree.
 | `yarn release`                         | Bump the version and write `CHANGELOG.md`             |
 | `yarn rules:dev` / `yarn rules:prod`   | Deploy `firestore.rules`                              |
 | `yarn auth:login` / `yarn auth:revoke` | Repo-local Google ADC, used by the operator scripts   |
+| `yarn appcheck:debug-token <uuid>`     | Register a browser's App Check debug token            |
 
 `yarn auth:login` writes to `.gcloud/` via `CLOUDSDK_CONFIG`, deliberately apart
 from the machine-wide `~/.config/gcloud`. There is no long-lived service-account
 key in this project, and there should not be one.
+
+`yarn appcheck:debug-token` is what makes `yarn dev` able to sign in at all once
+App Check enforcement covers `identitytoolkit`, which it does on `goitei-dev` and
+`goitei`. A deployed origin attests with reCAPTCHA v3; `localhost` cannot, because
+a v3 site key is bound to registered domains, so `src/infra/firebase/client.ts`
+switches to a debug token in `DEV`. The SDK generates one per browser profile and
+prints it to the console — `App Check debug token: <uuid>` — and until that UUID
+is registered, `signInWithPopup` is refused and the login screen reports the same
+「ログインできませんでした」 it reports for every other cause. Nothing else names
+App Check as the reason, which is why this has its own command rather than a line
+in a runbook.
+
+A debug token is a bypass, so registering one is a decision rather than a
+formality: it lives in IndexedDB, a cleared profile or a second browser produces
+another, and each registration attests as this app until somebody removes it.
+The Firebase console lists them under App Check → Apps → Manage debug tokens,
+which is also where they are deleted.
 
 ## Tests
 

--- a/admin/app-check-debug-token.shared.ts
+++ b/admin/app-check-debug-token.shared.ts
@@ -30,8 +30,15 @@ const USAGE =
  * to end: a half-selected paste registers a token that can never match, App
  * Check says nothing about it, and sign-in keeps failing with the same
  * generic message it failed with before.
+ *
+ * Version 4 specifically, variant nibble included, because that is what the
+ * API accepts: `debugTokens.create` documents `token` as "must be a UUID4,
+ * case insensitive" and refuses anything else. `crypto.randomUUID()`, which is
+ * what the SDK calls, produces exactly that — so the narrower pattern rejects
+ * nothing a browser can print, and turns a UUID from some other generator into
+ * an error at the prompt rather than a 400 from Google.
  */
-const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function parseAppCheckDebugTokenArgs(
   args: string[],

--- a/admin/app-check-debug-token.shared.ts
+++ b/admin/app-check-debug-token.shared.ts
@@ -1,0 +1,172 @@
+export interface DebugTokenRegistration {
+  token: string;
+  displayName: string;
+}
+
+export type ParsedAppCheckDebugTokenArgs =
+  | {
+      ok: true;
+      projectId: string;
+      /** Null when it has to be read from `envFile` instead. */
+      appId: string | null;
+      /** The Vite env file holding `VITE_FIREBASE_APP_ID`, or null when `--app-id` was given. */
+      envFile: string | null;
+      tokens: DebugTokenRegistration[];
+    }
+  | {
+      ok: false;
+      errors: string[];
+      usage: string;
+    };
+
+const USAGE =
+  'usage: app-check-debug-token.ts <uuid> [<uuid>...] [prod | --project <id>] ' +
+  '[--app-id <id>] [--name <label>]';
+
+/**
+ * `src/infra/firebase/client.ts` sets `FIREBASE_APPCHECK_DEBUG_TOKEN = true`,
+ * so every token this ever registers is a UUID the SDK generated and printed
+ * to the console. Checking the shape catches the failure this command exists
+ * to end: a half-selected paste registers a token that can never match, App
+ * Check says nothing about it, and sign-in keeps failing with the same
+ * generic message it failed with before.
+ */
+const TOKEN_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function parseAppCheckDebugTokenArgs(
+  args: string[],
+  fallbackName: string,
+): ParsedAppCheckDebugTokenArgs {
+  const errors: string[] = [];
+  const tokens: string[] = [];
+  let rejected = 0;
+  let projectId: string | null = null;
+  let appId: string | null = null;
+  let displayName: string | null = null;
+  let prod = false;
+
+  const takeOnce = (name: string, index: number, current: string | null): string | null => {
+    const value = args[index + 1];
+    if (!value || value.startsWith('--')) {
+      errors.push(`${name} requires a value`);
+      return current;
+    }
+    if (current !== null) {
+      errors.push(`${name} specified multiple times`);
+      return current;
+    }
+    return value;
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === 'prod') {
+      prod = true;
+      continue;
+    }
+    if (arg === '--project') {
+      projectId = takeOnce('--project', index, projectId);
+      index += 1;
+      continue;
+    }
+    if (arg === '--app-id') {
+      appId = takeOnce('--app-id', index, appId);
+      index += 1;
+      continue;
+    }
+    if (arg === '--name') {
+      displayName = takeOnce('--name', index, displayName);
+      index += 1;
+      continue;
+    }
+    if (arg === undefined || arg.startsWith('--')) {
+      errors.push(`unknown argument: ${arg}`);
+      continue;
+    }
+    if (!TOKEN_PATTERN.test(arg)) {
+      errors.push(`not a debug token: ${arg} — expected the UUID \`yarn dev\` prints`);
+      rejected += 1;
+      continue;
+    }
+    const normalized = arg.toLowerCase();
+    if (tokens.includes(normalized)) {
+      errors.push(`duplicate debug token: ${normalized}`);
+      continue;
+    }
+    tokens.push(normalized);
+  }
+
+  if (prod && projectId) errors.push('choose either prod or --project <project-id>, not both');
+  // Only when nothing token-shaped was offered at all: telling an operator who
+  // pasted half a UUID that they passed no token sends them looking for the
+  // wrong mistake.
+  if (tokens.length === 0 && rejected === 0) errors.push('missing debug token');
+
+  // With `--project` there is no env file to read an app id out of: the two
+  // Vite env files describe this repository's own projects and nothing else.
+  if (projectId && !appId) errors.push('--project requires --app-id');
+
+  if (errors.length > 0) return { ok: false, errors, usage: USAGE };
+
+  return {
+    ok: true,
+    projectId: projectId ?? (prod ? 'goitei' : 'goitei-dev'),
+    appId,
+    envFile: appId ? null : prod ? '.env.production' : '.env.development',
+    tokens: tokens.map((token, position) => ({
+      token,
+      // Numbered only when there is more than one, so the common single-token
+      // case reads as the label the operator asked for.
+      displayName:
+        tokens.length === 1
+          ? (displayName ?? fallbackName)
+          : `${displayName ?? fallbackName} (${position + 1})`,
+    })),
+  };
+}
+
+/**
+ * Pull `VITE_FIREBASE_APP_ID` out of a Vite env file.
+ *
+ * Deliberately not a general dotenv parser: this reads one known key out of a
+ * file this repository writes, and a wrong answer is caught immediately by the
+ * API rejecting the app id rather than by silently registering a token
+ * somewhere else.
+ */
+export function readAppIdFromEnvFile(contents: string): string | null {
+  for (const line of contents.split('\n')) {
+    const match = /^\s*VITE_FIREBASE_APP_ID\s*=\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const value = (match[1] ?? '').trim().replace(/^['"]|['"]$/g, '');
+    if (value) return value;
+  }
+  return null;
+}
+
+/**
+ * The app id carries colons (`1:123:web:abc`). They are legal in a path
+ * segment and the API accepts them as written; percent-encoding them is the
+ * change to avoid, not the one to make.
+ */
+export function debugTokensEndpoint(projectId: string, appId: string): string {
+  return `https://firebaseappcheck.googleapis.com/v1/projects/${projectId}/apps/${appId}/debugTokens`;
+}
+
+export function registrationFailureLines(
+  status: number,
+  body: string,
+  projectId: string,
+): string[] {
+  const lines = [`failed to register the debug token on ${projectId} (HTTP ${status}).`];
+  if (status === 403 || status === 401) {
+    lines.push(
+      'Check that the credential holds roles/firebaseappcheck.admin on this project, ' +
+        'and that `yarn auth:login` has been run.',
+    );
+  }
+  if (status === 404) {
+    lines.push('Check the app id: a web app id looks like `1:123456789:web:abcdef`.');
+  }
+  lines.push(body.trim());
+  return lines;
+}

--- a/admin/app-check-debug-token.shared.ts
+++ b/admin/app-check-debug-token.shared.ts
@@ -90,14 +90,21 @@ export function parseAppCheckDebugTokenArgs(
       errors.push(`unknown argument: ${arg}`);
       continue;
     }
+    // Named by position, never by value. A debug token is a credential, and
+    // the success path already refuses to print one; echoing a rejected one
+    // undoes that for the case most likely to be a real token — a duplicate is
+    // valid by definition, and a UUID that picked up trailing punctuation is
+    // almost all of one. The position is what the operator needs anyway.
     if (!TOKEN_PATTERN.test(arg)) {
-      errors.push(`not a debug token: ${arg} — expected the UUID \`yarn dev\` prints`);
+      errors.push(
+        `not a debug token at argument ${index + 1} — expected the UUID \`yarn dev\` prints`,
+      );
       rejected += 1;
       continue;
     }
     const normalized = arg.toLowerCase();
     if (tokens.includes(normalized)) {
-      errors.push(`duplicate debug token: ${normalized}`);
+      errors.push(`duplicate debug token at argument ${index + 1}`);
       continue;
     }
     tokens.push(normalized);

--- a/admin/app-check-debug-token.ts
+++ b/admin/app-check-debug-token.ts
@@ -1,0 +1,124 @@
+import { readFile } from 'node:fs/promises';
+import { hostname } from 'node:os';
+import { applicationDefault, cert } from 'firebase-admin/app';
+import { describeCredentialSource } from './allow-user.shared';
+import {
+  debugTokensEndpoint,
+  parseAppCheckDebugTokenArgs,
+  readAppIdFromEnvFile,
+  registrationFailureLines,
+} from './app-check-debug-token.shared';
+
+/**
+ * Register an App Check debug token, so a browser running `yarn dev` can
+ * attest.
+ *
+ *   yarn appcheck:debug-token <uuid>                       # goitei-dev
+ *   yarn appcheck:debug-token <uuid> <uuid> --name "Chrome"
+ *   yarn appcheck:debug-token <uuid> prod
+ *
+ * **What it is for.** App Check enforcement covers `identitytoolkit` as well as
+ * Firestore on these projects, so an unattested client cannot even sign in —
+ * `signInWithPopup` is refused and `Login.tsx` reports the same
+ * 「ログインできませんでした」 it reports for every other cause. On a deployed
+ * origin reCAPTCHA v3 answers for the client; on `localhost` it cannot, because
+ * a v3 site key is bound to registered domains, so `src/infra/firebase/client.ts`
+ * switches to a debug token in `DEV` and the SDK generates one per browser and
+ * prints it to the console. Until that UUID is registered here, the browser is
+ * exactly as unattested as a scripted client, which is the whole point of the
+ * mechanism.
+ *
+ * A debug token is a bypass. It is stored per browser profile in IndexedDB, so
+ * clearing site data or moving to another profile produces a new one and the
+ * failure returns; every registration is one more way to attest as this app,
+ * indefinitely, so remove the ones that belong to machines and browsers you no
+ * longer use — the Firebase console, App Check → Apps → Manage debug tokens,
+ * is where they are listed and deleted.
+ *
+ * **Needs `roles/firebaseappcheck.admin`** on whatever credential ADC resolves
+ * to — `yarn auth:login` is what puts one in `.gcloud/`.
+ *
+ * The Admin SDK has no debug-token API, so this calls the App Check REST
+ * endpoint directly with an ADC access token. `X-Goog-User-Project` is what
+ * makes a user credential's call billable to the target project; without it the
+ * API refuses a plain ADC login.
+ */
+
+const parsed = parseAppCheckDebugTokenArgs(process.argv.slice(2), hostname());
+
+if (!parsed.ok) {
+  for (const error of parsed.errors) console.error(error);
+  console.error(parsed.usage);
+  process.exit(1);
+}
+
+const { projectId, envFile, tokens } = parsed;
+
+let appId = parsed.appId;
+
+if (!appId && envFile) {
+  let contents: string;
+  try {
+    contents = await readFile(new URL(`../${envFile}`, import.meta.url), 'utf8');
+  } catch {
+    console.error(`cannot read ${envFile}, so there is no app id to register against.`);
+    console.error('Pass --app-id <id> instead, or copy .env.example and fill it in.');
+    process.exit(1);
+  }
+  appId = readAppIdFromEnvFile(contents);
+  if (!appId) {
+    console.error(`${envFile} has no VITE_FIREBASE_APP_ID. Pass --app-id <id> instead.`);
+    process.exit(1);
+  }
+}
+
+if (!appId) {
+  console.error('missing --app-id');
+  process.exit(1);
+}
+
+const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+const credential = key ? cert(key) : applicationDefault();
+
+let accessToken: string;
+try {
+  accessToken = (await credential.getAccessToken()).access_token;
+} catch (cause) {
+  console.error(`could not obtain a Google access token for ${projectId}.`);
+  console.error(`credential configuration: ${describeCredentialSource(process.env)}`);
+  console.error(cause);
+  process.exit(1);
+}
+
+for (const { token, displayName } of tokens) {
+  const response = await fetch(debugTokensEndpoint(projectId, appId), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+      'X-Goog-User-Project': projectId,
+    },
+    body: JSON.stringify({ displayName, token }),
+  });
+
+  if (!response.ok) {
+    for (const line of registrationFailureLines(
+      response.status,
+      await response.text(),
+      projectId,
+    )) {
+      console.error(line);
+    }
+    console.error(`credential configuration: ${describeCredentialSource(process.env)}`);
+    process.exit(1);
+  }
+
+  // Not the token itself: it is a credential, and a shell history or CI log is
+  // not where a bypass for this project should come to rest.
+  console.log(`registered "${displayName}" on ${projectId} (${appId}).`);
+}
+
+console.log(
+  'Reload the browser that printed the token. A debug token is picked up on the ' +
+    'next App Check request, but a page holding a refused token keeps it until then.',
+);

--- a/admin/app-check-debug-token.ts
+++ b/admin/app-check-debug-token.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { hostname } from 'node:os';
-import { applicationDefault, cert } from 'firebase-admin/app';
+import { applicationDefault } from 'firebase-admin/app';
 import { describeCredentialSource } from './allow-user.shared';
 import {
   debugTokensEndpoint,
@@ -77,8 +77,14 @@ if (!appId) {
   process.exit(1);
 }
 
-const key = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-const credential = key ? cert(key) : applicationDefault();
+// `applicationDefault()` unconditionally, for the reason
+// `mint-preview-app-check-token.ts` already records: `GOOGLE_APPLICATION_CREDENTIALS`
+// may point at a Workload Identity Federation config rather than a
+// service-account key JSON, and `cert()` accepts only the latter and throws on
+// the former. `applicationDefault()` reads either, and a key file set that way
+// is one of the things it reads, so branching on the variable buys nothing and
+// costs the credential type this repository's own CI issues.
+const credential = applicationDefault();
 
 let accessToken: string;
 try {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "auth:revoke": "CLOUDSDK_CONFIG=.gcloud gcloud auth application-default revoke",
     "allow": "vite-node admin/allow-user.ts --",
     "mint-preview-appcheck-token": "vite-node admin/mint-preview-app-check-token.ts --",
+    "appcheck:debug-token": "CLOUDSDK_CONFIG=${CLOUDSDK_CONFIG:-.gcloud} vite-node admin/app-check-debug-token.ts --",
     "icons": "vite-node scripts/icons.ts",
     "fonts": "vite-node scripts/fonts.ts",
     "manifest:screenshots": "vite-node scripts/manifest-screenshots.ts",

--- a/tests/unit/appCheckDebugToken.test.ts
+++ b/tests/unit/appCheckDebugToken.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../admin/app-check-debug-token.shared';
 
 describe('app-check-debug-token helpers', () => {
-  it('rejects a truncated token, which would register a bypass that can never match and leave sign-in failing the same way', () => {
+  it('parseAppCheckDebugTokenArgs rejects a truncated token, which would register a bypass that can never match and leave sign-in failing the same way', () => {
     const parsed = parseAppCheckDebugTokenArgs(['5e05991b-01cf-446b-aa33'], 'MacBookPro');
     expect(parsed.ok).toBe(false);
     expect(parsed.ok === false && parsed.errors).toEqual([
@@ -15,12 +15,21 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('says the token is missing only when none was offered, not when one was rejected for its shape', () => {
+  it('parseAppCheckDebugTokenArgs rejects a version 1 UUID, which the App Check API refuses as not a UUID4 after the command has already reported success', () => {
+    // Time-based rather than random: a valid RFC 4122 UUID that the SDK never
+    // produces and `debugTokens.create` will not store.
+    const parsed = parseAppCheckDebugTokenArgs(['5e05991b-01cf-11ee-aa33-c71a2359a27d'], 'host');
+    expect(parsed.ok === false && parsed.errors).toEqual([
+      'not a debug token: 5e05991b-01cf-11ee-aa33-c71a2359a27d — expected the UUID `yarn dev` prints',
+    ]);
+  });
+
+  it('parseAppCheckDebugTokenArgs says the token is missing only when none was offered, not when one was rejected for its shape', () => {
     const empty = parseAppCheckDebugTokenArgs([], 'MacBookPro');
     expect(empty.ok === false && empty.errors).toEqual(['missing debug token']);
   });
 
-  it('numbers the labels when one --name covers several tokens, so two browsers are not both listed under the same name', () => {
+  it('parseAppCheckDebugTokenArgs numbers the labels when one --name covers several tokens, so two browsers are not both listed under the same name', () => {
     const parsed = parseAppCheckDebugTokenArgs(
       [
         '5e05991b-01cf-446b-aa33-c71a2359a27d',
@@ -36,7 +45,7 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('leaves a single token labelled exactly as asked, unnumbered', () => {
+  it('parseAppCheckDebugTokenArgs leaves a single token labelled exactly as asked, unnumbered', () => {
     const parsed = parseAppCheckDebugTokenArgs(
       ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--name', 'Chrome'],
       'MacBookPro',
@@ -46,7 +55,7 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('reads the app id from .env.development unless prod is asked for, so a plain run cannot register a bypass on production', () => {
+  it('parseAppCheckDebugTokenArgs reads the app id from .env.development unless prod is asked for, so a plain run cannot register a bypass on production', () => {
     const dev = parseAppCheckDebugTokenArgs(['5e05991b-01cf-446b-aa33-c71a2359a27d'], 'host');
     expect(dev.ok === true && [dev.projectId, dev.envFile]).toEqual([
       'goitei-dev',
@@ -63,7 +72,7 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('refuses --project without --app-id, which would otherwise register this repository app id against somebody else project', () => {
+  it('parseAppCheckDebugTokenArgs refuses --project without --app-id, which would otherwise register this repository app id against somebody else project', () => {
     const parsed = parseAppCheckDebugTokenArgs(
       ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--project', 'other-dev'],
       'host',
@@ -71,7 +80,7 @@ describe('app-check-debug-token helpers', () => {
     expect(parsed.ok === false && parsed.errors).toEqual(['--project requires --app-id']);
   });
 
-  it('takes --app-id over the env file rather than reading one it was not asked to use', () => {
+  it('parseAppCheckDebugTokenArgs takes --app-id over the env file rather than reading one it was not asked to use', () => {
     const parsed = parseAppCheckDebugTokenArgs(
       ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--project', 'other-dev', '--app-id', '1:2:web:3'],
       'host',
@@ -83,7 +92,7 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('rejects the same token twice, which the API would accept as two entries nobody can tell apart', () => {
+  it('parseAppCheckDebugTokenArgs rejects the same token twice, which the API would accept as two entries nobody can tell apart', () => {
     const parsed = parseAppCheckDebugTokenArgs(
       ['5E05991B-01CF-446B-AA33-C71A2359A27D', '5e05991b-01cf-446b-aa33-c71a2359a27d'],
       'host',
@@ -93,7 +102,7 @@ describe('app-check-debug-token helpers', () => {
     ]);
   });
 
-  it('reads VITE_FIREBASE_APP_ID past a commented-out line rather than registering against the example value', () => {
+  it('readAppIdFromEnvFile reads VITE_FIREBASE_APP_ID past a commented-out line rather than registering against the example value', () => {
     const contents = [
       '# VITE_FIREBASE_APP_ID=1:000:web:example',
       'VITE_FIREBASE_PROJECT_ID=goitei-dev',
@@ -102,17 +111,17 @@ describe('app-check-debug-token helpers', () => {
     expect(readAppIdFromEnvFile(contents)).toBe('1:506149326465:web:abc');
   });
 
-  it('returns null for an env file with the key unset, so the script asks for --app-id instead of posting an empty id', () => {
+  it('readAppIdFromEnvFile returns null for an env file with the key unset, so the script asks for --app-id instead of posting an empty id', () => {
     expect(readAppIdFromEnvFile('VITE_FIREBASE_APP_ID=\n')).toBeNull();
   });
 
-  it('leaves the colons in an app id unencoded, which is the form the App Check API accepts', () => {
+  it('debugTokensEndpoint leaves the colons in an app id unencoded, which is the form the App Check API accepts', () => {
     expect(debugTokensEndpoint('goitei-dev', '1:123:web:abc')).toBe(
       'https://firebaseappcheck.googleapis.com/v1/projects/goitei-dev/apps/1:123:web:abc/debugTokens',
     );
   });
 
-  it('names the missing role on a 403, the one failure whose cause is not in the response body', () => {
+  it('registrationFailureLines names the missing role on a 403, the one failure whose cause is not in the response body', () => {
     expect(registrationFailureLines(403, '{"error":{"message":"denied"}}', 'goitei-dev')).toEqual([
       'failed to register the debug token on goitei-dev (HTTP 403).',
       'Check that the credential holds roles/firebaseappcheck.admin on this project, and that `yarn auth:login` has been run.',

--- a/tests/unit/appCheckDebugToken.test.ts
+++ b/tests/unit/appCheckDebugToken.test.ts
@@ -11,7 +11,7 @@ describe('app-check-debug-token helpers', () => {
     const parsed = parseAppCheckDebugTokenArgs(['5e05991b-01cf-446b-aa33'], 'MacBookPro');
     expect(parsed.ok).toBe(false);
     expect(parsed.ok === false && parsed.errors).toEqual([
-      'not a debug token: 5e05991b-01cf-446b-aa33 — expected the UUID `yarn dev` prints',
+      'not a debug token at argument 1 — expected the UUID `yarn dev` prints',
     ]);
   });
 
@@ -20,7 +20,7 @@ describe('app-check-debug-token helpers', () => {
     // produces and `debugTokens.create` will not store.
     const parsed = parseAppCheckDebugTokenArgs(['5e05991b-01cf-11ee-aa33-c71a2359a27d'], 'host');
     expect(parsed.ok === false && parsed.errors).toEqual([
-      'not a debug token: 5e05991b-01cf-11ee-aa33-c71a2359a27d — expected the UUID `yarn dev` prints',
+      'not a debug token at argument 1 — expected the UUID `yarn dev` prints',
     ]);
   });
 
@@ -97,9 +97,16 @@ describe('app-check-debug-token helpers', () => {
       ['5E05991B-01CF-446B-AA33-C71A2359A27D', '5e05991b-01cf-446b-aa33-c71a2359a27d'],
       'host',
     );
-    expect(parsed.ok === false && parsed.errors).toEqual([
-      'duplicate debug token: 5e05991b-01cf-446b-aa33-c71a2359a27d',
-    ]);
+    expect(parsed.ok === false && parsed.errors).toEqual(['duplicate debug token at argument 2']);
+  });
+
+  it('parseAppCheckDebugTokenArgs names the argument position rather than echoing a rejected token, which is a credential the success path already refuses to print', () => {
+    const almost = '5e05991b-01cf-446b-aa33-c71a2359a27d,';
+    const parsed = parseAppCheckDebugTokenArgs([almost], 'host');
+    expect(parsed.ok).toBe(false);
+    // The whole token bar the stray comma: rejecting it must not be the thing
+    // that writes it into a shell scrollback or a CI log.
+    expect(parsed.ok === false && parsed.errors.join(' ')).not.toContain(almost.slice(0, -1));
   });
 
   it('readAppIdFromEnvFile reads VITE_FIREBASE_APP_ID past a commented-out line rather than registering against the example value', () => {

--- a/tests/unit/appCheckDebugToken.test.ts
+++ b/tests/unit/appCheckDebugToken.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import {
+  debugTokensEndpoint,
+  parseAppCheckDebugTokenArgs,
+  readAppIdFromEnvFile,
+  registrationFailureLines,
+} from '../../admin/app-check-debug-token.shared';
+
+describe('app-check-debug-token helpers', () => {
+  it('rejects a truncated token, which would register a bypass that can never match and leave sign-in failing the same way', () => {
+    const parsed = parseAppCheckDebugTokenArgs(['5e05991b-01cf-446b-aa33'], 'MacBookPro');
+    expect(parsed.ok).toBe(false);
+    expect(parsed.ok === false && parsed.errors).toEqual([
+      'not a debug token: 5e05991b-01cf-446b-aa33 — expected the UUID `yarn dev` prints',
+    ]);
+  });
+
+  it('says the token is missing only when none was offered, not when one was rejected for its shape', () => {
+    const empty = parseAppCheckDebugTokenArgs([], 'MacBookPro');
+    expect(empty.ok === false && empty.errors).toEqual(['missing debug token']);
+  });
+
+  it('numbers the labels when one --name covers several tokens, so two browsers are not both listed under the same name', () => {
+    const parsed = parseAppCheckDebugTokenArgs(
+      [
+        '5e05991b-01cf-446b-aa33-c71a2359a27d',
+        'd9b4c1b6-d47e-4254-84cc-da29d95954a0',
+        '--name',
+        'Chrome',
+      ],
+      'MacBookPro',
+    );
+    expect(parsed.ok === true && parsed.tokens).toEqual([
+      { token: '5e05991b-01cf-446b-aa33-c71a2359a27d', displayName: 'Chrome (1)' },
+      { token: 'd9b4c1b6-d47e-4254-84cc-da29d95954a0', displayName: 'Chrome (2)' },
+    ]);
+  });
+
+  it('leaves a single token labelled exactly as asked, unnumbered', () => {
+    const parsed = parseAppCheckDebugTokenArgs(
+      ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--name', 'Chrome'],
+      'MacBookPro',
+    );
+    expect(parsed.ok === true && parsed.tokens).toEqual([
+      { token: '5e05991b-01cf-446b-aa33-c71a2359a27d', displayName: 'Chrome' },
+    ]);
+  });
+
+  it('reads the app id from .env.development unless prod is asked for, so a plain run cannot register a bypass on production', () => {
+    const dev = parseAppCheckDebugTokenArgs(['5e05991b-01cf-446b-aa33-c71a2359a27d'], 'host');
+    expect(dev.ok === true && [dev.projectId, dev.envFile]).toEqual([
+      'goitei-dev',
+      '.env.development',
+    ]);
+
+    const prod = parseAppCheckDebugTokenArgs(
+      ['5e05991b-01cf-446b-aa33-c71a2359a27d', 'prod'],
+      'host',
+    );
+    expect(prod.ok === true && [prod.projectId, prod.envFile]).toEqual([
+      'goitei',
+      '.env.production',
+    ]);
+  });
+
+  it('refuses --project without --app-id, which would otherwise register this repository app id against somebody else project', () => {
+    const parsed = parseAppCheckDebugTokenArgs(
+      ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--project', 'other-dev'],
+      'host',
+    );
+    expect(parsed.ok === false && parsed.errors).toEqual(['--project requires --app-id']);
+  });
+
+  it('takes --app-id over the env file rather than reading one it was not asked to use', () => {
+    const parsed = parseAppCheckDebugTokenArgs(
+      ['5e05991b-01cf-446b-aa33-c71a2359a27d', '--project', 'other-dev', '--app-id', '1:2:web:3'],
+      'host',
+    );
+    expect(parsed.ok === true && [parsed.projectId, parsed.appId, parsed.envFile]).toEqual([
+      'other-dev',
+      '1:2:web:3',
+      null,
+    ]);
+  });
+
+  it('rejects the same token twice, which the API would accept as two entries nobody can tell apart', () => {
+    const parsed = parseAppCheckDebugTokenArgs(
+      ['5E05991B-01CF-446B-AA33-C71A2359A27D', '5e05991b-01cf-446b-aa33-c71a2359a27d'],
+      'host',
+    );
+    expect(parsed.ok === false && parsed.errors).toEqual([
+      'duplicate debug token: 5e05991b-01cf-446b-aa33-c71a2359a27d',
+    ]);
+  });
+
+  it('reads VITE_FIREBASE_APP_ID past a commented-out line rather than registering against the example value', () => {
+    const contents = [
+      '# VITE_FIREBASE_APP_ID=1:000:web:example',
+      'VITE_FIREBASE_PROJECT_ID=goitei-dev',
+      'VITE_FIREBASE_APP_ID="1:506149326465:web:abc"',
+    ].join('\n');
+    expect(readAppIdFromEnvFile(contents)).toBe('1:506149326465:web:abc');
+  });
+
+  it('returns null for an env file with the key unset, so the script asks for --app-id instead of posting an empty id', () => {
+    expect(readAppIdFromEnvFile('VITE_FIREBASE_APP_ID=\n')).toBeNull();
+  });
+
+  it('leaves the colons in an app id unencoded, which is the form the App Check API accepts', () => {
+    expect(debugTokensEndpoint('goitei-dev', '1:123:web:abc')).toBe(
+      'https://firebaseappcheck.googleapis.com/v1/projects/goitei-dev/apps/1:123:web:abc/debugTokens',
+    );
+  });
+
+  it('names the missing role on a 403, the one failure whose cause is not in the response body', () => {
+    expect(registrationFailureLines(403, '{"error":{"message":"denied"}}', 'goitei-dev')).toEqual([
+      'failed to register the debug token on goitei-dev (HTTP 403).',
+      'Check that the credential holds roles/firebaseappcheck.admin on this project, and that `yarn auth:login` has been run.',
+      '{"error":{"message":"denied"}}',
+    ]);
+  });
+});


### PR DESCRIPTION
Signing in from `localhost` fails with the login screen's generic
「ログインできませんでした」, and nothing on the page or in the code says why.

App Check enforcement covers `identitytoolkit` on these projects, not only
Firestore, so an unattested client is refused at sign-in rather than at the
first read. A deployed origin attests with reCAPTCHA v3; `localhost` cannot,
because a v3 site key is bound to registered domains — which is why
`src/infra/firebase/client.ts` switches to `FIREBASE_APPCHECK_DEBUG_TOKEN` in
`DEV`. The SDK then generates a token per browser profile and prints it to the
console, and until that UUID is registered the browser is exactly as
unattested as a scripted client.

That registration existed only as a click path in the Firebase console, known
to whoever had done it before. `Login.tsx` reports the same message for a
refused App Check token as for every other cause, so the failure gives the
reader nothing to search for. This adds the command, and the paragraph in the
README that names App Check as the thing to suspect.

```sh
yarn appcheck:debug-token <uuid>                        # goitei-dev
yarn appcheck:debug-token <uuid> <uuid> --name "Chrome" # two browsers at once
yarn appcheck:debug-token <uuid> prod
yarn appcheck:debug-token <uuid> --project other --app-id 1:2:web:3
```

## What is here

- `admin/app-check-debug-token.ts` — resolves an ADC access token and POSTs to
  the App Check REST endpoint.
- `admin/app-check-debug-token.shared.ts` — argument parsing, the app id lookup
  and the failure messages, kept pure so they are unit-testable, the same split
  `allow-user` and `mint-preview-app-check-token` already use.
- `package.json` — the `appcheck:debug-token` script.
- `README.md` — a row in the scripts table, and why `localhost` needs this at
  all.

## Choices worth a reviewer's attention

- **REST rather than the Admin SDK.** The Admin SDK has no debug-token API. The
  call therefore needs `X-Goog-User-Project` explicitly: without it the API
  refuses a plain ADC user credential.
- **The app id is not typed.** It is read from `VITE_FIREBASE_APP_ID` in the env
  file for the target — `.env.development`, or `.env.production` behind `prod`.
  `--project` requires `--app-id`, because those two files describe this
  repository's projects and nothing else.
- **The token's shape is checked.** Every token this will ever register is a
  UUID the SDK generated, because `client.ts` sets the flag to `true` rather
  than to a string of its own. A half-selected paste is accepted by the API,
  never matches any browser, and leaves sign-in failing with the same message it
  was already failing with — the check turns that into an error at the prompt.
- **`CLOUDSDK_CONFIG` defaults to `.gcloud`** in the script, so the credential
  `yarn auth:login` writes is the one this uses. An operator who has exported
  their own keeps it: the default is `${CLOUDSDK_CONFIG:-.gcloud}`, not an
  overwrite.
- **A debug token is a bypass**, and registering one is a decision rather than a
  formality. The script's header and the README both say where they are listed
  and deleted, because a registration that outlives the machine it was made for
  is a standing way to attest as this app.

## Tests

**Unit** (`tests/unit/appCheckDebugToken.test.ts`, 12 tests), because everything
worth asserting here is a function of its inputs: which project and app id a set
of arguments resolves to, which arguments are refused, how a display name is
numbered, and what an env file yields. The half that talks to Google is four
lines of `fetch` around those answers, and an integration layer for it would
need a live project and would assert less.

**One went red before it went green, and it changed the code.** The first
parser reported both `not a debug token: …` and `missing debug token` for a
truncated UUID — the test asserting the single error failed on the second line,
and the fix was to report a missing token only when nothing token-shaped was
offered at all. Telling an operator who pasted half a UUID that they passed no
token sends them looking for the wrong mistake.

**Verified against `goitei-dev`.** Two debug tokens were registered with the
command as written here, and the App Check API's own listing was read back to
confirm both are present under the names it reported.

`yarn test:unit` — 966 passing across 66 files. `yarn typecheck`, `yarn lint`
and `yarn format` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for registering browser Firebase App Check debug tokens.
  * Supports token validation, duplicate detection, custom display names, and app/environment selection.
  * Provides clear feedback for authentication or registration failures without displaying token values.
* **Documentation**
  * Documented local App Check setup, token registration, persistence, and removal through the Firebase console.
* **Tests**
  * Added coverage for validation, configuration, environment parsing, endpoint generation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->