### PR TITLE
feat(rules): open signups to any verified account

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -257,12 +257,16 @@ jobs:
       # first means a client is briefly newer than its rules, which fails open:
       # it writes a shape the old rules still permit.
       #
-      # **Two steps come before this workflow runs, and it cannot check them.**
-      # These rules gate on a custom claim, which reaches a client only in a
-      # freshly minted ID token — so every account must be granted with
-      # `yarn allow` and must sign in again first, or it is locked out for up to
-      # an hour. See "Operator runbook" in README.md, which is in the working
-      # tree after merge in a way a pull request description is not.
+      # **No step comes before this workflow any more.** These rules used to
+      # gate on a custom claim, which reaches a client only in a freshly minted
+      # ID token, so every account had to be granted with `yarn allow` and sign
+      # in again first or be locked out for up to an hour. Signups are open and
+      # the gate is `signedIn()`, so there is nothing to grant.
+      #
+      # It comes back the moment `isAllowed()` does. Deploying rules that
+      # require the claim before granting it locks out the operator too — see
+      # "Operator runbook" in README.md, which is in the working tree after
+      # merge in a way a pull request description is not.
       - name: Deploy Firestore rules
         run: yarn firebase deploy --only firestore:rules --project prod --non-interactive
 

--- a/README.md
+++ b/README.md
@@ -373,12 +373,16 @@ Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth
 application-default login` against the right project.
 
 **Closing signups again.** The rules no longer read the `allowed` claim, so
-`yarn allow` grants nothing today. It is kept, and so are the `allowedUsers`
-documents, because restoring `isAllowed()` in `firestore.rules` is how the door
-shuts — and a rules deploy that lands after the claims have been tidied away
-locks out the operator along with everybody else. So the order is: grant the
-accounts that must keep working, have them sign out and back in, _then_ deploy
-the closed rules.
+`yarn allow` grants nothing today. It is kept because restoring `isAllowed()` in
+`firestore.rules` is how the door shuts, and those rules require a claim that no
+token issued beforehand carries — so a deploy that lands before the grants locks
+out the operator along with everybody else. The order is: grant the accounts that
+must keep working, have them sign out and back in, _then_ deploy the closed rules.
+
+The state that matters is the claim and nothing else. `yarn allow` sets it with
+`setCustomUserClaims` and writes no document; `allowedUsers` is the collection
+the claim replaced, and nothing in the rules or in `src` reads it. Whatever
+remains in it is legacy.
 
 `yarn allow you@example.com prod` targets the repository production project, and
 `yarn allow you@example.com --project your-project-id` targets any other Firebase

--- a/README.md
+++ b/README.md
@@ -79,27 +79,21 @@ Pointing this at a fresh Firebase project takes a few more steps, in order:
 4. `yarn firebase login`, then deploy the rules with `yarn rules:dev` (once the
    alias points at your project) or
    `yarn firebase deploy --only firestore:rules --project <your-project-id>`.
-5. Sign in once, then grant yourself access — the rules deny everything until
-   your account carries the `allowed` custom claim. `yarn allow <your-email> --project <your-project-id>`
-   sets it, and the account must have signed in
-   before that, because the claim goes on the uid Google issued and there is
-   nothing to set it on until then. The repository shortcuts still work too:
-   omit `--project` for `goitei-dev`, or pass `prod` for `goitei`.
-6. **Sign out and sign back in.** A claim reaches the client only in a freshly
-   minted ID token, so the session you granted access to is still denied — for
-   up to an hour, until its token expires on its own.
+5. Sign in. That is the whole of it: signups are open, so a verified Google
+   account gets its own notebook and nothing has to be granted.
 
 `firebase-tools` is a local devDependency, so the CLI is reached through
 `yarn firebase …` unless you have installed it globally.
 
 Step 3 only changes local configuration; nothing is enforced until step 4
-deploys the rules successfully. After step 6 every read and write is scoped to
+deploys the rules successfully. After step 5 every read and write is scoped to
 your account.
 
-Step 6 is a step rather than a note because leaving it out looks exactly like a
-broken build: every screen reports that it could not load, and running step 5
-again changes nothing. `yarn allow` prints the account it granted, so the last
-line of step 5 is not evidence that step 6 has happened.
+**This used to be two more steps**, because the rules denied everything until an
+operator granted the `allowed` custom claim with `yarn allow` and the account
+signed out and back in to pick it up. That gate is gone from the rules and the
+tooling is not: `yarn allow` is how signups close again, and the operator runbook
+below says why it is still here.
 
 `.env.development` and `.env.production` are gitignored. Their values ship inside
 the JS bundle and are not secrets — Firestore rules are what enforce access — but
@@ -230,11 +224,18 @@ yarn firebase deploy --only hosting,firestore:rules --project dev
 ```
 
 `firestore.rules` gives an account read and write over everything beneath its
-own `users/{uid}`, and nothing else; every unlisted path is denied. Access is
-gated on the custom claim `allowed`, which nothing but `yarn allow` sets, so
-signups are closed until an operator grants it. Nothing in front of the site can
-substitute for this: Hosting serves the config that reaches Firestore, so a
+own `users/{uid}`, and nothing else; every unlisted path is denied. **Signups are
+open**: any Google account with a verified email gets a notebook, and no operator
+step stands between signing in and using the app. Nothing in front of the site can
+substitute for the rules: Hosting serves the config that reaches Firestore, so a
 password on the HTML protects the page, not the data.
+
+What the rules do _not_ do is bound how much one account writes. There is no rate
+limit and no cap on how many documents an account creates, because rules see one
+write at a time and have no clock across requests. Those bounds live outside this
+repository — a per-user quota override on the AI proxy, Cloud Monitoring alerts on
+the free Firestore quotas — and the reason an exhausted quota is survivable is the
+Spark plan: it stops serving until the quota resets rather than producing a bill.
 
 Rules deploy before anything that writes through them, so a new top-level field
 is allowlisted before any client can send it. A client that ships a new field
@@ -371,19 +372,31 @@ browser against the dev site or a preview channel.
 Everything below assumes `GOOGLE_APPLICATION_CREDENTIALS`, or `gcloud auth
 application-default login` against the right project.
 
-**Granting access.** `yarn allow you@example.com prod` targets the repository
-production project, and `yarn allow you@example.com --project your-project-id`
-targets any other Firebase project. The account must have signed in once first
-— the claim is set on the uid Google issued, so there is nothing to set it on
-before that. Anything other than `prod`, `--project <project-id>` or
-`--revoke` is rejected rather than ignored.
+**Closing signups again.** The rules no longer read the `allowed` claim, so
+`yarn allow` grants nothing today. It is kept, and so are the `allowedUsers`
+documents, because restoring `isAllowed()` in `firestore.rules` is how the door
+shuts — and a rules deploy that lands after the claims have been tidied away
+locks out the operator along with everybody else. So the order is: grant the
+accounts that must keep working, have them sign out and back in, _then_ deploy
+the closed rules.
 
-**Revoking it.** `yarn allow you@example.com prod --revoke`. **This lands within
-the hour, not on the keystroke.** The claim lives inside the ID token the client
-already holds and Firestore rules have no revocation check, so it keeps working
-until that token expires. Revoking the refresh tokens ends the session at the
-next refresh but does not shorten that window. When responding to abuse, delete
-the data — that part takes effect now.
+`yarn allow you@example.com prod` targets the repository production project, and
+`yarn allow you@example.com --project your-project-id` targets any other Firebase
+project. The account must have signed in once first — the claim is set on the uid
+Google issued, so there is nothing to set it on before that. Anything other than
+`prod`, `--project <project-id>` or `--revoke` is rejected rather than ignored.
+`--revoke` takes the claim away, and **lands within the hour rather than on the
+keystroke**, for the same reason granting does: the claim lives inside the ID
+token the client already holds.
+
+**Responding to abuse, which is not the same thing.** There is no suspension
+mechanism now that signups are open, and there was less of one before than it
+looked. Deleting the Auth user stops the account signing in again, but the token
+already in hand keeps writing for up to an hour, and the person can sign up again
+straight away — a deleted account that returns gets a **new** uid, so nothing
+about the ban follows them. What takes effect immediately is deleting the data
+and, if the abuse is the AI, turning drafting off. A ban that actually holds has
+to be keyed on something the person keeps, and that has not been designed.
 
 **Clearing a deletion tombstone.** Deleting an account writes
 `deletedAccounts/{uid}`, and Firestore rules refuse every create and update from
@@ -402,23 +415,19 @@ immediately, because the rule reads the document on each write rather than
 anything in the token.
 
 **Releasing.** Cutting the version — the branch, the changelog and the tag — is
-[docs/releasing.md](docs/releasing.md). What follows is only the access half of
-it, which has an order that matters. Three steps:
+[docs/releasing.md](docs/releasing.md). Run _Deploy (production)_ from the
+Actions tab; there is no access step in front of it any more, because the rules
+being deployed do not require anything a signed-in token lacks.
 
-1. `yarn allow <email> prod` for every account that must keep working.
-2. Ask each of them to sign out and sign back in. A claim reaches the client
-   only in a freshly minted ID token; an open session picks it up at its next
-   refresh, which is up to an hour away.
-3. Run _Deploy (production)_.
+The workflow still deploys rules before hosting, and that order is not a
+preference: a new top-level field has to be allowlisted before any client can
+send it, or `hasOnly` denies every write the new build makes.
 
-The order is not a preference. The workflow deploys rules before hosting on
-purpose, so a new top-level field is allowlisted before any client can send it
-— and because the rules being deployed require a claim that no token issued
-before step 1 carries. Reversing steps 1 and 3 locks out everyone who was
-already signed in, for up to an hour, including whoever is doing the deploy.
-
-This matters most exactly once: the first production run of that workflow _is_
-the migration onto the claim.
+**The access steps this section used to carry belong to the closed gate, and
+that is when to come back for them.** Deploying rules that require the `allowed`
+claim before granting it locks out everyone already signed in — for up to an
+hour, the operator included. So closing signups is: grant, have people sign out
+and back in, deploy.
 
 ### Deploy credentials
 

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -97,8 +97,18 @@ console.log(
 // and changes nothing an operator can observe. Signups are open: whoever ran
 // this to restore somebody's access has not restored it, and whoever ran it as
 // step one of closing signups still has two steps left.
+//
+// The two paths differ and the note must not flatten them. Granting really does
+// nothing until `isAllowed()` is back. Revoking ends the session at the next
+// refresh — `revokeRefreshTokens` above is not a no-op — but the account can
+// sign straight back in, so what it is not is a ban.
 console.log(
-  'note: the deployed rules gate on signedIn(), not on this claim, so nothing ' +
-    'about access changed. It matters only when restoring isAllowed() — see ' +
-    '"Operator runbook" in README.md.',
+  revoke
+    ? 'note: the deployed rules gate on signedIn(), not on this claim, so this ' +
+        'ends the session without removing access — the account can sign in ' +
+        'again. Suspension is not something this project has; see "Responding ' +
+        'to abuse" in README.md.'
+    : 'note: the deployed rules gate on signedIn(), not on this claim, so ' +
+        'nothing about access changed. It matters only when restoring ' +
+        'isAllowed() — see "Operator runbook" in README.md.',
 );

--- a/admin/allow-user.ts
+++ b/admin/allow-user.ts
@@ -15,10 +15,18 @@ import {
  *   yarn allow you@example.com prod
  *   yarn allow you@example.com --project your-project-id
  *
- * The security rules read `request.auth.token.allowed`, so this is the only
- * thing that opens the door. It replaced an `allowedUsers` document that rules
- * checked with `exists()` on every request — one billed read per request, to
- * answer a question whose answer changes twice in an account's lifetime.
+ * **The deployed rules do not read this claim, so granting it opens nothing
+ * today.** Signups are open: `firestore.rules` gates on `signedIn()`. The claim
+ * is what the *closed* gate reads, and this command is step one of closing it —
+ * grant every account that must keep working, have them sign out and back in,
+ * and only then deploy rules that restore `isAllowed()`. Deploying first locks
+ * out the operator along with everybody else, which is why this survived the
+ * gate rather than being deleted with it. See "Operator runbook" in README.md.
+ *
+ * The claim replaced an `allowedUsers` document that rules checked with
+ * `exists()` on every request — one billed read per request, to answer a
+ * question whose answer changes twice in an account's lifetime. That collection
+ * is read by nothing now and this command has never written it.
  *
  * **A ban lands within the hour, not on the keystroke.** A claim lives inside
  * the ID token the client already holds, and Firestore rules have no revocation
@@ -83,4 +91,14 @@ console.log(
     (revoke
       ? ' — refresh tokens revoked. The ID token already issued stays valid until it expires, so access ends within the hour rather than immediately.'
       : ''),
+);
+
+// Said on every run, because the alternative is a command that reports success
+// and changes nothing an operator can observe. Signups are open: whoever ran
+// this to restore somebody's access has not restored it, and whoever ran it as
+// step one of closing signups still has two steps left.
+console.log(
+  'note: the deployed rules gate on signedIn(), not on this claim, so nothing ' +
+    'about access changed. It matters only when restoring isAllowed() — see ' +
+    '"Operator runbook" in README.md.',
 );

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,53 +25,46 @@ service cloud.firestore {
       return request.auth != null && request.auth.uid == uid;
     }
 
-    // The single gate that keeps this a private notebook.
+    // ---- signups are open, and this is what that cost ----
     //
-    // The paths below are already multi-user: every rule is written against
-    // request.auth.uid and nothing depends on there being one account. This
-    // check is the only thing standing between the current state and open
-    // signups, and it is deliberate — the billing plan has no hard spending
-    // cap, so a stranger who signed up would be writing to a project that can
-    // be alerted on but not capped.
+    // Until this change every path below went through `isAllowed()`, which
+    // required the custom claim `allowed` that only `yarn allow` sets. The paths
+    // were already multi-user — every rule is written against
+    // `request.auth.uid` and none of them assumes a single account — so opening
+    // signups was the body of one function. That cheapness is the thing to be
+    // careful about, not the thing to be reassured by.
     //
-    // It is an allowlist collection rather than a hard-coded address so that
-    // adding somebody is a document rather than a rules deploy, and so the same
-    // mechanism becomes a beta invite list later. `allowedUsers` has no match
-    // block of its own, so no client can read or write it — a rules-internal
-    // exists() is not itself subject to rules, and admin tooling writes it.
+    // **The allowlist was standing in for controls this project does not have.**
+    // Not one gate: the substitute for all of them. A signed-in account has no
+    // write rate limit and no cap on how many documents it creates, and rules
+    // cannot give it either — they see one write at a time and have no clock
+    // across requests. What bounds a stranger now lives outside this file: a
+    // per-user quota override on the AI proxy, Cloud Monitoring alerts on the
+    // free Firestore quotas, and the fact that an exhausted quota on the Spark
+    // plan stops the app until it resets rather than producing a bill.
     //
-    // Note this cannot be replaced by anything in front of the site: Firebase
-    // Hosting serves the config that reaches Firestore, so basic auth or any
-    // other gate on the HTML protects the page, not the data.
+    // **What rules still do is ownership, shape and size**, which is the rest of
+    // this file, plus `notDeleted()` below.
     //
-    // To open signups: delete this function and its call sites. Do that
-    // together with App Check and a budget-alert kill switch, not before.
+    // **There is no suspension mechanism, and removing this gate is not what
+    // took it away.** Clearing the claim never landed for up to an hour: the
+    // claim lives in the ID token the client already holds and rules have no
+    // revocation check, which is why `admin/allow-user.ts` revokes the refresh
+    // tokens as well — that ends the session at its next refresh, it does not
+    // invalidate the token in hand. Deleting the Auth user has the same tail and
+    // the same hole under it, because a deleted account that signs up again gets
+    // a **new uid** (measured against the Auth emulator, and the reason the
+    // tombstone below is an existence check rather than a permanent lockout). So
+    // a ban keyed on uid is a ban the banned account leaves by signing in again.
+    // A real one has to be keyed on something the person keeps, which is a
+    // decision and not a detail, and it is not made here.
     //
-    // **A custom claim, not a document read.** exists() here is billed as a
-    // document read on *every request to every path*, which on a public service
-    // doubles the read cost of the whole application to answer a question whose
-    // answer changes perhaps twice in an account's lifetime.
-    //
-    // **What it trades away is immediacy, and the trade is real.** The gate
-    // this replaces was re-evaluated on every request, so removing a document
-    // took effect on the next one. A claim lives inside the ID token the client
-    // is already holding, and Firestore rules have no revocation check — there
-    // is no rules equivalent of `verifyIdToken(..., checkRevoked: true)`. So a
-    // removed claim changes nothing until that token expires: **up to an hour.**
-    //
-    // Revoking the refresh tokens does not shorten it. It stops the *next*
-    // refresh from succeeding, which ends the session — but the ID token
-    // already in hand keeps its claims and keeps being accepted until it runs
-    // out. `admin/allow-user.ts` revokes them anyway, because ending the
-    // session is worth doing; it is not what makes a ban land.
-    //
-    // Closing the window properly means storing a revocation time and comparing
-    // `request.auth.token.auth_time` against it here, which reintroduces the
-    // per-request read this change removed. That is a decision worth making
-    // deliberately if abuse ever becomes a live problem, and not before.
-    function isAllowed() {
-      return signedIn() && request.auth.token.allowed == true;
-    }
+    // **To close signups again**, restore `isAllowed()` and its two call sites,
+    // `mine()` and the `deletedAccounts` block. That is why `allowedUsers`, the
+    // claim and `yarn allow` are all still here rather than deleted alongside
+    // the gate: the rollback is a rules deploy that takes seconds, and it only
+    // works if the operator's own claim still exists when it lands. Do not tidy
+    // them away.
 
     // ---- an account that has been deleted, which its token cannot say ----
     //
@@ -96,12 +89,16 @@ service cloud.firestore {
     //  * Gating `read` would break the export the account screen offers and
     //    change nothing about the race. The defect is data written back.
     //
-    // **This is the per-request read that `isAllowed()` above was changed to
+    // **This is the per-request read the gate above was changed to a claim to
     // avoid, and it is affordable here for a reason worth stating.** That one
     // ran on every request to every path, reads included, which doubles the
     // read cost of an application that loads a whole notebook on sign-in. This
     // one runs on writes alone, and it is called *last* in every rule below so
     // that a write already refused for its shape or its owner never spends it.
+    //
+    // Now that anyone may sign up, this is also the only per-uid check left in
+    // the file, and it stays cheap for the same reason: writes only, called
+    // last.
     function notDeleted(uid) {
       return !exists(/databases/$(database)/documents/deletedAccounts/$(uid));
     }
@@ -421,8 +418,10 @@ service cloud.firestore {
     // rather than allowed. That is the right way round, and it is why adding a
     // path to the app now means adding it here too.
     match /users/{uid} {
+      // `signedIn()` carries the email_verified check, so this is still two
+      // conditions and not one: the account is verified, and it is this uid.
       function mine() {
-        return isOwner(uid) && isAllowed();
+        return isOwner(uid) && signedIn();
       }
 
       allow read, delete: if mine();
@@ -485,14 +484,20 @@ service cloud.firestore {
     // says this record holds the account identifier and the time it was written,
     // and nothing else.
     //
-    // **`isAllowed()`, on the same footing as every other path.** This said
-    // `signedIn()` for one revision, on the reasoning that an account whose
-    // claim had been taken away should still be able to record that it was
-    // gone. That does not survive being written down: draining and deleting are
-    // all behind `mine()`, so such an account cannot delete anything anyway,
-    // and the tombstone would record a deletion that never happened. What the
-    // looser gate actually bought was one document per uid reachable by any
-    // verified Google account, on a project with no hard spending cap.
+    // **On the same footing as every other path**, which since signups opened
+    // means `signedIn()` — the allowlist gate this used to name is gone and the
+    // distinction it drew has collapsed, because every verified Google account
+    // is now an account in good standing. The reasoning is worth keeping anyway,
+    // because it is what stops the gate here being loosened *further*: an
+    // earlier revision argued that an account whose access had been taken away
+    // should still be able to record that it was gone, and that does not survive
+    // being written down. Draining and deleting are all behind `mine()`, so such
+    // an account cannot delete anything anyway, and the tombstone would record a
+    // deletion that never happened.
+    //
+    // What keeps this bounded now is `isOwner(uid)` and the single-field shape,
+    // not the gate: an account can write one small document, for its own uid,
+    // and nothing else.
     //
     // **`create` and `update` both, because deletion is retried.** The flow is
     // not atomic and says so: a failure part way asks the user to press delete
@@ -505,7 +510,7 @@ service cloud.firestore {
     // is what the publishing block below was closed for, and this is closed the
     // same way.
     match /deletedAccounts/{uid} {
-      allow create, update: if isOwner(uid) && isAllowed()
+      allow create, update: if isOwner(uid) && signedIn()
                             && request.resource.data.keys().hasOnly(['deletedAt'])
                             && request.resource.data.deletedAt is timestamp;
       allow read, delete: if false;
@@ -536,6 +541,14 @@ service cloud.firestore {
     // than as rules. The twelve tests that covered them were removed with the
     // rules and are not recoverable from this list — they are in pull request
     // #30, which is where to read them, and their names are the specification.
+    //
+    // The rule fragments quoted below are the removed text verbatim, so they
+    // still say `isAllowed()`, which no longer exists. Read it as `signedIn()`;
+    // it is left as written because falsifying the record of what those rules
+    // said is worse than an outdated identifier in a quotation. What that
+    // substitution *means* has changed and is the first thing to re-decide:
+    // "any allowed account" was a handful of invited people, and is now anybody
+    // with a Google account.
     //
     // Reads first, because they are the access model rather than a detail:
     //

--- a/firestore.rules
+++ b/firestore.rules
@@ -60,11 +60,17 @@ service cloud.firestore {
     // decision and not a detail, and it is not made here.
     //
     // **To close signups again**, restore `isAllowed()` and its two call sites,
-    // `mine()` and the `deletedAccounts` block. That is why `allowedUsers`, the
-    // claim and `yarn allow` are all still here rather than deleted alongside
-    // the gate: the rollback is a rules deploy that takes seconds, and it only
-    // works if the operator's own claim still exists when it lands. Do not tidy
-    // them away.
+    // `mine()` and the `deletedAccounts` block. That is why `yarn allow` is kept
+    // rather than deleted alongside the gate: the rollback is a rules deploy
+    // that takes seconds, and it only works if the operator's own claim is
+    // already minted when it lands — so grant first, sign out and back in, then
+    // deploy.
+    //
+    // The state that matters is the **claim**, and nothing else.
+    // `admin/allow-user.ts` sets it with `setCustomUserClaims` and writes no
+    // document; `allowedUsers` is the collection the claim replaced, has no
+    // match block, and is read by nothing here or in `src`. Whatever is left in
+    // it is legacy, and clearing it would neither close nor reopen anything.
 
     // ---- an account that has been deleted, which its token cannot say ----
     //

--- a/src/lib/loadError.ts
+++ b/src/lib/loadError.ts
@@ -34,14 +34,22 @@ const DENIED_CODES = new Set(['permission-denied', 'unauthenticated']);
  * Two sentences, and the second one is why there is a third.
  *
  * `permission-denied` is not one situation. It is at least three, and only one
- * of them is cleared by signing in again:
+ * of them is cleared by signing in again.
  *
- *  1. **A token minted before the grant.** Re-authenticating fixes it, which is
- *     what the first instruction is for.
- *  2. **No claim on the account at all** — nobody has run `yarn allow`, or rules
- *     requiring the claim were deployed to a project where nobody carries it.
- *     Signing out and back in mints another token with no claim, so the reader
- *     follows the instruction, lands on the same screen, and is out of moves.
+ * **The list changed when signups opened and the shape of it did not.** Two of
+ * these used to be the allowlist — a token minted before the grant, and an
+ * account nobody had granted — and both are gone with `isAllowed()`. What
+ * replaced them is not fewer causes but different ones, so the message and its
+ * exit to サポート are unchanged: the reader still cannot tell which case they
+ * are in, and two of the three still dead-end without it.
+ *
+ *  1. **An expired or absent token.** Re-authenticating fixes it, which is what
+ *     the first instruction is for, and it is the only one of the three that
+ *     instruction resolves.
+ *  2. **A deletion tombstone.** `deletedAccounts/{uid}` makes rules refuse every
+ *     create and update from that uid, and signing out and back in mints another
+ *     token for the same dead uid — so the reader follows the instruction, lands
+ *     on the same screen, and is out of moves.
  *  3. **App Check rejecting the request.** `src/infra/firebase/client.ts`
  *     initialises it whenever a site key is present, and an unregistered domain
  *     or a dead reCAPTCHA key surfaces here as `permission-denied` like the

--- a/tests/integration/localWriteTracker.test.ts
+++ b/tests/integration/localWriteTracker.test.ts
@@ -128,15 +128,29 @@ describe('waitForLocalWrite', () => {
     const error = new Error('rules rejected the write');
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const tracker = new LocalWriteTracker(shortFallbackMs);
+    // Refused by hand rather than by a second timer, which is what this used to
+    // do: it rejected `shortFallbackMs + 5` after the write, leaving five
+    // milliseconds between the fallback resolving `saved` and the refusal
+    // arriving. Under load the refusal won that race, `saved` rejected, and the
+    // run went red on the assertion above — a failure about the machine rather
+    // than about the tracker. The ordering this test is *about* — local
+    // persistence first, refusal second — is now stated rather than timed.
+    let refuse!: (cause: Error) => void;
     const saved = tracker.write(
       ref,
-      () => new Promise((_resolve, reject) => setTimeout(() => reject(error), shortFallbackMs + 5)),
+      () =>
+        new Promise((_resolve, reject) => {
+          refuse = reject;
+        }),
     );
 
     await sleep(shortFallbackMs + 1);
     await expect(saved).resolves.toBeUndefined();
 
-    await sleep(5);
+    refuse(error);
+    // One hop, so the tracker's rejection handler has run before `settle` asks.
+    await Promise.resolve();
+
     await expect(tracker.settle(() => Promise.resolve())).rejects.toBe(error);
     expect(consoleError).toHaveBeenCalledWith(
       'Firestore write rejected after local persistence',

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -24,25 +24,29 @@ import { makeWordSet } from '../fixtures/wordSet';
 
 const PROJECT_ID = 'demo-goitei';
 
-/** On the allowlist. */
+/** An account with a notebook. */
 const ALICE = 'uid-alice';
-/** On the allowlist, and not Alice — the "some other legitimate user" case. */
+/** Not Alice — the "some other legitimate user" case. */
 const BOB = 'uid-bob';
-/** Authenticated, verified, and deliberately absent from allowedUsers. */
+/** A third account, signed in and unrelated to either of the other two. */
 const MALLORY = 'uid-mallory';
 
 let testEnv: RulesTestEnvironment;
 
 /**
- * Signed in *and* allowed. The gate is a custom claim now rather than a
- * document read, so a test that forgets it is denied for the right reason.
+ * Signed in and verified, and **carrying no `allowed` claim** — which is the
+ * whole point of this helper since signups opened.
+ *
+ * It used to mint `allowed: true`, and leaving that in place would have made
+ * every test below pass under the closed gate as well as the open one: the
+ * suite would have gone green without saying anything about the change. Minting
+ * the plain token instead is what makes the red-green proof mean something —
+ * restore `isAllowed()` in `firestore.rules` and these tests fail, because
+ * nobody here has the claim any more.
+ *
+ * `email_verified` stays, because `signedIn()` still requires it.
  */
-const as = (uid: string) =>
-  testEnv.authenticatedContext(uid, { email_verified: true, allowed: true }).firestore();
-
-/** Signed in, verified, and not on the list. */
-const asStranger = (uid: string) =>
-  testEnv.authenticatedContext(uid, { email_verified: true }).firestore();
+const as = (uid: string) => testEnv.authenticatedContext(uid, { email_verified: true }).firestore();
 
 /**
  * A whole entry, the shape `sanitizeDraft` produces plus what the adapter adds.
@@ -161,7 +165,7 @@ describe('private data under users/{uid}', () => {
     await assertSucceeds(db.collection(`users/${ALICE}/entries`).get());
   });
 
-  it("denies another allowlisted user everything in someone else's notebook", async () => {
+  it("denies another signed-in user everything in someone else's notebook", async () => {
     const db = as(BOB);
     await assertFails(db.doc(`users/${ALICE}/entries/e1`).get());
     await assertFails(db.collection(`users/${ALICE}/entries`).get());
@@ -260,16 +264,38 @@ describe("a deleted account's token", () => {
   });
 
   /**
-   * The same gate as everything else, and it was `signedIn()` here for one
-   * revision on reasoning that does not survive being written down: an account
-   * whose claim is gone cannot drain or delete anything either, because all of
-   * that is behind `mine()`. A tombstone it could still write would record a
-   * deletion that cannot happen — while leaving one document per uid reachable
-   * by any verified Google account on a project with no spending cap.
+   * This used to assert that an account off the allowlist could not write a
+   * tombstone. Opening signups removed the allowlist, so that account is now an
+   * ordinary user and the assertion inverted — which leaves two properties that
+   * did not, and they are the ones worth holding onto.
+   *
+   * The first is `isOwner(uid)`, covered above: a tombstone is writable for your
+   * own uid and nobody else's. The second is this one. Signing in at all is
+   * still required, and it is the only thing now standing between
+   * `deletedAccounts` and an unauthenticated writer — so if the gate here is
+   * ever loosened again, this is what goes red.
    */
-  it('refuses a tombstone from an account that is not on the allowlist', async () => {
+  it('refuses a tombstone from a caller who is not signed in', async () => {
     await assertFails(
-      asStranger(MALLORY).doc(`deletedAccounts/${MALLORY}`).set({ deletedAt: new Date() }),
+      testEnv
+        .unauthenticatedContext()
+        .firestore()
+        .doc(`deletedAccounts/${MALLORY}`)
+        .set({ deletedAt: new Date() }),
+    );
+  });
+
+  /**
+   * The inverse of the test above, stated on purpose rather than left implied:
+   * a brand-new account that nobody invited can delete itself. Account deletion
+   * is the first thing a stranger might want from a service they just tried,
+   * and the tombstone is the first write in that flow — if it were refused the
+   * account could not finish deleting itself, which is the exact state the
+   * tombstone exists to avoid.
+   */
+  it('lets a brand-new account write its own tombstone', async () => {
+    await assertSucceeds(
+      as(MALLORY).doc(`deletedAccounts/${MALLORY}`).set({ deletedAt: new Date() }),
     );
   });
 
@@ -319,52 +345,85 @@ describe("a deleted account's token", () => {
   });
 });
 
-describe('the allowedUsers gate', () => {
-  it('denies a signed-in user who is not on the allowlist', async () => {
-    const db = asStranger(MALLORY);
-    await assertFails(db.doc(`users/${MALLORY}/entries/e1`).set(entry(MALLORY)));
-    await assertFails(db.doc(`users/${MALLORY}/entries/e1`).get());
+/**
+ * What replaced the allowlist, and what it did not.
+ *
+ * This block used to be `describe('the allowedUsers gate')` and its first test
+ * asserted that a signed-in stranger was refused everything. That is the
+ * assertion the change inverts, so it is the one that has to be replaced rather
+ * than deleted: what a stranger may now do is the feature, and the boundary
+ * around it is what still has to hold.
+ *
+ * **One test is gone and nothing here stands in for it.** It was called
+ * "takes away update and delete on what a revoked account already wrote", and
+ * it worked by minting Alice a token with no `allowed` claim — which is exactly
+ * the token every account now carries. There is no revocation any more, and
+ * writing a test that pretended otherwise would be worse than the gap: see the
+ * suspension paragraph in `firestore.rules`, which is where that is recorded
+ * and where the decision about a real ban belongs.
+ */
+describe('open signups', () => {
+  /**
+   * The change itself. `MALLORY` was the stranger this suite refused; the same
+   * uid, the same token, and now the first thing a new reader does — sign in,
+   * get a profile, write a first word.
+   */
+  it('lets an account nobody invited create its own profile and its first word', async () => {
+    const db = as(MALLORY);
+
+    await assertSucceeds(db.doc(`users/${MALLORY}`).set(profile(MALLORY)));
+    await assertSucceeds(db.doc(`users/${MALLORY}/entries/e1`).set(entry(MALLORY)));
+    await assertSucceeds(db.doc(`users/${MALLORY}/entries/e1`).get());
+  });
+
+  /**
+   * Opening the gate is not opening the door between notebooks, and this is the
+   * pair that says so in both directions. A new account is a new tenant, not a
+   * reader of everyone else's.
+   */
+  it('keeps a brand-new account out of an existing notebook, and vice versa', async () => {
+    await assertFails(as(MALLORY).doc(`users/${ALICE}/entries/e1`).get());
+    await assertFails(as(MALLORY).doc(`users/${ALICE}/entries/e2`).set(entry(ALICE)));
+    await assertFails(as(ALICE).doc(`users/${MALLORY}/entries/e1`).get());
+  });
+
+  /**
+   * Publishing is still unbuilt and its paths are still shut — including to the
+   * accounts that can now sign themselves up, which is the population that made
+   * leaving those rules in place a bad idea in the first place.
+   */
+  it('does not open the unbuilt publishing paths to a new account', async () => {
+    const db = as(MALLORY);
     await assertFails(db.doc(`publicEntries/pe-alice`).get());
     await assertFails(db.doc(`publicSets/set-alice`).get());
   });
 
-  it('denies an unverified email even when the uid is on the allowlist', async () => {
+  it('still denies an unverified email', async () => {
     const db = testEnv.authenticatedContext(ALICE, { email_verified: false }).firestore();
     await assertFails(db.doc(`users/${ALICE}/entries/e1`).get());
+    await assertFails(db.doc(`users/${ALICE}/entries/e1`).set(entry(ALICE)));
   });
 
-  it('keeps allowedUsers itself unreachable from any client', async () => {
-    const db = as(ALICE);
-    await assertFails(db.doc(`allowedUsers/${ALICE}`).get());
-    await assertFails(db.doc(`allowedUsers/${MALLORY}`).set({ email: 'm@example.com' }));
+  it('still denies a caller who is not signed in at all', async () => {
+    const db = testEnv.unauthenticatedContext().firestore();
+    await assertFails(db.doc(`users/${ALICE}/entries/e1`).get());
+    await assertFails(db.doc(`users/${MALLORY}/entries/e1`).set(entry(MALLORY)));
   });
 
   /**
-   * Revocation is the claim going away, not a document being deleted.
+   * `allowedUsers` and the `allowed` claim outlive the gate they served, and
+   * deliberately: restoring `isAllowed()` is how signups close again, and a
+   * rules deploy that lands after the documents have been tidied away locks out
+   * the operator along with everybody else.
    *
-   * That is a real change in what "revoked" means: the claim lives in the ID
-   * token, and Firestore rules have no revocation check, so clearing it takes
-   * effect only when that token expires — up to an hour. Revoking the refresh
-   * tokens ends the session at the next refresh but does not invalidate the
-   * token already in hand.
-   *
-   * **This test is the state after the token has turned over**, which is the
-   * one this harness can express: `@firebase/rules-unit-testing` mints tokens
-   * directly, so the window itself is not reachable from here.
-   *
-   * The published-copy version of this went with the publishing rules. The
-   * property survives it: revocation has to take away update and delete on what
-   * the account already wrote, not only create. Gating `create` alone would
-   * leave a revoked account editing its own notebook indefinitely, which is the
-   * gap the first review round found.
+   * So the collection has to stay unreachable from a client for the same reason
+   * it always did — it is admin-written state that decides access — and this
+   * test is what keeps that true while nothing in the rules reads it.
    */
-  it('takes away update and delete on what a revoked account already wrote', async () => {
-    const db = asStranger(ALICE);
-
-    await assertFails(db.doc(`users/${ALICE}/entries/e1`).update({ headword: 'edited' }));
-    await assertFails(db.doc(`users/${ALICE}/entries/e1`).delete());
-    // ...and reading it, which it could do a moment ago.
-    await assertFails(db.doc(`users/${ALICE}/entries/e1`).get());
+  it('keeps allowedUsers unreachable, so closing signups again still works', async () => {
+    const db = as(ALICE);
+    await assertFails(db.doc(`allowedUsers/${ALICE}`).get());
+    await assertFails(db.doc(`allowedUsers/${MALLORY}`).set({ email: 'm@example.com' }));
   });
 });
 

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -272,15 +272,32 @@ describe("a deleted account's token", () => {
    * did not, and they are the ones worth holding onto.
    *
    * The first is `isOwner(uid)`, covered above: a tombstone is writable for your
-   * own uid and nobody else's. The second is this one. Signing in at all is
-   * still required, and it is the only thing now standing between
-   * `deletedAccounts` and an unauthenticated writer — so if the gate here is
-   * ever loosened again, this is what goes red.
+   * own uid and nobody else's. The second is this pair. Signing in is still
+   * required, and it is the only thing now standing between `deletedAccounts`
+   * and a caller this rule should refuse — so if the gate here is ever loosened,
+   * these are what go red.
+   *
+   * **Both halves are asserted because `signedIn()` is two conditions and
+   * `isOwner()` covers neither.** This block does not go through `mine()`, so
+   * dropping `signedIn()` from the rule would leave `isOwner(uid)` — which
+   * checks that a token exists and names this uid, and says nothing about the
+   * email being verified. With only the unauthenticated case covered, that edit
+   * passed the whole suite.
    */
   it('refuses a tombstone from a caller who is not signed in', async () => {
     await assertFails(
       testEnv
         .unauthenticatedContext()
+        .firestore()
+        .doc(`deletedAccounts/${MALLORY}`)
+        .set({ deletedAt: new Date() }),
+    );
+  });
+
+  it('refuses a tombstone from an authenticated caller whose email is unverified', async () => {
+    await assertFails(
+      testEnv
+        .authenticatedContext(MALLORY, { email_verified: false })
         .firestore()
         .doc(`deletedAccounts/${MALLORY}`)
         .set({ deletedAt: new Date() }),

--- a/tests/rules/firestore-rules.test.ts
+++ b/tests/rules/firestore-rules.test.ts
@@ -144,8 +144,10 @@ beforeEach(async () => {
   await testEnv.clearFirestore();
   await testEnv.withSecurityRulesDisabled(async (context) => {
     const db = context.firestore();
-    // allowedUsers is written by admin tooling only; no rule matches it, so
-    // seeding has to bypass rules exactly as `upload.mjs` does.
+    // allowedUsers is the legacy collection the `allowed` claim replaced.
+    // Nothing writes it any more and no rule matches it, so seeding has to
+    // bypass rules — which is also the only way a leftover document could exist
+    // in production, and the state the unreachability test below is about.
     await db.doc(`allowedUsers/${ALICE}`).set({ email: 'alice@example.com' });
     await db.doc(`allowedUsers/${BOB}`).set({ email: 'bob@example.com' });
 
@@ -411,16 +413,18 @@ describe('open signups', () => {
   });
 
   /**
-   * `allowedUsers` and the `allowed` claim outlive the gate they served, and
-   * deliberately: restoring `isAllowed()` is how signups close again, and a
-   * rules deploy that lands after the documents have been tidied away locks out
-   * the operator along with everybody else.
+   * `allowedUsers` is legacy: the `allowed` claim replaced it, `yarn allow`
+   * writes no document, and nothing in the rules or in `src` reads it. What the
+   * gate needed was never this collection — closing signups again is restoring
+   * `isAllowed()`, which reads the claim.
    *
-   * So the collection has to stay unreachable from a client for the same reason
-   * it always did — it is admin-written state that decides access — and this
-   * test is what keeps that true while nothing in the rules reads it.
+   * The test stays anyway, because "no rule matches this path" is a property of
+   * the file rather than of the collection: the day somebody adds a match block
+   * to sweep the legacy documents away, this is what says the sweep gave a
+   * client a way in. An unreadable leftover is harmless; a writable one is a
+   * write surface nothing accounts for.
    */
-  it('keeps allowedUsers unreachable, so closing signups again still works', async () => {
+  it('keeps the legacy allowedUsers collection unreachable from any client', async () => {
     const db = as(ALICE);
     await assertFails(db.doc(`allowedUsers/${ALICE}`).get());
     await assertFails(db.doc(`allowedUsers/${MALLORY}`).set({ email: 'm@example.com' }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,6 +84,22 @@ export default defineConfig({
           name: 'emulator',
           environment: 'node',
           include: ['tests/{integration,rules}/**/*.test.ts'],
+          // `initializeTestEnvironment` loads the rules into a JVM that
+          // `emulators:exec` has started but not warmed, and vitest's default
+          // hook timeout is 10s. Measured here at **12.5s** on a loaded
+          // machine — so the whole rules suite failed its `beforeAll`, reported
+          // 66 tests skipped, and exited 1.
+          //
+          // That failure is worth spelling out because of how it reads: a
+          // security-rules suite that skips every case looks like flake, not
+          // like a build with no coverage of its authorization boundary. It
+          // also survives `--hookTimeout` on the command line, which these
+          // projects do not pick up, so the number has to live here.
+          //
+          // The budget is generous on purpose. It bounds a hang; it is not a
+          // performance assertion, and a rules evaluation that stalls still
+          // fails on `testTimeout` above.
+          hookTimeout: 60_000,
         },
       },
     ],


### PR DESCRIPTION
Every private path went through `isAllowed()`, which required the `allowed`
custom claim that only `yarn allow` sets. This replaces it with `signedIn()` at
both call sites, so any Google account with a verified email gets its own
notebook and no operator step stands between signing in and using the app.

The functional diff is three lines. That is the part worth being careful about
rather than reassured by.

## 1. What the allowlist was standing in for

Not one gate — the substitute for every control this project does not have. A
signed-in account has no write rate limit and no cap on how many documents it
creates, and rules can give it neither: they see one write at a time and have no
clock across requests. So the comment above the old function has been replaced
rather than deleted, and the new one says where those bounds actually live — a
per-user quota override on the AI proxy, Cloud Monitoring alerts on the free
Firestore quotas, and the Spark plan, whose exhausted-quota behaviour is to stop
serving until it resets rather than to produce a bill.

What rules still do is ownership, shape and size, plus `notDeleted()`. `mine()`
is now `isOwner(uid) && signedIn()`, which is still two conditions: `signedIn()`
carries the `email_verified` check, so nothing was loosened beyond the claim.

## 2. There is no suspension mechanism, and this is not what took it away

One test was deleted and nothing stands in for it —
`takes away update and delete on what a revoked account already wrote`. It
worked by minting a token with no `allowed` claim, which is the token every
account now carries.

Clearing the claim never landed for up to an hour anyway: the claim lives in the
ID token the client already holds and rules have no revocation check. Deleting
the Auth user has the same tail and the same hole under it, because a deleted
account that signs up again gets a **new uid** — measured against the Auth
emulator when the tombstone was designed, and the reason that check is an
existence test rather than a permanent lockout. A ban keyed on uid is a ban the
banned account leaves by signing in again.

Writing a test that pretended otherwise would be worse than the gap, so the gap
is recorded in `firestore.rules` and in the operator runbook instead. A ban that
holds has to be keyed on something the person keeps, and that is a decision this
pull request does not make.

## 3. Closing signups again

`yarn allow` is kept. Restoring `isAllowed()` and its two call sites is how the
door shuts, and those rules require a claim no token issued beforehand carries —
so the order is grant, sign out and back in, then deploy. Deploying first locks
out the operator along with everybody else.

The state that matters is the claim and nothing else. `admin/allow-user.ts` sets
it with `setCustomUserClaims` and writes no document; `allowedUsers` is the
collection that claim replaced, and nothing in the rules or in `src` reads it.
An earlier revision of this branch said its documents had to be preserved, which
described a mechanism that does not exist — `3353601` corrects it, in the rules,
the README and the test that covers the path.

That test keeps its assertions and loses its reason. What it guards is that no
match block covers `allowedUsers`, so the day somebody sweeps the legacy
documents away, it says whether the sweep handed a client a write surface.

## Test layer, and the proof it went red

**Rules**, against the emulator: the claim is "who may read or write what", which
is the row in `CLAUDE.md` this belongs to and the only layer that can see it.

The suite's `as()` helper no longer mints `allowed: true`. That matters more than
the new cases: left as it was, every test would have passed under the closed gate
as well as the open one, and the suite would have gone green saying nothing about
the change. This repository has shipped that exact shape before — 62 rules tests
green while the deleted-account gate closed on nothing.

**Red proof.** With `isAllowed()` restored and the tests as they now stand,
**30 of 66 fail**: both new cases —
`lets an account nobody invited create its own profile and its first word` and
`lets a brand-new account write its own tombstone` — plus every existing case
that writes as an owner, because nobody in the suite holds the claim any more.
The cases asserting denial stay green, which is the right way round. Restoring
the change: 66 pass.

New cases beyond the two above: a brand-new account is kept out of an existing
notebook in both directions, the unbuilt publishing paths stay shut to it, an
unverified email is still refused, and an unauthenticated caller is still
refused.

## The emulator suite was red before this branch, for two unrelated reasons

Both are fixed here, because otherwise none of the above is verifiable.

**`initializeTestEnvironment` takes longer than vitest's default hook timeout.**
Measured directly, outside vitest, at **12.5s** against a 10s default: it loads
the rules into a JVM `emulators:exec` has started but not warmed. The whole rules
file therefore failed its `beforeAll`, reported 66 tests skipped and exited 1 —
a security-rules suite covering nothing, which reads as flake rather than as an
absence of coverage. A command-line `--hookTimeout` does not reach a project
defined with `extends: true`, so the budget lives in `vitest.config.ts`. It
bounds a hang; a rules evaluation that stalls still fails on `testTimeout`.

Before and after on the same machine under the same load: the rules file alone
failed twice consecutively with `66 skipped`, and passes with `66 passed`.

**A five-millisecond race in `tests/integration/localWriteTracker.test.ts`.**
Pre-existing and unrelated to signups — its "rules rejected the write" error is a
hand-made `Error`, nothing touches Firestore. The write was refused
`shortFallbackMs + 5` after it started, leaving five milliseconds between the
fallback resolving `saved` and the refusal arriving; under load the refusal won.
It now refuses by hand, the way the sibling test below it already does.

## Verification

`yarn test:emulator` 110 passed (7 files), `yarn test:unit` 995 passed (68
files), `yarn typecheck` clean, `yarn lint` 0 errors and 19 pre-existing
warnings. `yarn format` was run.

## What this does not do

Merging opens signups on **dev**. Production is still a manual _Deploy
(production)_ run, and before that button is pressed the controls named in
section 1 have to exist: the AI per-user quota override, HTTP referrer
restrictions on the production browser key, and Cloud Monitoring alerts on the
free Firestore quotas. None of them is code and none of them is in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Verified accounts can now sign up without an allowlist approval.
  * Users can create their own profiles, entries, and deletion requests while ownership protections remain enforced.
  * Publishing remains restricted.

* **Documentation**
  * Updated signup guidance and operator runbooks, including abuse limitations, delayed token effects, and procedures for restoring claim-based access controls.

* **Bug Fixes**
  * Improved reliability when handling rejected local writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->