### PR TITLE
fix(import): lock modal during clipboard paste

### DIFF
--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -146,6 +146,15 @@ export function EntryFormModal({
    */
   const [drafting, setDrafting] = useState(false);
   /**
+   * Whether the browser is still deciding whether it may read the clipboard.
+   *
+   * This is intentionally separate from drafting: beginning a paste must not
+   * clear the handoff that sent the reader to this tab. It does, however, make
+   * the footer and tabs unsafe, because either action can save or unmount the
+   * form before the clipboard reply arrives.
+   */
+  const [pasting, setPasting] = useState(false);
+  /**
    * Which request the lock above belongs to.
    *
    * A request outlives the panel that made it and can outlive the whole dialog:
@@ -240,6 +249,7 @@ export function EntryFormModal({
     setAiError(null);
     setHandedOff(false);
     setDrafting(false);
+    setPasting(false);
     // Reset here as well as guarded in `saveDraft`: a save from the previous run
     // skips its own `setSaving(false)`, so without this the new dialog opens
     // with its footer already locked by a write it knows nothing about.
@@ -441,7 +451,7 @@ export function EntryFormModal({
               // to import, and a bare handler would hand it the MouseEvent —
               // which `jsonToDraft` would dutifully try to parse.
               onClick={() => void importJson(json.raw)}
-              disabled={!json.raw.trim() || drafting}
+              disabled={!json.raw.trim() || drafting || pasting}
               className="min-h-10 rounded-pill bg-bg-alt px-5 text-sm font-semibold text-ink disabled:opacity-50"
             >
               {t('form.import')}
@@ -457,7 +467,7 @@ export function EntryFormModal({
           <button
             type="button"
             onClick={() => void saveDraft(draft)}
-            disabled={saving || drafting}
+            disabled={saving || drafting || pasting}
             className="min-h-10 rounded-pill bg-accent px-5 text-sm font-semibold text-on-accent disabled:opacity-60"
           >
             {saving ? t('form.saving') : t('form.save')}
@@ -475,7 +485,7 @@ export function EntryFormModal({
               // unmounts the panel that made it and the reply is then dropped —
               // silently, and after the allowance has already been spent. The
               // close button stays live, which is the way out if it hangs.
-              disabled={drafting}
+              disabled={drafting || pasting}
               onClick={() => {
                 setTab(item.id);
                 // Chosen, not arrived at: the handoff notice explains why the
@@ -569,6 +579,7 @@ export function EntryFormModal({
           aiError={aiError}
           handedOff={handedOff}
           onBusyChange={trackDrafting}
+          onPasteBusyChange={setPasting}
           onFailure={(reason) => {
             setAiError(reason);
             setHandedOff(false);

--- a/src/components/entry-form/EntryFormModal.tsx
+++ b/src/components/entry-form/EntryFormModal.tsx
@@ -154,6 +154,8 @@ export function EntryFormModal({
    * form before the clipboard reply arrives.
    */
   const [pasting, setPasting] = useState(false);
+  /** The paste request that owns the lock above, if this modal run has one. */
+  const pasteFor = useRef<symbol | null>(null);
   /**
    * Which request the lock above belongs to.
    *
@@ -214,6 +216,16 @@ export function EntryFormModal({
     busyFor.current = null;
     setDrafting(false);
   };
+  const trackPasting = (busy: boolean, request: symbol) => {
+    if (busy) {
+      pasteFor.current = request;
+      setPasting(true);
+      return;
+    }
+    if (pasteFor.current !== request) return;
+    pasteFor.current = null;
+    setPasting(false);
+  };
   /**
    * The current `json`, readable from a callback that outlived the render it
    * was created in.
@@ -257,6 +269,7 @@ export function EntryFormModal({
     // The outstanding request, if there is one, is now nobody's: it may still
     // settle, and what it must not do on the way past is unlock this session.
     busyFor.current = null;
+    pasteFor.current = null;
     setErrors([]);
   }, [open, entry, translationLanguage]);
 
@@ -579,7 +592,7 @@ export function EntryFormModal({
           aiError={aiError}
           handedOff={handedOff}
           onBusyChange={trackDrafting}
-          onPasteBusyChange={setPasting}
+          onPasteBusyChange={trackPasting}
           onFailure={(reason) => {
             setAiError(reason);
             setHandedOff(false);

--- a/src/components/entry-form/JsonImport.tsx
+++ b/src/components/entry-form/JsonImport.tsx
@@ -100,7 +100,7 @@ export function JsonImport({
   /** See `SimpleForm`: lets the modal lock its footer for the same window. */
   onBusyChange: (busy: boolean, request: DraftRequest) => void;
   /** Lets the modal lock controls that would discard a pending clipboard read. */
-  onPasteBusyChange?: (busy: boolean) => void;
+  onPasteBusyChange?: (busy: boolean, request: symbol) => void;
 }) {
   // Purely local: nothing outside this component acts on it.
   const [state, setState] = useState<'idle' | 'copied' | 'failed'>('idle');
@@ -236,9 +236,10 @@ export function JsonImport({
     the point.
   */
   const pasteJson = () => {
+    const request = Symbol('clipboard-paste');
     setPasteFailed(false);
     setPasting(true);
-    onPasteBusyChange?.(true);
+    onPasteBusyChange?.(true, request);
     let read: Promise<string> | undefined;
     try {
       read = navigator.clipboard?.readText();
@@ -248,13 +249,13 @@ export function JsonImport({
       // direction.
       setPasteFailed(true);
       setPasting(false);
-      onPasteBusyChange?.(false);
+      onPasteBusyChange?.(false, request);
       return;
     }
     if (read === undefined) {
       setPasteFailed(true);
       setPasting(false);
-      onPasteBusyChange?.(false);
+      onPasteBusyChange?.(false, request);
       return;
     }
     read
@@ -274,9 +275,11 @@ export function JsonImport({
         if (alive.current) setPasteFailed(true);
       })
       .finally(() => {
-        if (!alive.current) return;
-        setPasting(false);
-        onPasteBusyChange?.(false);
+        if (alive.current) setPasting(false);
+        // `onDrafted` can move to the full tab and unmount this panel. The
+        // modal still owns the footer lock, so it must hear that this specific
+        // request settled even after the local state is no longer writable.
+        onPasteBusyChange?.(false, request);
       });
   };
 

--- a/src/components/entry-form/JsonImport.tsx
+++ b/src/components/entry-form/JsonImport.tsx
@@ -55,6 +55,7 @@ export function JsonImport({
   handedOff,
   onFailure,
   onBusyChange,
+  onPasteBusyChange,
 }: {
   value: JsonImportState;
   /**
@@ -98,6 +99,8 @@ export function JsonImport({
   onFailure: (reason: EntryDraftingFailure) => void;
   /** See `SimpleForm`: lets the modal lock its footer for the same window. */
   onBusyChange: (busy: boolean, request: DraftRequest) => void;
+  /** Lets the modal lock controls that would discard a pending clipboard read. */
+  onPasteBusyChange?: (busy: boolean) => void;
 }) {
   // Purely local: nothing outside this component acts on it.
   const [state, setState] = useState<'idle' | 'copied' | 'failed'>('idle');
@@ -235,6 +238,7 @@ export function JsonImport({
   const pasteJson = () => {
     setPasteFailed(false);
     setPasting(true);
+    onPasteBusyChange?.(true);
     let read: Promise<string> | undefined;
     try {
       read = navigator.clipboard?.readText();
@@ -244,11 +248,13 @@ export function JsonImport({
       // direction.
       setPasteFailed(true);
       setPasting(false);
+      onPasteBusyChange?.(false);
       return;
     }
     if (read === undefined) {
       setPasteFailed(true);
       setPasting(false);
+      onPasteBusyChange?.(false);
       return;
     }
     read
@@ -268,7 +274,9 @@ export function JsonImport({
         if (alive.current) setPasteFailed(true);
       })
       .finally(() => {
-        if (alive.current) setPasting(false);
+        if (!alive.current) return;
+        setPasting(false);
+        onPasteBusyChange?.(false);
       });
   };
 

--- a/tests/component/EntryFormModal.test.tsx
+++ b/tests/component/EntryFormModal.test.tsx
@@ -1,11 +1,10 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
 import { I18nProvider } from '@/i18n/I18nProvider';
 import { messages } from '@/i18n/messages';
 import { EntriesProvider } from '@/lib/entries';
-import { render } from '@testing-library/react';
 
 const ja = (key: keyof (typeof messages)['ja']) => messages.ja[key];
 
@@ -53,9 +52,11 @@ describe('EntryFormModal — clipboard paste while a handoff is visible', () => 
     fireEvent.click(screen.getByRole('button', { name: ja('import.paste') }));
 
     // A browser permission prompt can hold readText open. Acting on the footer
-    // then either drops the paste or saves the draft it was about to replace.
+    // or leaving this tab then either drops the paste or saves the draft it was
+    // about to replace.
     expect(screen.getByRole('button', { name: ja('form.import') })).toBeDisabled();
     expect(screen.getByRole('button', { name: ja('form.save') })).toBeDisabled();
+    expect(screen.getByRole('button', { name: ja('form.full') })).toBeDisabled();
     expect(screen.getByText(ja('import.aiHandoff'))).toBeVisible();
 
     release('{"headword":"兆候"}');

--- a/tests/component/EntryFormModal.test.tsx
+++ b/tests/component/EntryFormModal.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EntryFormModal } from '@/components/entry-form/EntryFormModal';
+import { I18nProvider } from '@/i18n/I18nProvider';
+import { messages } from '@/i18n/messages';
+import { EntriesProvider } from '@/lib/entries';
+import { render } from '@testing-library/react';
+
+const ja = (key: keyof (typeof messages)['ja']) => messages.ja[key];
+
+const withClipboard = (clipboard: unknown) => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: clipboard,
+    configurable: true,
+    writable: true,
+  });
+};
+
+afterEach(() => {
+  withClipboard(undefined);
+  delete (window as { __GOITEI_E2E__?: unknown }).__GOITEI_E2E__;
+});
+
+function mount() {
+  render(
+    <I18nProvider locale="ja">
+      <MemoryRouter>
+        <EntriesProvider uid="modal-test-user">
+          <EntryFormModal open onClose={vi.fn()} />
+        </EntriesProvider>
+      </MemoryRouter>
+    </I18nProvider>,
+  );
+}
+
+describe('EntryFormModal — clipboard paste while a handoff is visible', () => {
+  it('locks import and save while the clipboard permission waits, without clearing the AI handoff', async () => {
+    (window as { __GOITEI_E2E__?: unknown }).__GOITEI_E2E__ = { entryDrafting: 'failed' };
+    let release!: (text: string) => void;
+    withClipboard({ readText: () => new Promise<string>((resolve) => (release = resolve)) });
+    mount();
+
+    fireEvent.change(screen.getByRole('textbox', { name: /^見出し語/ }), {
+      target: { value: '兆候' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: ja('import.draftAndSave') }));
+
+    await screen.findByText(ja('import.aiHandoff'));
+    fireEvent.change(screen.getByRole('textbox', { name: ja('import.pasteJson') }), {
+      target: { value: '{"headword":"既存"}' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: ja('import.paste') }));
+
+    // A browser permission prompt can hold readText open. Acting on the footer
+    // then either drops the paste or saves the draft it was about to replace.
+    expect(screen.getByRole('button', { name: ja('form.import') })).toBeDisabled();
+    expect(screen.getByRole('button', { name: ja('form.save') })).toBeDisabled();
+    expect(screen.getByText(ja('import.aiHandoff'))).toBeVisible();
+
+    release('{"headword":"兆候"}');
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: ja('form.save') })).toBeEnabled(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #161.

- Lock the modal footer and tabs while `navigator.clipboard.readText()` is pending.
- Keep clipboard busy state separate from drafting, preserving an existing AI handoff notice.
- Cover the footer, tab, and handoff behaviour with a component regression test.

## Testing

Test layer: component, because the defect spans rendered JSON-panel controls and the modal footer/tab state.

Regression proof: before the production fix, the new test failed only at the expectation that the enabled `読み込む` footer button becomes disabled while the clipboard promise is pending.

- `yarn vitest run --project dom tests/component/EntryFormModal.test.tsx`
- `yarn test:unit`
- `yarn typecheck`
- `yarn lint`
- `yarn format:check`
- `git diff --check develop...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting form actions while pasted JSON is being processed.
  * Import, save, and tab-switch controls now remain disabled during pending clipboard access.
  * Controls automatically re-enable after clipboard processing completes or fails.

* **Tests**
  * Added coverage for clipboard permission delays while AI drafting is visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->