### PR TITLE
fix: pin visual test container architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,10 @@ against — or written over — the Chromium file beside it.
   A screenshot diff is a bug report. Investigate it, fix the cause, and if the
   new rendering really is correct, ask the user to regenerate.
 - Regeneration is `yarn test:visual:update`, which runs in the same container
-  image CI uses. Never run `--update-snapshots` outside it: a macOS-authored
-  baseline fails on every CI run.
+  image and `linux/amd64` architecture CI uses. Both are pinned because font
+  rasterisation depends on the container and machine architecture. Never run
+  `--update-snapshots` outside it: a baseline authored by a different renderer
+  fails on CI.
 - Prefer `locator.toHaveScreenshot()` over a full-page shot. Do not add a new
   full-page baseline without asking.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:emulator": "firebase emulators:exec --only firestore --project demo-goitei 'vitest run --project emulator'",
     "test:e2e": "playwright test",
     "test:monkey": "playwright test --config playwright.monkey.config.ts",
-    "test:visual:update": "docker run --rm --init --ipc=host -v \"$PWD\":/w -v goitei-e2e-modules:/w/node_modules -w /w mcr.microsoft.com/playwright:v1.62.1-noble sh -c \"yarn install --frozen-lockfile && npx playwright test tests/e2e/visual.spec.ts --update-snapshots\"",
+    "test:visual:update": "docker run --rm --init --ipc=host --platform linux/amd64 -v \"$PWD\":/w -v goitei-e2e-modules-amd64:/w/node_modules -w /w mcr.microsoft.com/playwright:v1.62.1-noble sh -c \"yarn install --frozen-lockfile && npx playwright test tests/e2e/visual.spec.ts --update-snapshots\"",
     "coverage": "vitest run --project unit --project dom --coverage",
     "release": "commit-and-tag-version",
     "release:dry": "commit-and-tag-version --dry-run",


### PR DESCRIPTION
## Summary

- pin visual baseline regeneration to the `linux/amd64` architecture used by CI
- isolate the amd64 container dependencies in `goitei-e2e-modules-amd64`
- document why both the Playwright image and machine architecture are pinned

Closes #139

## Testing

Test layer: no automated test was added because this changes the Docker runner configuration rather than application behaviour. The container architecture was verified directly.

- `yarn format`
- `docker run --rm --platform linux/amd64 mcr.microsoft.com/playwright:v1.62.1-noble uname -m` returns `x86_64`
- parsed `package.json` and asserted the script contains the pinned platform and volume
- `git diff --check`

The snapshot update command was not run, so no existing baselines were regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved visual test snapshot consistency by standardizing screenshot updates in the pinned test environment.
  * Added architecture-specific test execution to reduce differences between local and CI results.

* **Documentation**
  * Clarified the required environment and process for regenerating visual test baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->