### PR TITLE
fix(import): pass the JSON import clock explicitly

### DIFF
--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -290,7 +290,7 @@ export function EntryFormModal({
       written it, so both are setting the value they read.
     */
     setJson((prev) => ({ ...prev, raw }));
-    const { draft: loaded, error: failure, oversize } = jsonToDraft(raw, context);
+    const { draft: loaded, error: failure, oversize } = jsonToDraft(raw, context, new Date());
 
     /*
       A reply that arrived and could not be used is still a reply.

--- a/src/lib/jsonImport.ts
+++ b/src/lib/jsonImport.ts
@@ -198,7 +198,7 @@ function delimiterMayStandAt(text: string, from: number): boolean {
 export function jsonToDraft(
   raw: string,
   context: PromptContext = {},
-  now: Date = new Date(),
+  now: Date,
 ): { draft?: EntryDraft; error?: string; oversize?: string[] } {
   // Before the parse, not after: `JSON.parse` on a multi-megabyte paste blocks
   // the main thread long enough to read as a hung tab, and every check below

--- a/tests/unit/jsonImport.test.ts
+++ b/tests/unit/jsonImport.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { INPUT_LIMITS } from '@/domain/limits';
-import { buildPrompt, jsonToDraft, promptLanguageName, SCHEMA } from '@/lib/jsonImport';
+import {
+  buildPrompt,
+  jsonToDraft as parseJsonToDraft,
+  promptLanguageName,
+  SCHEMA,
+} from '@/lib/jsonImport';
 
 /**
  * The import box takes JSON an assistant wrote somewhere else and a human
@@ -11,6 +16,13 @@ import { buildPrompt, jsonToDraft, promptLanguageName, SCHEMA } from '@/lib/json
  */
 
 const minimal = { headword: '兆候', definition: '何かが起こる前ぶれ。' };
+const testNow = new Date(2026, 7, 24);
+
+const jsonToDraft = (
+  raw: string,
+  context: Parameters<typeof parseJsonToDraft>[1] = {},
+  now: Date = testNow,
+) => parseJsonToDraft(raw, context, now);
 
 describe('jsonToDraft — parsing', () => {
   it('accepts a bare JSON object', () => {


### PR DESCRIPTION
## Summary

Closes #155

Require callers of `jsonToDraft` to provide the import clock explicitly, while preserving the existing behaviour of assigning the current date at the entry-form boundary.

## Changes

- remove the `new Date()` default from `jsonToDraft`
- pass the current time from `EntryFormModal`
- give JSON import unit tests a fixed clock

## Testing

Unit layer: this change is a pure function dependency contract, so unit and TypeScript checks cover it.

- `yarn vitest run --project unit tests/unit/jsonImport.test.ts --reporter=dot` (52 passed)
- `yarn typecheck`
- `yarn format`
- `yarn test:unit --reporter=dot` (994 passed, 1 unrelated failure: `tests/unit/fontConfig.test.ts` cannot find `noto-sans-jp-119-400-normal.woff2` in local `node_modules`)

Regression proof: after removing the default, `yarn typecheck` failed at `EntryFormModal.tsx` because the caller omitted the clock; it passed after the boundary supplied `new Date()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported entries are now validated against the current date, improving handling of date-sensitive draft data.

* **Tests**
  * Added deterministic date handling to improve the reliability and consistency of import validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->