### PR TITLE
test(sanitize): use practice mode constants

### DIFF
--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -40,7 +40,8 @@ test.describe('dashboard', () => {
     // overflow asserted above appears when the row is laid out, and the pin is
     // written by an effect after that — so a single pair of reads can land in
     // between and measure the unpinned position. This is the assertion that
-    // owns the claim, which is why it is the one hardened.
+    // owns the claim: without it, a reader opens the dashboard on older weeks
+    // and has to drag sideways to reach today's progress.
     await expect
       .poll(
         async () => {

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { POS } from '@/domain/entry';
+import { PRACTICE_MODES } from '@/domain/practice';
 import { toDraft } from '@/lib/draft';
 import {
   isValidIsoDate,
@@ -32,6 +33,8 @@ const FALLBACK = toDraft(
     learnedOn: '2020-01-01',
   }),
 );
+
+const [FLASHCARD_MODE, DICTATION_MODE] = PRACTICE_MODES;
 
 describe('isValidIsoDate', () => {
   /**
@@ -499,7 +502,7 @@ describe('sanitizeEntry — 品詞 as a set', () => {
 
 describe('sanitizeSession — the missed list, in both shapes it is stored in', () => {
   const stored = (missed: unknown) => ({
-    mode: 'flashcard',
+    mode: FLASHCARD_MODE,
     filterLabel: 'すべて',
     total: 3,
     correct: 1,
@@ -557,11 +560,11 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
     // half of it is shared with every other enum field and is already covered
     // by `falls back when jlpt is outside the scale` — asserting it again here
     // would test the helper a second time rather than this field's wiring.
-    expect(sanitizeSession('s1', { ...stored([]), mode: 'writing' }).mode).toBe('flashcard');
+    expect(sanitizeSession('s1', { ...stored([]), mode: 'writing' }).mode).toBe(FLASHCARD_MODE);
   });
 
   it('keeps a mode it does recognise', () => {
-    expect(sanitizeSession('s1', { ...stored([]), mode: 'dictation' }).mode).toBe('dictation');
+    expect(sanitizeSession('s1', { ...stored([]), mode: DICTATION_MODE }).mode).toBe(DICTATION_MODE);
   });
 });
 
@@ -574,7 +577,7 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
  */
 describe('sanitizeSession — the run', () => {
   const stored = (over: Record<string, unknown>) => ({
-    mode: 'flashcard',
+    mode: FLASHCARD_MODE,
     filterLabel: 'すべて',
     total: 2,
     correct: 1,

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -437,7 +437,7 @@ describe('sanitizeEntry — a document from the previous schema', () => {
 describe('sanitizeProgressMap', () => {
   it('keeps the good rows when one key holds something unusable', () => {
     const rows = sanitizeProgressMap({
-      good: { status: 'correct', lastMode: 'dictation', attempts: 2, correctCount: 2 },
+      good: { status: 'correct', lastMode: DICTATION_MODE, attempts: 2, correctCount: 2 },
       broken: 'not an object',
     });
 
@@ -564,7 +564,9 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
   });
 
   it('keeps a mode it does recognise', () => {
-    expect(sanitizeSession('s1', { ...stored([]), mode: DICTATION_MODE }).mode).toBe(DICTATION_MODE);
+    expect(sanitizeSession('s1', { ...stored([]), mode: DICTATION_MODE }).mode).toBe(
+      DICTATION_MODE,
+    );
   });
 });
 

--- a/tests/unit/sanitize.test.ts
+++ b/tests/unit/sanitize.test.ts
@@ -563,7 +563,7 @@ describe('sanitizeSession — the missed list, in both shapes it is stored in', 
     expect(sanitizeSession('s1', { ...stored([]), mode: 'writing' }).mode).toBe(FLASHCARD_MODE);
   });
 
-  it('keeps a mode it does recognise', () => {
+  it('does not fall back for a recognized dictation mode', () => {
     expect(sanitizeSession('s1', { ...stored([]), mode: DICTATION_MODE }).mode).toBe(
       DICTATION_MODE,
     );


### PR DESCRIPTION
## Summary

Closes #164.

- Explain the user-visible mobile heatmap outcome beside its bounding-box assertion.
- Derive all recognised practice mode fixtures from PRACTICE_MODES.
- Keep only the intentionally invalid writing mode inline.

## Test layer

Unit is the appropriate layer for the sanitizer fixture contract because it is pure input validation. The dashboard change is comment-only and does not change Playwright behaviour.

## Verification

- yarn test:unit
- yarn typecheck
- yarn vitest run --project unit tests/unit/sanitize.test.ts
- yarn format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified dashboard end-to-end test coverage to better document the expected starting point for the heatmap and prevent regressions involving older weeks.
  * Updated sanitizer tests to use shared practice-mode constants, improving consistency and reducing the risk of tests becoming outdated when supported modes change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->