### PR TITLE
test: fix a timezone-dependent assertion and a font wait that synchronised nothing

### DIFF
--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -238,19 +238,28 @@ test.describe('with the network off', () => {
         };
       });
 
-    // Polled rather than read once, because `ready` settles for the layout it
-    // was asked about and a face can still arrive behind it. A precached chunk
-    // that never loads fails these three on the last attempt just as it does on
-    // the first; only a slow one is given the chance the network cannot.
+    // What breaks when this goes red: the dashboard is showing 兆候, and a
+    // headword whose characters are in no loaded face is drawn in whatever the
+    // device falls back to — legible, and in the wrong letterforms, which is
+    // the one thing a reader copying strokes off the screen must not be given.
+    //
+    // Polled as one predicate rather than gated on the count first. Every face
+    // of this family reports the same family and weight, and
+    // `src/fonts.css:2209` is a 700 face covering only kana and punctuation —
+    // it carries the header's brand mark, so it loads early and reliably while
+    // chunks 77 and 94 are still arriving. Waiting for `faces > 0` therefore
+    // waits for that face and nothing else, which is exactly the condition the
+    // note above says this test must not settle for.
+    //
+    // Polling does not soften the claim: a chunk genuinely absent from the
+    // precache fails on the last attempt as surely as on the first. The whole
+    // record is polled rather than a boolean so a timeout prints which of the
+    // two characters is missing, and whether any face loaded at all.
     await expect
-      .poll(async () => (await read()).faces, {
-        message: 'no Zen Maru Gothic 700 face loaded offline at all',
+      .poll(read, {
+        message: 'no Zen Maru Gothic 700 face covering 兆 (U+5146) and 候 (U+5019) loaded offline',
       })
-      .toBeGreaterThan(0);
-
-    const covers = await read();
-    expect(covers.cho, '兆 (U+5146) is in no loaded face').toBe(true);
-    expect(covers.ko, '候 (U+5019) is in no loaded face').toBe(true);
+      .toMatchObject({ cho: true, ko: true });
   });
 
   test('keeps every font chunk a file, so the runtime half cannot ride into the precache', async ({

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -209,29 +209,46 @@ test.describe('with the network off', () => {
     // is drawn in Zen Maru Gothic 700 too — so a test that asked only whether
     // *a* 700 face had loaded would stay green with 兆 and 候 both missing from
     // the precache, which is the one thing it is here to notice.
-    await page.waitForFunction(() => document.fonts.status === 'loaded');
-    const covers = await page.evaluate(() => {
-      const inRange = (range: string, cp: number) =>
-        range.split(',').some((part) => {
-          const [start, end] = part.trim().replace(/^u\+/i, '').split('-');
-          const low = parseInt(start ?? '', 16);
-          return cp >= low && cp <= (end === undefined ? low : parseInt(end, 16));
-        });
-      const loaded = [...document.fonts].filter(
-        (face) =>
-          face.family.replace(/["']/g, '') === 'Zen Maru Gothic' &&
-          face.weight === '700' &&
-          face.status === 'loaded',
-      );
-      return {
-        faces: loaded.length,
-        // 兆 and 候 — the headword the dashboard is showing.
-        cho: loaded.some((face) => inRange(face.unicodeRange, 0x5146)),
-        ko: loaded.some((face) => inRange(face.unicodeRange, 0x5019)),
-      };
-    });
+    // `document.fonts.ready`, not `status === 'loaded'`. `status` reports
+    // whether the font loading process is *currently* active, so it reads
+    // `loaded` before any face has begun — including on the tick this reload
+    // arrives, ahead of the layout that asks for Zen Maru Gothic at all. The
+    // wait then returns immediately and the single read below reports no faces
+    // on a build that is correct.
+    await page.evaluate(() => document.fonts.ready.then(() => undefined));
+    const read = () =>
+      page.evaluate(() => {
+        const inRange = (range: string, cp: number) =>
+          range.split(',').some((part) => {
+            const [start, end] = part.trim().replace(/^u\+/i, '').split('-');
+            const low = parseInt(start ?? '', 16);
+            return cp >= low && cp <= (end === undefined ? low : parseInt(end, 16));
+          });
+        const loaded = [...document.fonts].filter(
+          (face) =>
+            face.family.replace(/["']/g, '') === 'Zen Maru Gothic' &&
+            face.weight === '700' &&
+            face.status === 'loaded',
+        );
+        return {
+          faces: loaded.length,
+          // 兆 and 候 — the headword the dashboard is showing.
+          cho: loaded.some((face) => inRange(face.unicodeRange, 0x5146)),
+          ko: loaded.some((face) => inRange(face.unicodeRange, 0x5019)),
+        };
+      });
 
-    expect(covers.faces, 'no Zen Maru Gothic 700 face loaded offline at all').toBeGreaterThan(0);
+    // Polled rather than read once, because `ready` settles for the layout it
+    // was asked about and a face can still arrive behind it. A precached chunk
+    // that never loads fails these three on the last attempt just as it does on
+    // the first; only a slow one is given the chance the network cannot.
+    await expect
+      .poll(async () => (await read()).faces, {
+        message: 'no Zen Maru Gothic 700 face loaded offline at all',
+      })
+      .toBeGreaterThan(0);
+
+    const covers = await read();
     expect(covers.cho, '兆 (U+5146) is in no loaded face').toBe(true);
     expect(covers.ko, '候 (U+5019) is in no loaded face').toBe(true);
   });

--- a/tests/unit/devSeed.test.ts
+++ b/tests/unit/devSeed.test.ts
@@ -57,12 +57,19 @@ describe('devSeed', () => {
    * the day somebody typed the fixture in.
    */
   it('moves its dates with the clock rather than being pinned to the day it was written', () => {
-    const later = devSeed(new Date('2027-03-04T10:00:00+09:00'));
+    const laterNow = new Date('2027-03-04T10:00:00+09:00');
+    const later = devSeed(laterNow);
     const newest = (data: typeof seed) =>
       (data.entries ?? []).map((entry) => entry.learnedOn ?? '').sort();
 
     expect(newest(seed).at(-1)).toBe(dateKey(NOW));
-    expect(newest(later).at(-1)).toBe('2027-03-04');
+    // Through `dateKey`, like the line above it, rather than as the calendar
+    // date the instant was written as. `dateKey` reads `getFullYear`,
+    // `getMonth` and `getDate`, which are local — and nothing pins `TZ` for
+    // this suite, so `2027-03-04T01:00Z` is the third of March on any runner
+    // two hours or more behind UTC. Hard-coded, this passed in the timezone it
+    // was written in and failed across the Atlantic.
+    expect(newest(later).at(-1)).toBe(dateKey(laterNow));
   });
 
   /** Signed in, or the dev server still opens on the login screen. */


### PR DESCRIPTION
Fourth and final round of follow-ups on #149. Both findings are from
@coderabbitai's full review, both are against tests that shipped in 1.1.0, and
both are test-only.

## The dev-seed assertion depended on the runner's timezone

`dateKey` reads `getFullYear`, `getMonth` and `getDate` — local time — and
nothing pins `TZ` in `vitest.config.ts`, `package.json` or `ci.yml`. The instant
the test hands `devSeed` is `2027-03-04T10:00:00+09:00`, which is
`2027-03-04T01:00Z`, so on any runner two hours or more behind UTC the local
date is the third of March and `toBe('2027-03-04')` fails.

Derived through `dateKey` now, exactly like the assertion on the line above it,
which was already right.

**Measured rather than reasoned about:**

| code | `TZ` | result |
| --- | --- | --- |
| fixed | `America/New_York` | 6 passed |
| hard-coded literal restored | `America/New_York` | `expected '2027-03-03' to be '2027-03-04'` |
| hard-coded literal restored | `Asia/Tokyo` | 6 passed |

CI runs UTC, which is why this never surfaced. It would have met the next
contributor west of the Atlantic as a failure in a test they had not touched.

## The font wait was returning immediately

`document.fonts.status` reports whether the font loading process is *currently*
active, so it reads `loaded` before any face has begun — not only after they all
have. `await page.waitForFunction(() => document.fonts.status === 'loaded')`
therefore passed on its first check.

Confirmed with a probe rather than assumed. Reading the value immediately after
the offline reload, before any wait:

```
[probe] immediately after goto: {"status":"loaded","zenMaru700":8}
```

So the guard was synchronising nothing, and the three assertions behind it were
reading whatever had happened to load by that point. It passed because eight
faces were already there — not because anything had waited for them.

The read is now behind `document.fonts.ready` and the face count is polled. This
does not weaken the claim: a precached chunk that never loads fails on the last
attempt exactly as it did on the first, and the two code-point assertions still
run once, against the settled list. Only a slow face gets the time that offline
cannot otherwise give it.

## Checks

`yarn test:unit` 989 passed · `yarn test:e2e offline.spec.ts` 7 passed ·
`yarn typecheck` · `yarn format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved offline font-loading coverage checks to accommodate delayed font availability.
  - Updated date-shifting validation to derive expected dates dynamically, making tests more reliable across execution dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->