### PR TITLE
fix(entry-form): render and store parts of speech in POS order

### DIFF
--- a/src/components/entry-form/EntryForm.tsx
+++ b/src/components/entry-form/EntryForm.tsx
@@ -1,22 +1,13 @@
 import { chipClass, DateControl, SelectControl } from '@/components/controls';
-import type { EntryDraft, Pos } from '@/domain/entry';
+import type { EntryDraft } from '@/domain/entry';
 import { JLPT_LEVELS, POLITENESS, POS, STYLES, WORD_ORIGINS } from '@/domain/entry';
 import { ENTRY_LIMITS, TAG_INPUT_MAX } from '@/domain/limits';
 import { useI18n } from '@/i18n/context';
 import { useEntryLabel } from '@/i18n/useEntryLabel';
-import { parseTags } from '@/lib/draft';
+import { parseTags, togglePos } from '@/lib/draft';
 import { accentKana } from '@/lib/mora';
 import { Area, Field, RepeatableList, Select, Text } from './fields';
 import { PitchAccentField } from './PitchAccentField';
-
-/**
- * Order is not preserved: 品詞 is a set, and `POS` is the order it renders in.
- * Written out rather than reused from the filter panels because those toggle
- * `string[]` and this has to stay a `Pos[]` for the draft.
- */
-function togglePos(list: Pos[], value: Pos): Pos[] {
-  return list.includes(value) ? list.filter((item) => item !== value) : [...list, value];
-}
 
 export function EntryForm({
   draft,

--- a/src/lib/draft.ts
+++ b/src/lib/draft.ts
@@ -1,6 +1,7 @@
 import type { IsoDate } from '@/domain/common';
 import { TAG_PATTERN } from '@/domain/common';
-import type { Entry, EntryDraft } from '@/domain/entry';
+import type { Entry, EntryDraft, Pos } from '@/domain/entry';
+import { POS } from '@/domain/entry';
 import { ENTRY_LIMITS } from '@/domain/limits';
 import { isValidIsoDate } from './dates';
 import { accentKana, accentProblem } from './mora';
@@ -264,4 +265,22 @@ export function invalidTags(tags: string[]): string[] {
  */
 export function validTags(tags: string[]): string[] {
   return tags.filter((tag) => TAG_PATTERN.test(tag));
+}
+
+/**
+ * Adds or removes one part of speech, and returns the set in `POS` order.
+ *
+ * 品詞 is a set, and `POS` is the order it renders in — but appending put the
+ * draft in click order and nothing downstream sorted it. `EntryHeadline` and
+ * the manifest row in `EntryBody` both map `entry.pos` as stored, and
+ * `sanitizeEntry` filters it without reordering, so the same two parts of
+ * speech read 名詞／動詞 or 動詞／名詞 depending on which chip was pressed
+ * first — and that order was written to Firestore and came back that way.
+ *
+ * Kept apart from the filter panels' `toggle`, which works on `string[]`;
+ * this has to stay a `Pos[]` for the draft.
+ */
+export function togglePos(list: Pos[], value: Pos): Pos[] {
+  const next = list.includes(value) ? list.filter((item) => item !== value) : [...list, value];
+  return POS.filter((part) => next.includes(part));
 }

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -41,6 +41,25 @@ export { isValidIsoDate };
 const str = (value: unknown): string =>
   typeof value === 'string' ? value : typeof value === 'number' ? String(value) : '';
 
+/**
+ * 品詞 as a set, in the order it renders in.
+ *
+ * `POS.filter` rather than a filter over the stored list, so this normalises as
+ * well as validates. Nothing downstream sorts `pos` — `EntryHeadline` and the
+ * manifest row in `EntryBody` map it as stored — so a document written in the
+ * order its chips were pressed, or imported from an assistant that listed them
+ * its own way, is drawn in that order forever. Reading it through the canonical
+ * order settles it for every note already in the notebook, which toggling a
+ * chip cannot: a reader who never touches 品詞 never rewrites it.
+ *
+ * De-duplication comes with it, and is wanted for the same reason: a set that
+ * lists 名詞 twice is not one.
+ */
+const posList = (value: unknown): (typeof POS)[number][] => {
+  const stored = strings(value);
+  return POS.filter((part) => stored.includes(part));
+};
+
 const oneOf = <T extends string>(value: unknown, allowed: readonly T[], fallback: T): T =>
   typeof value === 'string' && (allowed as readonly string[]).includes(value)
     ? (value as T)
@@ -197,9 +216,7 @@ export function sanitizeDraft(value: unknown, fallback: EntryDraft = emptyDraft(
     headword: str(raw.headword).trim() || fallback.headword,
     reading: str(raw.reading) || fallback.reading,
     pitchAccent: pitchAccent(raw.pitchAccent),
-    pos: strings(raw.pos).filter((p): p is (typeof POS)[number] =>
-      (POS as readonly string[]).includes(p),
-    ),
+    pos: posList(raw.pos),
     jlpt: oneOf(raw.jlpt, JLPT_LEVELS, fallback.jlpt),
     origin: oneOfOptional(raw.origin, WORD_ORIGINS),
     style: oneOfOptional(raw.style, STYLES),

--- a/tests/unit/draft.test.ts
+++ b/tests/unit/draft.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { EntryDraft, Pos } from '@/domain/entry';
+import type { EntryDraft } from '@/domain/entry';
 import { POS } from '@/domain/entry';
 import { ENTRY_LIMITS } from '@/domain/limits';
 import {
@@ -389,10 +389,9 @@ describe('togglePos', () => {
   });
 
   it('removes one without disturbing the order of the rest', () => {
-    const three = POS.slice(0, 3) as Pos[];
-    const [, second] = three;
+    const [first, second, third] = POS;
 
-    expect(togglePos(three, second as Pos)).toEqual([three[0], three[2]]);
+    expect(togglePos([first, second, third], second)).toEqual([first, third]);
   });
 
   it('adds one that was not there and drops one that was', () => {

--- a/tests/unit/draft.test.ts
+++ b/tests/unit/draft.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { EntryDraft } from '@/domain/entry';
+import type { EntryDraft, Pos } from '@/domain/entry';
+import { POS } from '@/domain/entry';
 import { ENTRY_LIMITS } from '@/domain/limits';
 import {
   describeSizeProblem,
@@ -9,6 +10,7 @@ import {
   invalidTags,
   parseTags,
   toDraft,
+  togglePos,
 } from '@/lib/draft';
 import { wordSetError } from '@/lib/wordSetDraft';
 import { makeEntry } from '../fixtures/entry';
@@ -364,5 +366,37 @@ describe('wordSetError', () => {
    */
   it('measures the trimmed value, which is what the write path sends', () => {
     expect(wordSetError({ ...ok, name: `${'あ'.repeat(30)}   ` })).toBeNull();
+  });
+});
+
+/**
+ * 品詞 is a set, and the order it renders in is `POS`.
+ *
+ * Nothing downstream sorts it: `EntryHeadline` and the manifest row in
+ * `EntryBody` map `entry.pos` as stored, and `sanitizeEntry` filters without
+ * reordering. So an order that came out of the form in the order the chips
+ * were pressed is the order that reached Firestore, came back, and was drawn —
+ * two readers with the same two parts of speech seeing 名詞／動詞 and
+ * 動詞／名詞.
+ */
+describe('togglePos', () => {
+  it('returns the same order however the chips were pressed, which is what the display and the stored draft both take as given', () => {
+    const forwards = togglePos(togglePos([], '名詞'), '動詞');
+    const backwards = togglePos(togglePos([], '動詞'), '名詞');
+
+    expect(forwards).toEqual(backwards);
+    expect(forwards).toEqual(POS.filter((part) => part === '名詞' || part === '動詞'));
+  });
+
+  it('removes one without disturbing the order of the rest', () => {
+    const three = POS.slice(0, 3) as Pos[];
+    const [, second] = three;
+
+    expect(togglePos(three, second as Pos)).toEqual([three[0], three[2]]);
+  });
+
+  it('adds one that was not there and drops one that was', () => {
+    expect(togglePos([], '名詞')).toEqual(['名詞']);
+    expect(togglePos(['名詞'], '名詞')).toEqual([]);
   });
 });

--- a/tests/unit/draft.test.ts
+++ b/tests/unit/draft.test.ts
@@ -381,11 +381,13 @@ describe('wordSetError', () => {
  */
 describe('togglePos', () => {
   it('returns the same order however the chips were pressed, which is what the display and the stored draft both take as given', () => {
-    const forwards = togglePos(togglePos([], '名詞'), '動詞');
-    const backwards = togglePos(togglePos([], '動詞'), '名詞');
+    // Taken from `POS` rather than named, because which two parts of speech
+    // these are is not the claim — that they come back in the order `POS`
+    // lists them, whichever was pressed first, is.
+    const [first, second] = POS;
 
-    expect(forwards).toEqual(backwards);
-    expect(forwards).toEqual(POS.filter((part) => part === '名詞' || part === '動詞'));
+    expect(togglePos(togglePos([], second), first)).toEqual([first, second]);
+    expect(togglePos(togglePos([], first), second)).toEqual([first, second]);
   });
 
   it('removes one without disturbing the order of the rest', () => {
@@ -395,7 +397,9 @@ describe('togglePos', () => {
   });
 
   it('adds one that was not there and drops one that was', () => {
-    expect(togglePos([], '名詞')).toEqual(['名詞']);
-    expect(togglePos(['名詞'], '名詞')).toEqual([]);
+    const [first] = POS;
+
+    expect(togglePos([], first)).toEqual([first]);
+    expect(togglePos([first], first)).toEqual([]);
   });
 });

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { POS } from '@/domain/entry';
 import { toDraft } from '@/lib/draft';
 import {
   isValidIsoDate,
@@ -467,6 +468,35 @@ describe('sanitizeProgressMap', () => {
  * be recovered. So the reader takes both, and the old shape reads back as a
  * snapshot with nothing in it, which is what it is.
  */
+/**
+ * 品詞 read back from a document nobody is editing.
+ *
+ * `togglePos` puts the form's own list in `POS` order, but a reader who never
+ * touches a 品詞 chip never rewrites the field — so every note stored before
+ * that, and every note imported from an assistant that listed them its own way,
+ * would keep the order it arrived in. `EntryHeadline` and the manifest row in
+ * `EntryBody` map `pos` as stored, so that order is what is drawn.
+ */
+describe('sanitizeEntry — 品詞 as a set', () => {
+  it('reads a stored order back in the order the app renders, so a note nobody edits stops disagreeing with one that was', () => {
+    const [first, second] = POS;
+
+    expect(sanitizeEntry('e1', { pos: [second, first] }).pos).toEqual([first, second]);
+  });
+
+  it('drops a repeat rather than drawing the same part of speech twice', () => {
+    const [first] = POS;
+
+    expect(sanitizeEntry('e1', { pos: [first, first] }).pos).toEqual([first]);
+  });
+
+  it('still refuses a value that is not a part of speech at all', () => {
+    const [first] = POS;
+
+    expect(sanitizeEntry('e1', { pos: [first, 'ヌルポ', 42, null] }).pos).toEqual([first]);
+  });
+});
+
 describe('sanitizeSession — the missed list, in both shapes it is stored in', () => {
   const stored = (missed: unknown) => ({
     mode: 'flashcard',


### PR DESCRIPTION
Four review threads on #149 were left unanswered — the `@coderabbitai` full
review posted six comments in one batch and only two were picked up. This
closes the other four: one is fixed here, one is filed, two are disputed with
reasoning on the threads.

## Fixed: parts of speech kept their click order

`togglePos` carried a comment describing the property it did not have:

> Order is not preserved: 品詞 is a set, and `POS` is the order it renders in.

Appending put the draft in click order, and nothing downstream sorts it.
`EntryHeadline` (Line 60) and the manifest row in `EntryBody` both map
`entry.pos` as stored, and `sanitizeEntry` (`sanitize.ts:200`) filters it
without reordering. So the same two parts of speech read 名詞／動詞 or
動詞／名詞 depending on which chip was pressed first — and that order was
written to Firestore, came back, and was drawn.

**Layer: `tests/unit`.** It is a function of its inputs, which is where
`CLAUDE.md` puts it by default. The function moved to `lib/draft` beside
`parseTags` — which `EntryForm` already imports from — so the claim is covered
without adding a test to `EntryForm.tsx`, a file `CLAUDE.md` deliberately leaves
to one end-to-end save.

**Proved red first.** With the append restored, exactly one of the three new
tests failed:
`expected [ '名詞', '動詞' ] to deeply equal [ '動詞', '名詞' ]`. The other two
stayed green, because removal and add/drop do not depend on the normalisation —
they discriminate rather than restate.

## Filed: the clipboard paste does not report itself busy — #161

Real and narrow. `pasting` is local to `JsonImport`; the modal footer's 読み込む
is `disabled={!json.raw.trim() || drafting}` (`EntryFormModal.tsx:444`) and does
not see it. A clipboard permission prompt can hold `readText()` open for
seconds with the footer live.

Not taken here because the remedy runs through the form's busy-state plumbing
and `onBusyChange(true, request)` also clears `aiError` and `handedOff` — the
reviewer flagged that itself — so it wants a decision about whether a paste
should do that, not a five-line patch before a release.

## Disputed

**`EntryBody.tsx:59`, an empty manifest section.** Unreachable. `manifest` is
filtered on truthiness, but `jlpt` is a required field of a closed union —
`JLPT_LEVELS` has no blank member — and `useEntryLabel` returns the raw value
when no translation key matches, never `''`. The JLPT row is therefore always
present and the proposed guard is dead code.

**`backend.e2e.ts:73`, the fallback seed's clock.** Deliberate and documented on
the six lines above it: `devSeed` reads the clock, so a per-call value would
have the notebook and the heatmap disagree across midnight, and
`entryDraftingPort` compares the seed **by identity**. It is also unreachable
from any test — the `MODE === 'e2e'` guard excludes vitest and every end-to-end
spec injects its own seed — so the path instruction's condition, logic a test
would need to pin down, does not hold. `devSeed` itself takes `now` and is
covered that way.

## Checks

`yarn test:unit` 992 passed · `yarn test:e2e vocabulary.spec.ts` 41 passed ·
`yarn typecheck` · `yarn format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Part-of-speech selections now remain in a consistent order regardless of the order in which options are selected.
  * Removing a selection preserves the order of the remaining options.

* **Tests**
  * Added coverage for adding, removing, and consistently ordering part-of-speech selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->