### PR TITLE
fix(reconnect): preserve pending reconnect retries

### DIFF
--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -59,6 +59,7 @@ const PAGE_SIZE = 200;
 export function EntriesProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadSucceeded, setLoadSucceeded] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   // Rebuilt when the signed-in user changes, so the `users/{uid}` path baked
@@ -93,6 +94,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    * The gate goes up on mount and on an account change, in the effect below.
    */
   const refresh = useCallback(async () => {
+    setLoadSucceeded(false);
     const mine = (walk.current += 1);
     try {
       const all: Entry[] = [];
@@ -109,6 +111,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
       if (walk.current === mine) {
         setEntries(all);
         setError(null);
+        setLoadSucceeded(true);
       }
     } catch (cause) {
       console.error(cause);
@@ -127,7 +130,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    * Denial does not belong here: signing back in is what clears it, not the
    * network coming back, and a retry would only repeat the same rejection.
    */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
 
   const value = useMemo(
     () => ({ entries, loading, error, refresh, repository }),

--- a/src/lib/entries.tsx
+++ b/src/lib/entries.tsx
@@ -59,7 +59,7 @@ const PAGE_SIZE = 200;
 export function EntriesProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [entries, setEntries] = useState<Entry[]>([]);
   const [loading, setLoading] = useState(true);
-  const [loadSucceeded, setLoadSucceeded] = useState(false);
+  const [successfulLoadFor, setSuccessfulLoadFor] = useState<string | null>(null);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   // Rebuilt when the signed-in user changes, so the `users/{uid}` path baked
@@ -94,7 +94,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    * The gate goes up on mount and on an account change, in the effect below.
    */
   const refresh = useCallback(async () => {
-    setLoadSucceeded(false);
+    setSuccessfulLoadFor(null);
     const mine = (walk.current += 1);
     try {
       const all: Entry[] = [];
@@ -111,7 +111,7 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
       if (walk.current === mine) {
         setEntries(all);
         setError(null);
-        setLoadSucceeded(true);
+        setSuccessfulLoadFor(uid);
       }
     } catch (cause) {
       console.error(cause);
@@ -130,7 +130,11 @@ export function EntriesProvider({ uid, children }: { uid: string; children: Reac
    * Denial does not belong here: signing back in is what clears it, not the
    * network coming back, and a retry would only repeat the same rejection.
    */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
+  useRetryOnReconnect(
+    error !== null && isUnreachable(error.cause),
+    successfulLoadFor === uid,
+    refresh,
+  );
 
   const value = useMemo(
     () => ({ entries, loading, error, refresh, repository }),

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -53,7 +53,7 @@ const ProgressContext = createContext<ProgressValue | null>(null);
 export function ProgressProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [progress, setProgress] = useState<EntryProgress[]>([]);
   const [loading, setLoading] = useState(true);
-  const [loadSucceeded, setLoadSucceeded] = useState(false);
+  const [successfulLoadFor, setSuccessfulLoadFor] = useState<string | null>(null);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   const repository = useMemo(() => progressRepositoryFor(uid), [uid]);
@@ -63,7 +63,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
 
   /** Re-read progress. Deliberately does not raise `loading` — see the effect below. */
   const refresh = useCallback(async () => {
-    setLoadSucceeded(false);
+    setSuccessfulLoadFor(null);
     const mine = (walk.current += 1);
     try {
       const rows = await repository.listAll();
@@ -71,7 +71,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
       if (walk.current === mine) {
         setProgress(rows);
         setError(null);
-        setLoadSucceeded(true);
+        setSuccessfulLoadFor(uid);
       }
     } catch (cause) {
       console.error(cause);
@@ -87,7 +87,11 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
   }, [refresh]);
 
   /** Denial is not cleared by reconnecting — see `EntriesProvider`'s same guard. */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
+  useRetryOnReconnect(
+    error !== null && isUnreachable(error.cause),
+    successfulLoadFor === uid,
+    refresh,
+  );
 
   const record = useCallback(
     async (session: PracticeSessionDraft, rows: EntryProgress[]) => {

--- a/src/lib/progress.tsx
+++ b/src/lib/progress.tsx
@@ -53,6 +53,7 @@ const ProgressContext = createContext<ProgressValue | null>(null);
 export function ProgressProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [progress, setProgress] = useState<EntryProgress[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadSucceeded, setLoadSucceeded] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   const repository = useMemo(() => progressRepositoryFor(uid), [uid]);
@@ -62,6 +63,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
 
   /** Re-read progress. Deliberately does not raise `loading` — see the effect below. */
   const refresh = useCallback(async () => {
+    setLoadSucceeded(false);
     const mine = (walk.current += 1);
     try {
       const rows = await repository.listAll();
@@ -69,6 +71,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
       if (walk.current === mine) {
         setProgress(rows);
         setError(null);
+        setLoadSucceeded(true);
       }
     } catch (cause) {
       console.error(cause);
@@ -84,7 +87,7 @@ export function ProgressProvider({ uid, children }: { uid: string; children: Rea
   }, [refresh]);
 
   /** Denial is not cleared by reconnecting — see `EntriesProvider`'s same guard. */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
 
   const record = useCallback(
     async (session: PracticeSessionDraft, rows: EntryProgress[]) => {

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -2,9 +2,9 @@ import { useEffect, useRef } from 'react';
 import { useOnline } from '@/lib/useOnline';
 
 /**
- * Retries once when the browser regains a connection, and only on the
- * transition into it — not on every render while already online and failed,
- * which would retry nothing new and just repeat the same rejection.
+ * Retries once after the browser regains a connection and a read has failed —
+ * not on every render while already online and failed, which would retry
+ * nothing new and just repeat the same rejection.
  *
  * Scoped to callers that have already decided the failure is worth retrying:
  * `useOnline`'s own caveat is that `true` is a hint to retry, not proof it will
@@ -30,22 +30,31 @@ import { useOnline } from '@/lib/useOnline';
  */
 export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise<void>): void {
   const online = useOnline();
-  const wasOffline = useRef(!online);
+  const reconnectPending = useRef(!online);
   const retrying = useRef(false);
 
   useEffect(() => {
-    if (online && wasOffline.current && failed && !retrying.current) {
-      retrying.current = true;
-      // `retry` is always a provider's `refresh`, which already catches its
-      // own failure into the caller's error state and never rejects — the
-      // `catch` here guards the hook's public contract, typed to accept a
-      // rejecting `Promise<void>`, not a rejection this codebase produces.
-      void Promise.resolve(retry())
-        .catch(() => undefined)
-        .finally(() => {
-          retrying.current = false;
-        });
+    if (!online) {
+      reconnectPending.current = true;
+      return;
     }
-    wasOffline.current = !online;
+
+    // A read that began offline can reject after the online event. Keep that
+    // reconnect available until the failure is published and can use it.
+    if (!reconnectPending.current || !failed) return;
+
+    reconnectPending.current = false;
+    if (retrying.current) return;
+
+    retrying.current = true;
+    // `retry` is always a provider's `refresh`, which already catches its
+    // own failure into the caller's error state and never rejects — the
+    // `catch` here guards the hook's public contract, typed to accept a
+    // rejecting `Promise<void>`, not a rejection this codebase produces.
+    void Promise.resolve(retry())
+      .catch(() => undefined)
+      .finally(() => {
+        retrying.current = false;
+      });
   }, [online, failed, retry]);
 }

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useOnline } from '@/lib/useOnline';
 
 /**
@@ -35,7 +35,7 @@ export function useRetryOnReconnect(
 ): void {
   const online = useOnline();
   const reconnectPending = useRef(!online);
-  const retrying = useRef(false);
+  const [retrying, setRetrying] = useState(false);
 
   useEffect(() => {
     if (!online) {
@@ -43,7 +43,7 @@ export function useRetryOnReconnect(
       return;
     }
 
-    if (!reconnectPending.current) return;
+    if (!reconnectPending.current || retrying) return;
 
     // A read that began offline can reject after the online event. Keep that
     // reconnect available until that read either succeeds or publishes a
@@ -55,9 +55,7 @@ export function useRetryOnReconnect(
     if (!failed) return;
 
     reconnectPending.current = false;
-    if (retrying.current) return;
-
-    retrying.current = true;
+    setRetrying(true);
     // `retry` is always a provider's `refresh`, which already catches its
     // own failure into the caller's error state and never rejects — the
     // `catch` here guards the hook's public contract, typed to accept a
@@ -65,7 +63,7 @@ export function useRetryOnReconnect(
     void Promise.resolve(retry())
       .catch(() => undefined)
       .finally(() => {
-        retrying.current = false;
+        setRetrying(false);
       });
-  }, [online, failed, loadSucceeded, retry]);
+  }, [online, failed, loadSucceeded, retry, retrying]);
 }

--- a/src/lib/retryOnReconnect.ts
+++ b/src/lib/retryOnReconnect.ts
@@ -28,7 +28,11 @@ import { useOnline } from '@/lib/useOnline';
  * (the stale result is discarded), but it is still a second read charged for
  * no reason, which is exactly the overlap #84 asked this hook to avoid.
  */
-export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise<void>): void {
+export function useRetryOnReconnect(
+  failed: boolean,
+  loadSucceeded: boolean,
+  retry: () => void | Promise<void>,
+): void {
   const online = useOnline();
   const reconnectPending = useRef(!online);
   const retrying = useRef(false);
@@ -39,9 +43,16 @@ export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise
       return;
     }
 
+    if (!reconnectPending.current) return;
+
     // A read that began offline can reject after the online event. Keep that
-    // reconnect available until the failure is published and can use it.
-    if (!reconnectPending.current || !failed) return;
+    // reconnect available until that read either succeeds or publishes a
+    // failure that can use it.
+    if (loadSucceeded) {
+      reconnectPending.current = false;
+      return;
+    }
+    if (!failed) return;
 
     reconnectPending.current = false;
     if (retrying.current) return;
@@ -56,5 +67,5 @@ export function useRetryOnReconnect(failed: boolean, retry: () => void | Promise
       .finally(() => {
         retrying.current = false;
       });
-  }, [online, failed, retry]);
+  }, [online, failed, loadSucceeded, retry]);
 }

--- a/src/lib/userSettings.tsx
+++ b/src/lib/userSettings.tsx
@@ -51,7 +51,7 @@ function UserSettingsState({
   const [storedProfile, setStoredProfile] = useState(defaults);
   const [previewDraft, setPreviewDraft] = useState<UserProfileDraft | null>(null);
   const [loading, setLoading] = useState(true);
-  const [loadSucceeded, setLoadSucceeded] = useState(false);
+  const [successfulLoadFor, setSuccessfulLoadFor] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
@@ -63,7 +63,7 @@ function UserSettingsState({
    * Deliberately does not raise `loading` — see the effect below.
    */
   const refresh = useCallback(async () => {
-    setLoadSucceeded(false);
+    setSuccessfulLoadFor(null);
     const mine = (walk.current += 1);
     try {
       const stored = await userRepository.get(uid);
@@ -82,7 +82,7 @@ function UserSettingsState({
       if (walk.current === mine) {
         setStoredProfile(next);
         setError(null);
-        setLoadSucceeded(true);
+        setSuccessfulLoadFor(uid);
       }
     } catch (cause) {
       console.error(cause);
@@ -107,7 +107,7 @@ function UserSettingsState({
    */
   useRetryOnReconnect(
     error !== null && error.fallback === 'load.settings' && isUnreachable(error.cause),
-    loadSucceeded,
+    successfulLoadFor === uid,
     refresh,
   );
 
@@ -150,8 +150,10 @@ function UserSettingsState({
         throw cause;
       }
       try {
+        setSuccessfulLoadFor(null);
         const stored = await userRepository.get(uid);
         if (stored) setStoredProfile(stored);
+        setSuccessfulLoadFor(uid);
       } catch (cause) {
         console.error(cause);
         // Read wording, because a read is what failed. The server-written

--- a/src/lib/userSettings.tsx
+++ b/src/lib/userSettings.tsx
@@ -51,6 +51,7 @@ function UserSettingsState({
   const [storedProfile, setStoredProfile] = useState(defaults);
   const [previewDraft, setPreviewDraft] = useState<UserProfileDraft | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadSucceeded, setLoadSucceeded] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
@@ -62,6 +63,7 @@ function UserSettingsState({
    * Deliberately does not raise `loading` — see the effect below.
    */
   const refresh = useCallback(async () => {
+    setLoadSucceeded(false);
     const mine = (walk.current += 1);
     try {
       const stored = await userRepository.get(uid);
@@ -80,6 +82,7 @@ function UserSettingsState({
       if (walk.current === mine) {
         setStoredProfile(next);
         setError(null);
+        setLoadSucceeded(true);
       }
     } catch (cause) {
       console.error(cause);
@@ -104,6 +107,7 @@ function UserSettingsState({
    */
   useRetryOnReconnect(
     error !== null && error.fallback === 'load.settings' && isUnreachable(error.cause),
+    loadSucceeded,
     refresh,
   );
 

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -48,7 +48,7 @@ const PAGE_SIZE = 200;
 export function WordSetsProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [sets, setSets] = useState<WordSet[]>([]);
   const [loading, setLoading] = useState(true);
-  const [loadSucceeded, setLoadSucceeded] = useState(false);
+  const [successfulLoadFor, setSuccessfulLoadFor] = useState<string | null>(null);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   const repository = useMemo(() => wordSetRepositoryFor(uid), [uid]);
@@ -78,7 +78,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
    * `repository` changes because the account did. That is the effect below.
    */
   const refresh = useCallback(async () => {
-    setLoadSucceeded(false);
+    setSuccessfulLoadFor(null);
     const mine = (walk.current += 1);
     try {
       const all: WordSet[] = [];
@@ -92,7 +92,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
       if (walk.current === mine) {
         setSets(all);
         setError(null);
-        setLoadSucceeded(true);
+        setSuccessfulLoadFor(uid);
       }
     } catch (cause) {
       console.error(cause);
@@ -108,7 +108,11 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
   }, [refresh]);
 
   /** See the same guard on `EntriesProvider` — denial is not cleared by reconnecting. */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
+  useRetryOnReconnect(
+    error !== null && isUnreachable(error.cause),
+    successfulLoadFor === uid,
+    refresh,
+  );
 
   const value = useMemo(
     () => ({ sets, loading, error, refresh, repository }),

--- a/src/lib/wordSets.tsx
+++ b/src/lib/wordSets.tsx
@@ -48,6 +48,7 @@ const PAGE_SIZE = 200;
 export function WordSetsProvider({ uid, children }: { uid: string; children: ReactNode }) {
   const [sets, setSets] = useState<WordSet[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadSucceeded, setLoadSucceeded] = useState(false);
   const [error, setError] = useState<LoadFailure | null>(null);
 
   const repository = useMemo(() => wordSetRepositoryFor(uid), [uid]);
@@ -77,6 +78,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
    * `repository` changes because the account did. That is the effect below.
    */
   const refresh = useCallback(async () => {
+    setLoadSucceeded(false);
     const mine = (walk.current += 1);
     try {
       const all: WordSet[] = [];
@@ -90,6 +92,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
       if (walk.current === mine) {
         setSets(all);
         setError(null);
+        setLoadSucceeded(true);
       }
     } catch (cause) {
       console.error(cause);
@@ -105,7 +108,7 @@ export function WordSetsProvider({ uid, children }: { uid: string; children: Rea
   }, [refresh]);
 
   /** See the same guard on `EntriesProvider` — denial is not cleared by reconnecting. */
-  useRetryOnReconnect(error !== null && isUnreachable(error.cause), refresh);
+  useRetryOnReconnect(error !== null && isUnreachable(error.cause), loadSucceeded, refresh);
 
   const value = useMemo(
     () => ({ sets, loading, error, refresh, repository }),

--- a/tests/component/retryOnReconnect.test.tsx
+++ b/tests/component/retryOnReconnect.test.tsx
@@ -1,19 +1,34 @@
-import { act, render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCallback, useState } from 'react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
 import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 
 function RetryHarness({
   failed,
   loadSucceeded,
-  retry,
+  retryResult,
 }: {
   failed: boolean;
   loadSucceeded: boolean;
-  retry: () => void;
+  retryResult?: Promise<void>;
 }) {
+  const [retryCount, setRetryCount] = useState(0);
+  const retry = useCallback(() => {
+    setRetryCount((count) => count + 1);
+    return retryResult;
+  }, [retryResult]);
+
   useRetryOnReconnect(failed, loadSucceeded, retry);
-  return null;
+  return <output data-testid="retry-count">{retryCount}</output>;
 }
+
+const deferred = () => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((_resolve, rejectPromise) => {
+    reject = rejectPromise;
+  });
+  return { promise, reject };
+};
 
 const setOnline = (value: boolean) => {
   Object.defineProperty(navigator, 'onLine', { value, configurable: true });
@@ -29,24 +44,39 @@ afterEach(() => {
 describe('useRetryOnReconnect', () => {
   it('retries when an offline read fails after the browser has reconnected', () => {
     setOnline(false);
-    const retry = vi.fn();
-    const view = render(<RetryHarness failed={false} loadSucceeded={false} retry={retry} />);
+    const view = render(<RetryHarness failed={false} loadSucceeded={false} />);
 
     setOnline(true);
-    view.rerender(<RetryHarness failed loadSucceeded={false} retry={retry} />);
+    view.rerender(<RetryHarness failed loadSucceeded={false} />);
 
-    expect(retry).toHaveBeenCalledOnce();
+    expect(screen.getByTestId('retry-count')).toHaveTextContent('1');
   });
 
   it('does not retry an online failure after the reconnected read succeeded', () => {
     setOnline(false);
-    const retry = vi.fn();
-    const view = render(<RetryHarness failed={false} loadSucceeded={false} retry={retry} />);
+    const view = render(<RetryHarness failed={false} loadSucceeded={false} />);
 
     setOnline(true);
-    view.rerender(<RetryHarness failed={false} loadSucceeded retry={retry} />);
-    view.rerender(<RetryHarness failed loadSucceeded={false} retry={retry} />);
+    view.rerender(<RetryHarness failed={false} loadSucceeded />);
+    view.rerender(<RetryHarness failed loadSucceeded={false} />);
 
-    expect(retry).not.toHaveBeenCalled();
+    expect(screen.getByTestId('retry-count')).toHaveTextContent('0');
+  });
+
+  it('uses a later reconnect when the in-flight retry fails', async () => {
+    setOnline(false);
+    const firstRetry = deferred();
+    render(<RetryHarness failed loadSucceeded={false} retryResult={firstRetry.promise} />);
+
+    setOnline(true);
+    expect(screen.getByTestId('retry-count')).toHaveTextContent('1');
+
+    setOnline(false);
+    setOnline(true);
+    act(() => firstRetry.reject(new Error('unavailable')));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('retry-count')).toHaveTextContent('2');
+    });
   });
 });

--- a/tests/component/retryOnReconnect.test.tsx
+++ b/tests/component/retryOnReconnect.test.tsx
@@ -1,0 +1,32 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
+
+function RetryHarness({ failed, retry }: { failed: boolean; retry: () => void }) {
+  useRetryOnReconnect(failed, retry);
+  return null;
+}
+
+const setOnline = (value: boolean) => {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true });
+  act(() => {
+    window.dispatchEvent(new Event(value ? 'online' : 'offline'));
+  });
+};
+
+afterEach(() => {
+  Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+});
+
+describe('useRetryOnReconnect', () => {
+  it('retries when an offline read fails after the browser has reconnected', () => {
+    setOnline(false);
+    const retry = vi.fn();
+    const view = render(<RetryHarness failed={false} retry={retry} />);
+
+    setOnline(true);
+    view.rerender(<RetryHarness failed retry={retry} />);
+
+    expect(retry).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/component/retryOnReconnect.test.tsx
+++ b/tests/component/retryOnReconnect.test.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import { useCallback, useState } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 

--- a/tests/component/retryOnReconnect.test.tsx
+++ b/tests/component/retryOnReconnect.test.tsx
@@ -2,8 +2,16 @@ import { act, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useRetryOnReconnect } from '@/lib/retryOnReconnect';
 
-function RetryHarness({ failed, retry }: { failed: boolean; retry: () => void }) {
-  useRetryOnReconnect(failed, retry);
+function RetryHarness({
+  failed,
+  loadSucceeded,
+  retry,
+}: {
+  failed: boolean;
+  loadSucceeded: boolean;
+  retry: () => void;
+}) {
+  useRetryOnReconnect(failed, loadSucceeded, retry);
   return null;
 }
 
@@ -22,11 +30,23 @@ describe('useRetryOnReconnect', () => {
   it('retries when an offline read fails after the browser has reconnected', () => {
     setOnline(false);
     const retry = vi.fn();
-    const view = render(<RetryHarness failed={false} retry={retry} />);
+    const view = render(<RetryHarness failed={false} loadSucceeded={false} retry={retry} />);
 
     setOnline(true);
-    view.rerender(<RetryHarness failed retry={retry} />);
+    view.rerender(<RetryHarness failed loadSucceeded={false} retry={retry} />);
 
     expect(retry).toHaveBeenCalledOnce();
+  });
+
+  it('does not retry an online failure after the reconnected read succeeded', () => {
+    setOnline(false);
+    const retry = vi.fn();
+    const view = render(<RetryHarness failed={false} loadSucceeded={false} retry={retry} />);
+
+    setOnline(true);
+    view.rerender(<RetryHarness failed={false} loadSucceeded retry={retry} />);
+    view.rerender(<RetryHarness failed loadSucceeded={false} retry={retry} />);
+
+    expect(retry).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #153.

### Summary

- retain a reconnect until the associated load either fails or succeeds
- pass each provider's current load-success signal to the retry hook
- cover both the delayed offline failure and the later unrelated online failure

### Test layer

DOM/component: the defect depends on React's subscription to the browser's real `online` event, so this is the smallest layer that can reproduce the ordering without mocking application code.

### Validation

- `yarn vitest run --project dom tests/component/retryOnReconnect.test.tsx --reporter=dot`
- `yarn typecheck`
- `yarn format`
- `yarn test:unit --reporter=dot` (996 passed; existing `tests/unit/fontConfig.test.ts` fails because `noto-sans-jp-119-400-normal.woff2` is absent from `node_modules`)

### Regression proof

Removed the success branch temporarily: only `does not retry an online failure after the reconnected read succeeded` failed, because the old hook invoked retry once. Restored the branch and both reconnect tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic retries after connectivity is restored.
  * Prevented unnecessary or duplicate retries after data loads successfully.
  * Preserved retry handling for failed loads caused by temporary connectivity issues.
  * Applied more reliable recovery behavior across entries, progress, profile, and word-set loading.

* **Tests**
  * Added coverage for reconnect retry scenarios, including successful and failed loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->