### PR TITLE
fix(practice): announce mode switches as pressed buttons

### DIFF
--- a/src/components/practice/PracticeSetup.tsx
+++ b/src/components/practice/PracticeSetup.tsx
@@ -113,7 +113,7 @@ export function PracticeSetup({
       <header className="space-y-3">
         {/* The screen is 「練習」 and the drill is a choice inside it, so the
             heading names the screen: the mode is already announced by the
-            selected tab below, and printing it twice was what a title plus a
+            pressed button below, and printing it twice was what a title plus a
             switch would do. */}
         <h1 className="font-display text-2xl font-bold">{t('nav.practice')}</h1>
         {/*
@@ -124,7 +124,7 @@ export function PracticeSetup({
           this is also the only way to reach the other drill there.
         */}
         <div
-          role="tablist"
+          role="group"
           aria-label={t('nav.practice')}
           className="flex gap-1 rounded-pill bg-bg-alt p-1"
         >
@@ -132,8 +132,7 @@ export function PracticeSetup({
             <button
               key={option.mode}
               type="button"
-              role="tab"
-              aria-selected={mode === option.mode}
+              aria-pressed={mode === option.mode}
               onClick={() => onModeChange(option.mode)}
               className={`min-h-11 flex-1 rounded-pill px-3 text-sm font-semibold transition ${
                 mode === option.mode ? 'bg-card text-ink shadow-panel' : 'text-muted'

--- a/tests/component/PracticeSetup.test.tsx
+++ b/tests/component/PracticeSetup.test.tsx
@@ -1,14 +1,17 @@
 import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { PracticeSetup } from '@/components/practice/PracticeSetup';
+import { PRACTICE_MODES } from '@/domain/practice';
 import { EMPTY_PRACTICE_FILTERS } from '@/lib/practice';
 import { renderWithI18n as render } from '../fixtures/renderWithI18n';
+
+const [FLASHCARD_MODE] = PRACTICE_MODES;
 
 describe('PracticeSetup — mode switch semantics', () => {
   it('does not announce route-changing practice modes as tabs without panels', () => {
     render(
       <PracticeSetup
-        mode="flashcard"
+        mode={FLASHCARD_MODE}
         filters={EMPTY_PRACTICE_FILTERS}
         recentTags={[]}
         allSets={[]}
@@ -26,15 +29,22 @@ describe('PracticeSetup — mode switch semantics', () => {
     // Tabs promise several panels with one visible. These buttons navigate to
     // separate routes, so that announcement would describe a UI that is not there.
     expect(screen.getByRole('group', { name: '練習' })).toBeInTheDocument();
+    // The selected drill must be announced as pressed, or a screen reader user
+    // cannot tell which exercise the setup below will start.
     expect(screen.getByRole('button', { name: 'フラッシュカード' })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
+    // The other drill must not also be pressed, or both choices sound active
+    // even though selecting one route replaces the other.
     expect(screen.getByRole('button', { name: '書き取り練習' })).toHaveAttribute(
       'aria-pressed',
       'false',
     );
+    // A tablist would promise a set of panels to navigate between, but changing
+    // mode instead leaves this route and loads another one.
     expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+    // Individual tabs would make the same false promise for each drill button.
     expect(screen.queryByRole('tab')).not.toBeInTheDocument();
   });
 });

--- a/tests/component/PracticeSetup.test.tsx
+++ b/tests/component/PracticeSetup.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PracticeSetup } from '@/components/practice/PracticeSetup';
+import { EMPTY_PRACTICE_FILTERS } from '@/lib/practice';
+import { renderWithI18n as render } from '../fixtures/renderWithI18n';
+
+describe('PracticeSetup — mode switch semantics', () => {
+  it('does not announce route-changing practice modes as tabs without panels', () => {
+    render(
+      <PracticeSetup
+        mode="flashcard"
+        filters={EMPTY_PRACTICE_FILTERS}
+        recentTags={[]}
+        allSets={[]}
+        now={new Date('2026-06-24T00:00:00.000Z')}
+        matchCount={0}
+        weakCount={0}
+        weakState="ready"
+        onChange={vi.fn()}
+        onModeChange={vi.fn()}
+        onStart={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Tabs promise several panels with one visible. These buttons navigate to
+    // separate routes, so that announcement would describe a UI that is not there.
+    expect(screen.getByRole('group', { name: '練習' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'フラッシュカード' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('button', { name: '書き取り練習' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+});

--- a/tests/e2e/bottomNav.spec.ts
+++ b/tests/e2e/bottomNav.spec.ts
@@ -93,17 +93,17 @@ test.describe('the bottom navigation', () => {
     const chosen = await page.getByLabel('開始日').inputValue();
     expect(chosen).not.toBe('');
 
-    await page.getByRole('tab', { name: '書き取り練習' }).click();
+    await page.getByRole('button', { name: '書き取り練習' }).click();
 
     // The route, not the query string: how the filters travel is this
     // screen's business, and asserting the `?` would fail on the mechanism
     // before reaching the assertions below that a learner would notice.
     await expect(page).toHaveURL(/\/practice\/dictation/);
-    // A switch that navigates but leaves the flashcard tab selected tells the
+    // A switch that navigates but leaves the flashcard button pressed tells the
     // learner they are still drilling the thing they just moved away from —
     // and tells a screen reader so in as many words.
-    await expect(page.getByRole('tab', { name: '書き取り練習' })).toHaveAttribute(
-      'aria-selected',
+    await expect(page.getByRole('button', { name: '書き取り練習' })).toHaveAttribute(
+      'aria-pressed',
       'true',
     );
     await expect(page.getByLabel('開始日')).toHaveValue(chosen);

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -162,10 +162,10 @@ test.describe('with the network off', () => {
     // installed on.
     await page.goto('/practice/dictation');
 
-    // The selected tab and not the heading: both drills are one screen called
+    // The pressed button and not the heading: both drills are one screen called
     // 「練習」 now, so its `<h1>` says the same thing on either route and would
     // pass this test for a fallback that landed on the wrong one.
-    await expect(page.getByRole('tab', { name: '書き取り練習', selected: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: '書き取り練習', pressed: true })).toBeVisible();
   });
 
   test('draws the headword in its own face, which is the thing the reader came for', async ({


### PR DESCRIPTION
## Summary

Closes #152.

- Replace the unsupported tab widget semantics with a labelled button group and aria-pressed state.
- Update route and offline workflow selectors to the button semantics.
- Add focused component coverage for the accessible mode-switch structure.

## Test layer

Component: the regression is rendered ARIA structure, so PracticeSetup.test.tsx asserts the labelled group, pressed state, and absence of tab roles.

End-to-end: bottomNav.spec.ts and offline.spec.ts continue to prove mode selection preserves filters and the offline deep link opens the requested mode.

## Verification

- yarn test:unit
- yarn typecheck
- yarn playwright test tests/e2e/bottomNav.spec.ts tests/e2e/offline.spec.ts
- yarn lint
- yarn format

## Regression proof

Temporarily restoring the former tablist/tab markup made only the PracticeSetup mode-switch semantics test fail. Restoring the button-group implementation made it pass.