### PR TITLE
test(fonts): unit test unicode range parsing

### DIFF
--- a/src/lib/unicodeRange.ts
+++ b/src/lib/unicodeRange.ts
@@ -2,8 +2,8 @@
 export function unicodeRangeIncludes(range: string, codePoint: number): boolean {
   return range.split(',').some((part) => {
     const [start, end] = part.trim().replace(/^u\+/i, '').split('-');
-    const low = Number.parseInt(start ?? '', 16);
-    const high = end === undefined ? low : Number.parseInt(end, 16);
+    const low = Number.parseInt((start ?? '').replace(/\?/g, '0'), 16);
+    const high = Number.parseInt((end ?? start ?? '').replace(/\?/g, 'F'), 16);
     return codePoint >= low && codePoint <= high;
   });
 }

--- a/src/lib/unicodeRange.ts
+++ b/src/lib/unicodeRange.ts
@@ -1,0 +1,9 @@
+/** Whether a CSS unicode-range includes a Unicode code point. */
+export function unicodeRangeIncludes(range: string, codePoint: number): boolean {
+  return range.split(',').some((part) => {
+    const [start, end] = part.trim().replace(/^u\+/i, '').split('-');
+    const low = Number.parseInt(start ?? '', 16);
+    const high = end === undefined ? low : Number.parseInt(end, 16);
+    return codePoint >= low && codePoint <= high;
+  });
+}

--- a/tests/e2e/offline.spec.ts
+++ b/tests/e2e/offline.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { unicodeRangeIncludes } from '@/lib/unicodeRange';
 import { seed, WORDS } from './fixtures';
 
 /**
@@ -217,26 +218,25 @@ test.describe('with the network off', () => {
     // on a build that is correct.
     await page.evaluate(() => document.fonts.ready.then(() => undefined));
     const read = () =>
-      page.evaluate(() => {
-        const inRange = (range: string, cp: number) =>
-          range.split(',').some((part) => {
-            const [start, end] = part.trim().replace(/^u\+/i, '').split('-');
-            const low = parseInt(start ?? '', 16);
-            return cp >= low && cp <= (end === undefined ? low : parseInt(end, 16));
-          });
-        const loaded = [...document.fonts].filter(
-          (face) =>
-            face.family.replace(/["']/g, '') === 'Zen Maru Gothic' &&
-            face.weight === '700' &&
-            face.status === 'loaded',
-        );
-        return {
-          faces: loaded.length,
+      page
+        .evaluate(() => {
+          const loaded = [...document.fonts].filter(
+            (face) =>
+              face.family.replace(/["']/g, '') === 'Zen Maru Gothic' &&
+              face.weight === '700' &&
+              face.status === 'loaded',
+          );
+          return {
+            faces: loaded.length,
+            ranges: loaded.map((face) => face.unicodeRange),
+          };
+        })
+        .then(({ faces, ranges }) => ({
+          faces,
           // 兆 and 候 — the headword the dashboard is showing.
-          cho: loaded.some((face) => inRange(face.unicodeRange, 0x5146)),
-          ko: loaded.some((face) => inRange(face.unicodeRange, 0x5019)),
-        };
-      });
+          cho: ranges.some((range) => unicodeRangeIncludes(range, 0x5146)),
+          ko: ranges.some((range) => unicodeRangeIncludes(range, 0x5019)),
+        }));
 
     // What breaks when this goes red: the dashboard is showing 兆候, and a
     // headword whose characters are in no loaded face is drawn in whatever the

--- a/tests/unit/unicodeRange.test.ts
+++ b/tests/unit/unicodeRange.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { unicodeRangeIncludes } from '@/lib/unicodeRange';
+
+/**
+ * CSS font faces declare a comma-separated `unicode-range`; a wrong match here
+ * would either reject a loaded font or let an offline fallback face pass.
+ */
+describe('unicodeRangeIncludes', () => {
+  it('finds a code point in any comma-separated range, so a later font subset is not ignored', () => {
+    expect(unicodeRangeIncludes('U+3000-30FF, U+4E00-9FFF', 0x5146)).toBe(true);
+    expect(unicodeRangeIncludes('U+3000-30FF, U+4E00-9FFF', 0x3042)).toBe(true);
+  });
+
+  it('accepts either case of the U+ prefix, which CSS permits before every range', () => {
+    expect(unicodeRangeIncludes('u+4E00-9FFF', 0x5146)).toBe(true);
+  });
+
+  it('matches a singleton range, so a loaded face is not mistaken for a fallback', () => {
+    expect(unicodeRangeIncludes('U+3005', 0x3005)).toBe(true);
+    expect(unicodeRangeIncludes('U+3005', 0x3006)).toBe(false);
+  });
+
+  it('includes both range boundaries, so a subset edge cannot pass or fail by one code point', () => {
+    expect(unicodeRangeIncludes('U+5019-5146', 0x5019)).toBe(true);
+    expect(unicodeRangeIncludes('U+5019-5146', 0x5146)).toBe(true);
+    expect(unicodeRangeIncludes('U+5019-5146', 0x5018)).toBe(false);
+    expect(unicodeRangeIncludes('U+5019-5146', 0x5147)).toBe(false);
+  });
+});

--- a/tests/unit/unicodeRange.test.ts
+++ b/tests/unit/unicodeRange.test.ts
@@ -15,6 +15,13 @@ describe('unicodeRangeIncludes', () => {
     expect(unicodeRangeIncludes('u+4E00-9FFF', 0x5146)).toBe(true);
   });
 
+  it('expands wildcards into their inclusive range, so a loaded CSS face is not rejected', () => {
+    expect(unicodeRangeIncludes('U+4??', 0x400)).toBe(true);
+    expect(unicodeRangeIncludes('U+4??', 0x4ff)).toBe(true);
+    expect(unicodeRangeIncludes('U+4??', 0x3ff)).toBe(false);
+    expect(unicodeRangeIncludes('U+4??', 0x500)).toBe(false);
+  });
+
   it('matches a singleton range, so a loaded face is not mistaken for a fallback', () => {
     expect(unicodeRangeIncludes('U+3005', 0x3005)).toBe(true);
     expect(unicodeRangeIncludes('U+3005', 0x3006)).toBe(false);


### PR DESCRIPTION
### Summary

Closes #159.

Move CSS unicode-range interpretation out of the offline Playwright browser context so the parser is independently covered.

### Changes

- Add unicodeRangeIncludes for comma-separated CSS ranges, U+ prefixes, single code points, and inclusive bounds.
- Return serializable unicodeRange strings from document.fonts in the offline spec and interpret them in Node.

### Testing

Unit tests are the selected layer because Unicode range parsing is pure input-to-output logic. The existing offline E2E remains responsible for verifying which font faces the browser loads through the service worker.

- yarn test:unit
- yarn typecheck
- yarn playwright test tests/e2e/offline.spec.ts
- yarn lint (passes with 19 pre-existing warnings)
- yarn format and yarn format:check

Regression proof: temporarily changed the inclusive upper-bound check to an exclusive one. Only the singleton and upper-bound cases in tests/unit/unicodeRange.test.ts failed, then passed again after restoring the inclusive check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for checking whether Unicode code points are included in CSS Unicode ranges.
  * Supports comma-separated ranges, optional case-insensitive `U+` prefixes, single code points, and inclusive boundaries.

* **Tests**
  * Added coverage for Unicode range parsing and boundary cases.
  * Updated font-loading checks to use the shared Unicode range validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->