### PR TITLE
test: cover the practice-mode fallback and say what a broken link costs

### DIFF
--- a/tests/component/SessionDialog.test.tsx
+++ b/tests/component/SessionDialog.test.tsx
@@ -88,6 +88,9 @@ describe('SessionDialog — a session recorded before the run was kept', () => {
     );
 
     const link = screen.getByRole('link', { name: /切り分け/ });
+    // The row is how a learner gets from a drill they got wrong back to the
+    // note itself. A wrong or missing target here leaves the word readable and
+    // unreachable — the history renders, and nothing in it opens.
     expect(link).toHaveAttribute('href', '/vocabulary/w1');
     expect(within(link).getByText('N2')).toBeInTheDocument();
   });

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -523,8 +523,11 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
    * that still have to be readable, which is what this whole module is for.
    */
   it('reads a session recorded in a drill this version no longer has as a flashcard run', () => {
+    // Only the unrecognised string. `oneOf` also refuses a non-string, but that
+    // half of it is shared with every other enum field and is already covered
+    // by `falls back when jlpt is outside the scale` — asserting it again here
+    // would test the helper a second time rather than this field's wiring.
     expect(sanitizeSession('s1', { ...stored([]), mode: 'writing' }).mode).toBe('flashcard');
-    expect(sanitizeSession('s1', { ...stored([]), mode: 42 }).mode).toBe('flashcard');
   });
 
   it('keeps a mode it does recognise', () => {

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -511,6 +511,25 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
   it('reads a missed list that is not a list at all as empty', () => {
     expect(sanitizeSession('s1', stored('w1')).missed).toEqual([]);
   });
+
+  /**
+   * The drill a session was recorded in, when it is one this version does not
+   * have. `PracticeMode` is a closed union, so an unrecognised string read
+   * straight off the document is a value the type says cannot exist — and it
+   * reaches `SessionDialog`, which picks its heading and its chips from it.
+   *
+   * Named for the mode rather than for the sanitiser because that is the fact
+   * that decides it: a drill removed in a later version leaves sessions behind
+   * that still have to be readable, which is what this whole module is for.
+   */
+  it('reads a session recorded in a drill this version no longer has as a flashcard run', () => {
+    expect(sanitizeSession('s1', { ...stored([]), mode: 'writing' }).mode).toBe('flashcard');
+    expect(sanitizeSession('s1', { ...stored([]), mode: 42 }).mode).toBe('flashcard');
+  });
+
+  it('keeps a mode it does recognise', () => {
+    expect(sanitizeSession('s1', { ...stored([]), mode: 'dictation' }).mode).toBe('dictation');
+  });
 });
 
 /**


### PR DESCRIPTION
Second round of review follow-ups on #149, again as a pull request into the
release branch rather than a commit on it.

Both changes come from @qodo-code-review holding its ground on two findings I
had disputed, and being right on the substance of one of them.

## The practice-mode fallback was never covered

I had defended the `mode: 'flashcard'` literals in `tests/unit/sanitize.test.ts`
as untrusted input under test. That was wrong, and the reviewer's correction is
exact: `sanitizeSession` normalises the field through
`oneOf(raw.mode, PRACTICE_MODES, 'flashcard')` at `src/lib/sanitize.ts:397`, and
those two `describe` blocks assert nothing about `mode` at all. Searching the
file confirms it — `mode` appears twice, both times as fixture filler, with no
assertion anywhere in the suite.

So the literal was not the input under test; it was scaffolding, and the
normalisation behind it had no coverage. That matters more than the literal
does: `PracticeMode` is a closed union, an unrecognised string read off a stored
document is a value the type says cannot exist, and it reaches `SessionDialog`,
which chooses its heading and its chips from that field. A drill removed in a
later version leaves sessions behind that still have to be readable, which is
what this module exists for.

Covered in both directions — an unrecognised mode reads as a flashcard run, a
recognised one is kept.

**Layer:** `tests/unit`. It is a function of its inputs, which is where
`CLAUDE.md` puts it by default.

**Proved red first.** `mode:` was reverted to `raw.mode as PracticeMode`, the
shape the guard replaces. Exactly one test failed —
`reads a session recorded in a drill this version no longer has as a flashcard run`,
with `expected 'writing' to be 'flashcard'`. `keeps a mode it does recognise`
correctly stayed green, since reading `dictation` straight through also yields
`dictation`; the two discriminate rather than restate each other.
`src/lib/sanitize.ts` is unchanged in this branch.

## The href assertion states its consequence

The reviewer maintained that `toHaveAttribute('href', '/vocabulary/w1')` needs
its impact at the assertion site, and re-reading the repository's own rule —
"If you write an assertion that looks structural, the comment above it must say
what breaks when it fails" — an assertion on an attribute reads as structural
whatever its meaning. One line, saying what a wrong target costs a reader: the
history renders and nothing in it opens.

## Checks

`yarn test:unit` 989 passed · `yarn typecheck` · `yarn format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming unsupported or invalid session modes default to flashcard mode.
  * Verified that recognized session modes, including dictation, remain unchanged.
* **Documentation**
  * Added explanatory comments clarifying navigation links in session history tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->