### PR TITLE
fix(detail): render headword as page heading

### DIFF
--- a/src/components/detail/EntryHeadline.tsx
+++ b/src/components/detail/EntryHeadline.tsx
@@ -24,11 +24,14 @@ import { accentKana } from '@/lib/mora';
 export function EntryHeadline({
   entry,
   compact = false,
+  pageHeading = false,
   actions,
 }: {
   entry: Entry;
   /** Dialog scale: a smaller headword and tighter spacing. */
   compact?: boolean;
+  /** The detail page's headword is the document heading. */
+  pageHeading?: boolean;
   actions?: ReactNode;
 }) {
   const { t } = useI18n();
@@ -37,15 +40,25 @@ export function EntryHeadline({
   return (
     <div className="flex flex-wrap items-start justify-between gap-4">
       <div className="max-w-full min-w-0">
-        <Ruby
-          headword={entry.headword}
-          reading={entry.reading}
-          className={
-            compact
-              ? 'has-ruby block font-display text-3xl font-bold [overflow-wrap:anywhere]'
-              : 'has-ruby block font-display text-[34px] font-bold [overflow-wrap:anywhere] sm:text-[40px]'
-          }
-        />
+        {pageHeading ? (
+          <h1 className="m-0">
+            <Ruby
+              headword={entry.headword}
+              reading={entry.reading}
+              className="has-ruby block font-display text-[34px] font-bold [overflow-wrap:anywhere] sm:text-[40px]"
+            />
+          </h1>
+        ) : (
+          <Ruby
+            headword={entry.headword}
+            reading={entry.reading}
+            className={
+              compact
+                ? 'has-ruby block font-display text-3xl font-bold [overflow-wrap:anywhere]'
+                : 'has-ruby block font-display text-[34px] font-bold [overflow-wrap:anywhere] sm:text-[40px]'
+            }
+          />
+        )}
         {entry.pitchAccent !== null && (
           <PitchAccent
             kana={accentKana(entry.headword, entry.reading)}

--- a/src/routes/EntryDetail.tsx
+++ b/src/routes/EntryDetail.tsx
@@ -65,6 +65,7 @@ export function Component() {
       <header className="rounded-card bg-card p-5 shadow-panel sm:p-6">
         <EntryHeadline
           entry={entry}
+          pageHeading
           actions={
             <>
               <SpeakButton status={speechStatus} onSpeak={() => speak(spokenForm(entry))} />

--- a/tests/component/EntryHeadline.test.tsx
+++ b/tests/component/EntryHeadline.test.tsx
@@ -27,6 +27,8 @@ describe('EntryHeadline — page heading semantics', () => {
       </MemoryRouter>,
     );
 
+    // The modal title already names this dialog. A second heading here adds a
+    // redundant stop when a reader navigates the dialog by headings.
     expect(screen.queryByRole('heading')).not.toBeInTheDocument();
   });
 });

--- a/tests/component/EntryHeadline.test.tsx
+++ b/tests/component/EntryHeadline.test.tsx
@@ -1,0 +1,32 @@
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { EntryHeadline } from '@/components/detail/EntryHeadline';
+import { makeEntry } from '../fixtures/entry';
+import { renderWithI18n as render } from '../fixtures/renderWithI18n';
+
+const entry = makeEntry({ headword: '兆候', reading: 'ちょうこう' });
+
+describe('EntryHeadline — page heading semantics', () => {
+  it('makes the detail page headword its h1, so assistive technology can identify the entry', () => {
+    render(
+      <MemoryRouter>
+        <EntryHeadline entry={entry} pageHeading />
+      </MemoryRouter>,
+    );
+
+    // The headword is the page subject. Without this h1, navigating headings
+    // announces no entry name even though the word is the first visible content.
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('兆候');
+  });
+
+  it('leaves the compact dialog headword unheaded, because its modal title already names the dialog', () => {
+    render(
+      <MemoryRouter>
+        <EntryHeadline entry={entry} compact />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+});

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -107,6 +107,19 @@ test.describe('browsing', () => {
     expect((await pitch.boundingBox())?.width ?? Infinity).toBeLessThan(400);
   });
 
+  test('makes the detail word the lone level-one heading, so heading navigation identifies the entry', async ({
+    page,
+  }) => {
+    await page.goto('/vocabulary/w-choukou');
+
+    // This route, rather than EntryHeadline in isolation, owns the page-level
+    // semantics. Without pageHeading here, a heading shortcut skips the word
+    // the reader opened to study.
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toHaveCount(1);
+    await expect(heading).toContainText('兆候');
+  });
+
   test('opens a word in a dialog without leaving the list', async ({ page }) => {
     await page.goto('/vocabulary');
     await page.getByRole('link', { name: /兆候/ }).click();


### PR DESCRIPTION
## Summary

Fixes #157 by rendering the headword as the detail page's level-one heading, while leaving the dialog preview headed by its modal title.

## Changes

- Add an explicit page-heading mode to EntryHeadline and enable it from EntryDetail.
- Cover the shared component's page and dialog heading semantics.
- Assert the real /vocabulary/w-choukou route exposes exactly one level-one heading containing the entry headword.

## Testing

Layer choice: component coverage checks the shared rendered DOM contract; end-to-end coverage checks the route, router, and provider wiring that supplies pageHeading.

- yarn test:unit
- yarn typecheck
- yarn format
- yarn format:check
- yarn lint (19 existing warnings, no errors)
- yarn playwright test tests/e2e/visual.spec.ts (44 passed; no baselines changed)
- yarn playwright test tests/e2e/vocabulary.spec.ts --grep "makes the detail word the lone level-one heading"

Regression proof: with pageHeading temporarily removed from EntryDetail, the new E2E test failed because it found zero level-one headings. Restoring the prop made it pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved vocabulary detail pages with a properly structured page heading for the entry headword and reading.

* **Bug Fixes**
  * Preserved compact dialog behavior without introducing an unnecessary heading.
  * Ensured detail pages contain exactly one level-one heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->